### PR TITLE
Use Cluster for member api retry

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -220,8 +220,7 @@ func (c *Cluster) monitorMembers() {
 			panic("TODO: All pods removed. Impossible. Anyway, we can't create etcd client.")
 		}
 
-		c.updateMembers([]string{makeClientAddr(running.PickOne().Name)})
-
+		c.updateMembers(running.ClientURLs())
 		if err := c.reconcile(running); err != nil {
 			panic(err)
 		}
@@ -231,7 +230,8 @@ func (c *Cluster) monitorMembers() {
 func (c *Cluster) updateMembers(endpoints []string) {
 	// TODO: put this into central event handling
 	cfg := clientv3.Config{
-		Endpoints: endpoints,
+		Endpoints:   endpoints,
+		DialTimeout: 5 * time.Second,
 	}
 	etcdcli, err := clientv3.New(cfg)
 	if err != nil {

--- a/member_set.go
+++ b/member_set.go
@@ -61,3 +61,13 @@ func (ms MemberSet) Add(m Member) {
 func (ms MemberSet) Remove(name string) {
 	delete(ms, name)
 }
+
+func (ms MemberSet) ClientURLs() []string {
+	endpoints := make([]string, len(ms))
+	i := 0
+	for _, m := range ms {
+		endpoints[i] = makeClientAddr(m.Name)
+		i++
+	}
+	return endpoints
+}


### PR DESCRIPTION
- Provide all available endpoints to etcd client instead of one
- Fix bug where idCounter was incremented between pod creation and member addition
- Provide 5 second dial timeout to etcd client to reduce recovery time in presence of network partitions

fixes #18 

@xiang90 @hongchaodeng this is now able to recover from pod deletion and node terminatio

I see there is #35 now, which does some well needed cleanup and also fixes the idCounter increment bug. Which one first?
