### PR TITLE
refactor codebase

### DIFF
--- a/design/reconciliation.md
+++ b/design/reconciliation.md
@@ -14,7 +14,7 @@ For each reconciling cycle, we get P from k8s API. Comparing M and P, we have th
 2. P’ consist of remaining pods of P
 3. If P’ = M, the current state matches the membership state. GOTO Resize.
 4. If len(P’) < len(M)/2 + 1, quorum lost. Go to recovery process (TODO).
-5. Remove one member that in M but does not in P's. GOTO Resize. 
+5. Remove one member that in M but does not in P's. GOTO Resize.
 
 ### Resize
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -121,7 +121,7 @@ func (c *Cluster) create(spec *Spec) {
 		panic(fmt.Sprintf("(TODO: we need to clean up already created ones.)\nError: %v", err))
 	}
 	c.idCounter++
-	fmt.Println("created cluster:", members)
+	log.Println("created cluster:", members)
 }
 
 func (c *Cluster) Update(spec *Spec) {


### PR DESCRIPTION
- trailing whitespace in docs
- reduce panic and return err
- use log instead of fmt
