### PR TITLE
Only start accepting events after seed member is created

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -66,13 +66,12 @@ func new(kclient *unversioned.Client, name string, spec *Spec, isNewCluster bool
 		stopCh:  make(chan struct{}),
 		spec:    spec,
 	}
-	go c.run()
-
 	if isNewCluster {
 		if err := c.startSeedMember(spec); err != nil {
 			panic(err)
 		}
 	}
+	go c.run()
 
 	return c
 }


### PR DESCRIPTION
We should start event loop after seed member created. Otherwise there will be concurrency issues.
This should be fixed in my last PR on this. Somewhat dismissed.
