### PR TITLE
Revert "use latest etcd to fix domain name problem"

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -43,7 +43,7 @@ func makeRestoreInitContainerSpec(backupAddr, name, token string) string {
 		},
 		{
 			Name:  "restore-datadir",
-			Image: "gcr.io/coreos-k8s-scale-testing/etcd-amd64:latest",
+			Image: "quay.io/coreos/etcd:latest",
 			Command: []string{
 				"/bin/sh", "-c",
 				fmt.Sprintf("ETCDCTL_API=3 etcdctl snapshot restore %[1]s"+
@@ -231,7 +231,7 @@ func MakeEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state
 				{
 					Command: commands,
 					Name:    m.Name,
-					Image:   "gcr.io/coreos-k8s-scale-testing/etcd-amd64:latest",
+					Image:   "quay.io/coreos/etcd:latest",
 					Ports: []api.ContainerPort{
 						{
 							Name:          "server",


### PR DESCRIPTION
Reverts coreos/kube-etcd-controller#116

etcd quay image has new release.
We strive to keep up-to-date and test it.
