### PR TITLE
Close response body on status code error

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -164,6 +164,7 @@ func monitorEtcdCluster(host string, httpClient *http.Client, watchVersion strin
 				return
 			}
 			if resp.StatusCode != 200 {
+				resp.Body.Close()
 				errc <- errors.New("Invalid status code: " + resp.Status)
 				return
 			}


### PR DESCRIPTION
The HTTP response body must be closed if the request error was not nil.
Otherwise connections are leaked.
