### PR TITLE
add controller flag for pd provisioner type

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -12,6 +12,7 @@ var (
 )
 
 func init() {
+	flag.StringVar(&cfg.PVProvisioner, "pv-provisioner", "kubernetes.io/gce-pd", "persistent volume provisioner type")
 	flag.StringVar(&cfg.MasterHost, "master", "", "API Server addr, e.g. ' - NOT RECOMMENDED FOR PRODUCTION - http://127.0.0.1:8080'. Omit parameter to run in on-cluster mode and utilize the service account token.")
 	flag.StringVar(&cfg.TLSConfig.CertFile, "cert-file", "", " - NOT RECOMMENDED FOR PRODUCTION - Path to public TLS certificate file.")
 	flag.StringVar(&cfg.TLSConfig.KeyFile, "key-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to private TLS certificate file.")

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -158,13 +158,12 @@ func GetNodePortString(srv *api.Service) string {
 	return fmt.Sprint(srv.Spec.Ports[0].NodePort)
 }
 
-func CreateStorageClass(kubecli *unversioned.Client) error {
+func CreateStorageClass(kubecli *unversioned.Client, pvProvisioner string) error {
 	class := &storage.StorageClass{
 		ObjectMeta: api.ObjectMeta{
 			Name: storageClassName,
 		},
-		// TODO: add aws
-		Provisioner: "kubernetes.io/gce-pd",
+		Provisioner: pvProvisioner,
 	}
 	_, err := kubecli.StorageClasses().Create(class)
 	return err


### PR DESCRIPTION
allows choosing pv provisioner type, `gce-pd` and `aws-ebs` are enabled/supported for now.

also added a `validate()` hook as well for controller config to validate pd provisioner type string.

\cc @xiang90 @hongchaodeng 
