### PR TITLE
trick: trigger cache watcher in apiserver

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -265,7 +265,7 @@ func CreateAndWaitPod(kclient *unversioned.Client, pod *api.Pod, m *etcdutil.Mem
 	if _, err := kclient.Pods(ns).Create(pod); err != nil {
 		return err
 	}
-	w, err := kclient.Pods(ns).Watch(api.SingleObject(api.ObjectMeta{Name: m.Name}))
+	w, err := kclient.Pods(ns).Watch(api.SingleObject(api.ObjectMeta{Name: m.Name, ResourceVersion: "0"}))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I have a theory about what's going on in previous failures.

Previously we have strong guarantee that after we finish addOneMember(), the pod should be watched notifying it's ready. Unfortunately, previous implementation will trigger apiserver to create a separate watcher directly on etcd.

What's happening:
- I have a watcher watching on etcd
- the pod is ready, triggering:
  - my watcher
  - apiserver cacher

The above two are concurrently running, and my watcher could returns, then list pods from cacher, and cacher state is stale.
In short, it violates read-your-write consistency.
