### PR TITLE
refine etcd pod readiness probe spec

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -247,8 +247,12 @@ func MakeEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state
 									"ETCDCTL_API=3 etcdctl get foo"},
 							},
 						},
-						InitialDelaySeconds: 1,
+						// if an etcd member tries to join quorum, it has 5s strict check
+						// before it can serve any client request
+						InitialDelaySeconds: 7,
 						TimeoutSeconds:      10,
+						PeriodSeconds:       10,
+						FailureThreshold:    3,
 					},
 					// a pod is alive only if a get succeeds
 					// the etcd pod should die if liveness probing fails.


### PR DESCRIPTION
~~If we don't set it, seems there is a default "periodSeconds: 10"~~
