### PR TITLE
fix logic in disaster recovery

### DIFF
--- a/pkg/backup/http.go
+++ b/pkg/backup/http.go
@@ -55,6 +55,10 @@ func (b *Backup) serveSnap(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	checkOnly := r.FormValue("checkonly")
+	if len(checkOnly) > 0 {
+		return
+	}
 	http.ServeFile(w, r, path.Join(constants.BackupDir, fname))
 }
 


### PR DESCRIPTION
 We don't return error if backupnow failed. Instead, we ask if there is previous backup.
If so, we can still continue. Otherwise, it's fatal error.
