### PR TITLE
e2e: increase timeout in setup controller

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -241,7 +241,7 @@ func (c *Cluster) migrateSeedMember() error {
 	pod := k8sutil.MakeEtcdPod(m, initialCluster, c.name, "existing", "", c.spec)
 	pod = k8sutil.PodWithAddMemberInitContainer(pod, m.Name, mpurls, c.spec)
 
-	if err := k8sutil.CreateAndWaitPod(c.kclient, c.namespace, pod); err != nil {
+	if err := k8sutil.CreateAndWaitPod(c.kclient, c.namespace, pod, 10*time.Second); err != nil {
 		return err
 	}
 	c.idCounter++
@@ -404,7 +404,7 @@ func (c *Cluster) createPodAndService(members etcdutil.MemberSet, m *etcdutil.Me
 	if needRecovery {
 		k8sutil.AddRecoveryToPod(pod, c.name, m.Name, token, c.spec)
 	}
-	return k8sutil.CreateAndWaitPod(c.kclient, c.namespace, pod)
+	return k8sutil.CreateAndWaitPod(c.kclient, c.namespace, pod, 10*time.Second)
 }
 
 func (c *Cluster) removePodAndService(name string) error {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -152,7 +152,7 @@ func CreateEtcdNodePortService(kclient *unversioned.Client, etcdName, clusterNam
 	return kclient.Services(ns).Create(svc)
 }
 
-func CreateAndWaitPod(kclient *unversioned.Client, ns string, pod *api.Pod) error {
+func CreateAndWaitPod(kclient *unversioned.Client, ns string, pod *api.Pod, timeout time.Duration) error {
 	if _, err := kclient.Pods(ns).Create(pod); err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func CreateAndWaitPod(kclient *unversioned.Client, ns string, pod *api.Pod) erro
 	if err != nil {
 		return err
 	}
-	_, err = watch.Until(10*time.Second, w, unversioned.PodRunning)
+	_, err = watch.Until(timeout, w, unversioned.PodRunning)
 	// TODO: cleanup pod on failure
 	return err
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -116,7 +116,7 @@ func (f *Framework) setupEtcdController(ctrlImage string) error {
 		},
 	}
 
-	err := k8sutil.CreateAndWaitPod(f.KubeClient, f.Namespace.Name, pod)
+	err := k8sutil.CreateAndWaitPod(f.KubeClient, f.Namespace.Name, pod, 60*time.Second)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Urgent fix.
e2e fails twice in sequence.
The failure is that waiting 10 seconds and etcd controller pod is still not running.
Not really a concern to us right now.
