### PR TITLE
e2e: stop etcd after seed test finished

### DIFF
--- a/test/e2e/seed_migration_test.go
+++ b/test/e2e/seed_migration_test.go
@@ -44,6 +44,7 @@ func TestCreateClusterWithSeedMember(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer e.Close()
 
 	<-e.Server.ReadyNotify()
 	fmt.Println("etcdserver is ready")


### PR DESCRIPTION
We call Close() on embedded etcd once test finished.
Otherwise it will keep the socket open until process exit.
