### PR TITLE
README: add a nodeport example

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ $ kubectl logs etcd-cluster-0000
 2016-08-05 00:33:32.454178 N | etcdmain: serving insecure client requests on 0.0.0.0:2379, this is strongly discouraged!
 ```
 
+If you are working with [minikube locally](https://github.com/kubernetes/minikube#minikube) create a nodePort service and test out that etcd is responding:
+
+```bash
+kubectl create -f example/example-etcd-cluster-nodeport-service.json
+export ETCDCTL_API=3
+export ETCDCTL_ENDPOINTS=$(minikube service etcd-cluster-client-service --url)
+etcdctl put foo bar
+```
+
 ## Resize an etcd cluster
 
 `kubectl apply` doesn't work for TPR at the moment. See [kubernetes/#29542](https://github.com/kubernetes/kubernetes/issues/29542).

--- a/example/example-etcd-cluster-nodeport-service.json
+++ b/example/example-etcd-cluster-nodeport-service.json
@@ -1,0 +1,22 @@
+{
+    "kind": "Service",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "etcd-cluster-client-service"
+    },
+    "spec": {
+        "selector": {
+            "etcd_cluster": "etcd-cluster",
+            "app": "etcd"
+        },
+        "ports": [
+            {
+                "protocol": "TCP",
+                "port": 2379,
+                "targetPort": 2379,
+                "nodePort": 32379
+            }
+        ],
+        "type": "NodePort"
+    }
+}


### PR DESCRIPTION
It is really helpful to be able to expose a nodeport for testing this
all out and verify with etcdctl.
