### PR TITLE
k8sutil: remove readiness probe in etcd pod

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -435,16 +435,16 @@ func WaitEtcdTPRReady(httpClient *http.Client, interval, timeout time.Duration, 
 	})
 }
 
-func SliceReadyAndUnreadyPods(podList *api.PodList) (ready, unready []*api.Pod) {
+func FilterRunning(podList *api.PodList) []*api.Pod {
+	running := []*api.Pod{}
 	for i := range podList.Items {
 		pod := &podList.Items[i]
-		if pod.Status.Phase == api.PodRunning && api.IsPodReady(pod) {
-			ready = append(ready, pod)
+		if pod.Status.Phase != api.PodRunning {
 			continue
 		}
-		unready = append(unready, pod)
+		running = append(running, pod)
 	}
-	return
+	return running
 }
 
 func EtcdPodListOpt(clusterName string) api.ListOptions {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -183,18 +183,13 @@ func waitSizeReachedWithFilter(f *framework.Framework, clusterName string, size,
 		if err != nil {
 			return false, err
 		}
-		ready, _ := k8sutil.SliceReadyAndUnreadyPods(pods)
-		names = []string{}
-		for _, pod := range ready {
-			if !filterPod(pod) {
-				continue
-			}
-			names = append(names, pod.Name)
-		}
+		running := k8sutil.FilterRunning(pods)
+		names = k8sutil.GetPodNames(running)
 		fmt.Printf("waiting size (%d), etcd pods: %v\n", size, names)
 		if len(names) != size {
 			return false, nil
 		}
+		// TODO: check etcd member membership
 		return true, nil
 	})
 	if err != nil {
@@ -291,8 +286,8 @@ func deleteEtcdCluster(f *framework.Framework, name string) error {
 	if err != nil {
 		return err
 	}
-	ready, unready := k8sutil.SliceReadyAndUnreadyPods(pods)
-	fmt.Printf("ready: %v, unready: %v\n", k8sutil.GetPodNames(ready), k8sutil.GetPodNames(unready))
+	running := k8sutil.FilterRunning(pods)
+	fmt.Printf("running: %v\n", k8sutil.GetPodNames(running))
 
 	buf := bytes.NewBuffer(nil)
 	if err := getLogs(f.KubeClient, f.Namespace.Name, "kube-etcd-controller", "kube-etcd-controller", buf); err != nil {


### PR DESCRIPTION
This readiness probe is problematic because it creates a circle:
- etcd server needed to establish quorum status before it can serve client req
- client req in readiness probe failed
- "unready" status cause service not able to talk to this pod.

This readiness probe can be removed since we are already handling error retrying in reconcile() loop. 
But we should keep doing more testing and uncover hidden bugs.
