### PR TITLE
cluster: refactor code that doesn't need to wait

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -258,7 +258,7 @@ func (c *Cluster) migrateSeedMember() error {
 	pod := k8sutil.MakeEtcdPod(m, initialCluster, c.name, "existing", "", c.spec)
 	pod = k8sutil.PodWithAddMemberInitContainer(pod, m.Name, mpurls, c.spec)
 
-	if err := k8sutil.CreateAndWaitPod(c.kclient, c.namespace, pod, 10*time.Second); err != nil {
+	if _, err := c.kclient.Pods(c.namespace).Create(pod); err != nil {
 		return err
 	}
 	c.idCounter++


### PR DESCRIPTION
Create the pod is enough:
- We have another delay in the following code.
- Trying to deprecate CreateAndWaitPod() since we used it before to wait pod "ready".
