### PR TITLE
spec/backup: rename CleanupBackupIfDeleted -> CleanupOnClusterDelete

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -407,7 +407,7 @@ func (c *Cluster) delete() {
 		}
 	}
 	if c.spec.Backup != nil {
-		k8sutil.DeleteBackupReplicaSetAndService(c.kclient, c.name, c.namespace, c.spec.Backup.CleanupBackupIfDeleted)
+		k8sutil.DeleteBackupReplicaSetAndService(c.kclient, c.name, c.namespace, c.spec.Backup.CleanupOnClusterDelete)
 	}
 }
 

--- a/pkg/spec/backup.go
+++ b/pkg/spec/backup.go
@@ -38,7 +38,7 @@ type BackupPolicy struct {
 	// StorageType specifies the type of storage device to store backup files.
 	// If it's not set by user, the default is "PersistentVolume".
 	StorageType BackupStorageType `json:"storageType"`
-	// CleanupStorageIfDeleted specified whether we want to cleanup the backup data if cluster is deleted.
+	// CleanupOnClusterDelete specified whether we want to cleanup the backup data if cluster is deleted.
 	// By default, operator will keep the backup data.
-	CleanupBackupIfDeleted bool `json:"cleanupBackupIfDeleted"`
+	CleanupOnClusterDelete bool `json:"cleanupOnClusterDelete"`
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -158,7 +158,7 @@ func testDisasterRecovery(t *testing.T, numToKill int) {
 		MaxSnapshot:              5,
 		VolumeSizeInMB:           512,
 		StorageType:              spec.BackupStorageTypePersistentVolume,
-		CleanupBackupIfDeleted:   true,
+		CleanupOnClusterDelete:   true,
 	}
 	origEtcd := makeEtcdCluster("test-etcd-", 3)
 	origEtcd = etcdClusterWithBackup(origEtcd, backupPolicy)


### PR DESCRIPTION
First of all, it's already in Backup. We don't need to say "cleanup backup" again.
Second, we make the event more explicit than "IfDeleted".