### PR TITLE
Fix orphan backup pod

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -394,6 +394,7 @@ func (c *Cluster) delete() {
 	option := k8sapi.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{
 			"etcd_cluster": c.name,
+			"app":          "etcd",
 		}),
 	}
 

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -184,7 +184,8 @@ func DeleteBackupReplicaSetAndService(kubecli *unversioned.Client, clusterName, 
 	if err != nil {
 		return err
 	}
-	err = kubecli.ReplicaSets(ns).Delete(name, nil)
+	orphanOption := false
+	err = kubecli.ReplicaSets(ns).Delete(name, &api.DeleteOptions{OrphanDependents: &orphanOption})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently we encountered a race in replicaset (TODO: issue number).

Instead, we will only delete etcd pods and let replica set delete the backup pod.