### PR TITLE
build: shrink docker image size

### DIFF
--- a/hack/build/operator/Dockerfile
+++ b/hack/build/operator/Dockerfile
@@ -1,14 +1,6 @@
-FROM golang
+FROM alpine
 
-ADD . /go/src/github.com/coreos/etcd-operator
-
-ARG ARG_LDFLAGS
-
-RUN cd /go/src/github.com/coreos/etcd-operator && \
-	go build -ldflags "${ARG_LDFLAGS:-}" -o etcd-operator ./cmd/operator/main.go && \
-	mv etcd-operator /usr/local/bin && \
-	go build -ldflags "${ARG_LDFLAGS:-}" -o etcd-backup ./cmd/backup/main.go && \
-	mv etcd-backup /usr/local/bin && \
-	rm -rf /go/*
+ADD _output/bin/etcd-operator /usr/local/bin
+ADD _output/bin/etcd-backup /usr/local/bin
 
 CMD ["/bin/sh", "-c", "/usr/local/bin/etcd-operator"]

--- a/hack/build/operator/build
+++ b/hack/build/operator/build
@@ -4,21 +4,31 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if ! which docker > /dev/null; then
-	echo "docker needs to be installed"
+if ! which go > /dev/null; then
+	echo "golang needs to be installed"
 	exit 1
 fi
 
-if ! which gcloud > /dev/null; then
+if ! which docker > /dev/null; then
 	echo "docker needs to be installed"
 	exit 1
 fi
 
 : ${IMAGE:?"Need to set IMAGE, e.g. gcr.io/coreos-k8s-scale-testing/etcd-operator"}
 
+bin_dir="_output/bin"
+mkdir -p ${bin_dir} || true
+
+
 ldKVPairs="github.com/coreos/etcd-operator/pkg/util/k8sutil.BackupImage=${IMAGE}"
 go_ldflags="-X ${ldKVPairs}"
 
-docker build --build-arg ARG_LDFLAGS="${go_ldflags}" \
-	--tag "${IMAGE}" -f hack/build/operator/Dockerfile .
-gcloud docker -- push "${IMAGE}"
+CGO_ENABLED=0 go build -installsuffix cgo -ldflags "$go_ldflags" \
+	-o ${bin_dir}/etcd-operator ./cmd/operator/main.go
+CGO_ENABLED=0 go build -installsuffix cgo -ldflags "$go_ldflags" \
+	-o ${bin_dir}/etcd-backup ./cmd/backup/main.go
+
+
+docker build --tag "${IMAGE}" -f hack/build/operator/Dockerfile .
+# For gcr users, do "gcloud docker -a" to have access.
+docker push "${IMAGE}"

--- a/hack/jenkins
+++ b/hack/jenkins
@@ -33,6 +33,8 @@ export TEST_NAMESPACE="e2e-test-${BUILD_ID}"
 echo "operator image: ${OPERATOR_IMAGE}"
 echo "test namespace: ${TEST_NAMESPACE}"
 
+gcloud docker -a # have docker command access to gcloud 
+
 if "hack/test"; then
 	echo "Success! ==="
 else

--- a/hack/release/README.md
+++ b/hack/release/README.md
@@ -5,15 +5,19 @@ This docs describes the release process of etcd-operator public docker image.
 
 ## Prerequisites
 
-Make sure following tools are installed:
+Supported build arch
+- linux/amd64
+
+Make sure the following tools are installed:
 - glide
 - docker
+- go 1.7
 
-Make sure you have a quay.io account.
+Have a quay.io account.
 
 ## Build image
 
-Make sure your working directory is root of "etcd-operator/".
+Working directory is root of "etcd-operator/".
 
 Install dependency if none exists:
 ```
@@ -21,23 +25,16 @@ $ glide install
 ```
 You should see "vendor/".
 
-Build docker image
-```
-$ docker build --tag quay.io/coreos/etcd-operator:${TAG} -f hack/build/operator/Dockerfile .
-```
-`${TAG}` is the release tag. For example, "v0.0.1", "latest".
-We also need to create a corresponding release on github with release note.
-
-## Push to quay.io
-
-Login to quay.io using docker if not done before:
+Login to quay.io using docker if haven't:
 ```
 $ docker login quay.io
 ```
 Follow the prompts.
 
-Push docker image to quay.io:
+Use build script to build binaries, docker images, and push to quay registry:
 ```
-$ docker push quay.io/coreos/etcd-operator:${TAG}
+$ IMAGE=quay.io/coreos/etcd-operator:${TAG} hack/build/operator/build
 ```
-`${TAG}` is the same as above.
+`${TAG}` is the release tag. For example, "v0.0.1", "latest".
+
+We also need to create a corresponding release on github with release note.


### PR DESCRIPTION
Fix #361

We are using "alpine" as base images now. The output is just 27MB on quay, compared to ~400MB previously.

docker images:
```
quay.io/coreos/etcd-operator                           test                          9773f55873c3        10 minutes ago      137.3 MB
```
Compared to 1.2GB previously.

Not sure why they are different though.