### PR TITLE
pod_util: fix liveness check to use MY_POD_IP

### DIFF
--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -58,7 +58,7 @@ func etcdContainer(commands, version string) api.Container {
 			Handler: api.Handler{
 				Exec: &api.ExecAction{
 					Command: []string{"/bin/sh", "-c",
-						"ETCDCTL_API=3 etcdctl get foo"},
+						"ETCDCTL_API=3 etcdctl --endpoints=http://$(MY_POD_IP):2379 get foo"},
 				},
 			},
 			InitialDelaySeconds: 10,


### PR DESCRIPTION
Previously we rely on etcd to listen on localhost:2379.
This is problemantic. We should talk to the interface that it listens to.