### PR TITLE
e2e_test: increase timeout to 30m

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -45,7 +45,7 @@ function build_pass {
 
 function e2e_pass {
 	TEST_PKGS=`go list ./test/... | grep -v framework`
-	go test -v ${TEST_PKGS} --kubeconfig $KUBERNETES_KUBECONFIG_PATH --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
+	go test -v ${TEST_PKGS} -timeout 30m --kubeconfig $KUBERNETES_KUBECONFIG_PATH --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
 }
 
 function unittest_pass {


### PR DESCRIPTION
Recently We have seen many test timeout error:
```
Test killed: ran too long (10m0s)
```

One change I made is that I have downgraded k8s master from n4 to n2. After that test started failing.