### PR TITLE
example: rename etcd-cluster to example-etcd-cluster

### DIFF
--- a/example/example-etcd-cluster-nodeport-service.json
+++ b/example/example-etcd-cluster-nodeport-service.json
@@ -2,11 +2,11 @@
     "kind": "Service",
     "apiVersion": "v1",
     "metadata": {
-        "name": "etcd-cluster-client-service"
+        "name": "example-etcd-cluster-client-service"
     },
     "spec": {
         "selector": {
-            "etcd_cluster": "etcd-cluster",
+            "etcd_cluster": "example-etcd-cluster",
             "app": "etcd"
         },
         "ports": [

--- a/example/example-etcd-cluster.yaml
+++ b/example/example-etcd-cluster.yaml
@@ -1,7 +1,7 @@
 apiVersion: "coreos.com/v1"
 kind: "EtcdCluster"
 metadata:
-  name: "etcd-cluster"
+  name: "example-etcd-cluster"
 spec:
   size: 3
   version: "v3.1.0-alpha.1"


### PR DESCRIPTION
EtcdCluster is the type so it is a bit confusing that our example
cluster is named etcd-cluster.