### PR TITLE
cluster: backup RS to guard reentrancy

### DIFF
--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -191,6 +191,17 @@ func CreateBackupReplicaSetAndService(kubecli *unversioned.Client, clusterName, 
 	return nil
 }
 
+func IsBackupReplicaSetExist(kubecli *unversioned.Client, clusterName, ns string) (bool, error) {
+	_, err := kubecli.ReplicaSets(ns).Get(MakeBackupName(clusterName))
+	if err != nil {
+		if IsKubernetesResourceNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 func DeleteBackupReplicaSetAndService(kubecli *unversioned.Client, clusterName, ns string, cleanup bool) error {
 	name := MakeBackupName(clusterName)
 	err := kubecli.Services(ns).Delete(name)


### PR DESCRIPTION
Reentrancy will happen when controller tries to restore each cluster
state. However, backup conflict detection and restore process is one
time only. We need to put a guard on it.