### PR TITLE
backup: pass aws, s3 params and set up volumes

### DIFF
--- a/hack/build/operator/Dockerfile
+++ b/hack/build/operator/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
 
+RUN apk add --no-cache ca-certificates
+
 ADD _output/bin/etcd-operator /usr/local/bin
 ADD _output/bin/etcd-backup /usr/local/bin
 

--- a/pkg/backup/s3/s3.go
+++ b/pkg/backup/s3/s3.go
@@ -39,10 +39,15 @@ func New() (*S3, error) {
 	if bucket == "" {
 		return nil, fmt.Errorf("%s bucket must be set", env.AWSS3Bucket)
 	}
+	sess, err := session.NewSessionWithOptions(session.Options{
+		SharedConfigState: session.SharedConfigEnable,
+	})
+	if err != nil {
+		return nil, err
+	}
+	client := s3.New(sess)
 
-	client := s3.New(session.New())
-
-	_, err := client.HeadBucket(&s3.HeadBucketInput{Bucket: &bucket})
+	_, err = client.HeadBucket(&s3.HeadBucketInput{Bucket: &bucket})
 	if err != nil {
 		return nil, fmt.Errorf("unable to access bucket %s: %v", bucket, err)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -32,7 +32,6 @@ import (
 	k8sapi "k8s.io/kubernetes/pkg/api"
 	unversionedAPI "k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/client/unversioned"
 )
 
 const (
@@ -70,10 +69,8 @@ type Controller struct {
 }
 
 type Config struct {
-	Namespace     string
-	MasterHost    string
-	KubeCli       *unversioned.Client
-	PVProvisioner string
+	MasterHost string
+	cluster.Config
 }
 
 func (c *Config) validate() error {
@@ -133,13 +130,7 @@ func (c *Controller) Run() error {
 			switch event.Type {
 			case "ADDED":
 				stopC := make(chan struct{})
-				cfg := cluster.Config{
-					Name:          clusterName,
-					Namespace:     c.Namespace,
-					PVProvisioner: c.PVProvisioner,
-					KubeCli:       c.KubeCli,
-				}
-				nc, err := cluster.New(cfg, &event.Object.Spec, stopC, &c.waitCluster)
+				nc, err := cluster.New(c.Config.Config, &event.Object.Spec, stopC, &c.waitCluster)
 				if err != nil {
 					c.logger.Errorf("cluster (%q) is dead: %v", clusterName, err)
 					continue

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -21,9 +21,9 @@ import (
 	"time"
 
 	backupenv "github.com/coreos/etcd-operator/pkg/backup/env"
+	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/constants"
 
-	"github.com/coreos/etcd-operator/pkg/spec"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/resource"
 	unversionedAPI "k8s.io/kubernetes/pkg/api/unversioned"
@@ -104,17 +104,89 @@ func CreateAndWaitPVC(kubecli *unversioned.Client, clusterName, ns, pvProvisione
 
 var BackupImage = "quay.io/coreos/etcd-operator:latest"
 
-func CreateBackupReplicaSetAndService(kubecli *unversioned.Client, clusterName, ns string, policy *spec.BackupPolicy) error {
+func PodSpecWithPVStorage(ps *api.PodSpec, clusterName string) *api.PodSpec {
+	ps.Containers[0].VolumeMounts = []api.VolumeMount{{
+		Name:      "etcd-backup-storage",
+		MountPath: constants.BackupDir,
+	}}
+	ps.Volumes = []api.Volume{{
+		Name: "etcd-backup-storage",
+		VolumeSource: api.VolumeSource{
+			PersistentVolumeClaim: &api.PersistentVolumeClaimVolumeSource{
+				ClaimName: makePVCName(clusterName),
+			},
+		},
+	}}
+	return ps
+}
+
+func PodSpecWithS3Storage(ps *api.PodSpec, awsSecret, awsConfig string) *api.PodSpec {
+	ps.Containers[0].VolumeMounts = []api.VolumeMount{{
+		Name:      "secret-aws",
+		MountPath: "/root/.aws/",
+	}, {
+		Name:      "config-aws",
+		MountPath: "/root/.aws/",
+	}}
+	ps.Volumes = []api.Volume{{
+		Name: "secret-aws",
+		VolumeSource: api.VolumeSource{
+			Secret: &api.SecretVolumeSource{
+				SecretName: awsSecret,
+			},
+		},
+	}, {
+		Name: "config-aws",
+		VolumeSource: api.VolumeSource{
+			ConfigMap: &api.ConfigMapVolumeSource{
+				LocalObjectReference: api.LocalObjectReference{
+					Name: awsConfig,
+				},
+			},
+		},
+	}}
+	return ps
+}
+
+func MakeBackupPodSpec(clusterName, s3Bucket string, policy *spec.BackupPolicy) (*api.PodSpec, error) {
 	bp, err := json.Marshal(policy)
 	if err != nil {
-		return err
+		return nil, err
 	}
+
+	ps := &api.PodSpec{
+		Containers: []api.Container{
+			{
+				Name:  "backup",
+				Image: BackupImage,
+				Command: []string{
+					"/bin/sh",
+					"-c",
+					"/usr/local/bin/etcd-backup --etcd-cluster=" + clusterName,
+				},
+				Env: []api.EnvVar{{
+					Name:      "MY_POD_NAMESPACE",
+					ValueFrom: &api.EnvVarSource{FieldRef: &api.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
+				}, {
+					Name:  backupenv.BackupPolicy,
+					Value: string(bp),
+				}, {
+					Name:  backupenv.AWSS3Bucket,
+					Value: s3Bucket,
+				}},
+			},
+		},
+	}
+	return ps, nil
+}
+
+func CreateBackupReplicaSetAndService(kubecli *unversioned.Client, clusterName, ns string, ps api.PodSpec) error {
 	labels := map[string]string{
 		"app":          BackupPodSelectorAppField,
 		"etcd_cluster": clusterName,
 	}
 	name := MakeBackupName(clusterName)
-	_, err = kubecli.ReplicaSets(ns).Create(&extensions.ReplicaSet{
+	_, err := kubecli.ReplicaSets(ns).Create(&extensions.ReplicaSet{
 		ObjectMeta: api.ObjectMeta{
 			Name: name,
 		},
@@ -125,38 +197,7 @@ func CreateBackupReplicaSetAndService(kubecli *unversioned.Client, clusterName, 
 				ObjectMeta: api.ObjectMeta{
 					Labels: labels,
 				},
-				Spec: api.PodSpec{
-					Containers: []api.Container{
-						{
-							Name:  "backup",
-							Image: BackupImage,
-							Command: []string{
-								"/bin/sh",
-								"-c",
-								"/usr/local/bin/etcd-backup --etcd-cluster=" + clusterName,
-							},
-							Env: []api.EnvVar{{
-								Name:      "MY_POD_NAMESPACE",
-								ValueFrom: &api.EnvVarSource{FieldRef: &api.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
-							}, {
-								Name:  backupenv.BackupPolicy,
-								Value: string(bp),
-							}},
-							VolumeMounts: []api.VolumeMount{{
-								Name:      "etcd-backup-storage",
-								MountPath: constants.BackupDir,
-							}},
-						},
-					},
-					Volumes: []api.Volume{{
-						Name: "etcd-backup-storage",
-						VolumeSource: api.VolumeSource{
-							PersistentVolumeClaim: &api.PersistentVolumeClaimVolumeSource{
-								ClaimName: makePVCName(clusterName),
-							},
-						},
-					}},
-				},
+				Spec: ps,
 			},
 		},
 	})


### PR DESCRIPTION
This PR shows how we can pass aws, s3 params to backup pod for early feedback.

Once we have converged enough and I have tested it with confidence, I would separate it into two or  more PRs.