### PR TITLE
Dockerfile: add ca-certificates in alpine image

### DIFF
--- a/hack/build/operator/Dockerfile
+++ b/hack/build/operator/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
 
+RUN apk add --no-cache ca-certificates
+
 ADD _output/bin/etcd-operator /usr/local/bin
 ADD _output/bin/etcd-backup /usr/local/bin
 


### PR DESCRIPTION
alpine doesn’t have CA certificates. We need to add them so that AWS
client could be created securely.