### PR TITLE
e2e: framework use ns string param directly

### DIFF
--- a/hack/jenkins
+++ b/hack/jenkins
@@ -28,7 +28,6 @@ glide install
 
 GIT_VERSION=$(git rev-parse HEAD)
 export OPERATOR_IMAGE="gcr.io/coreos-k8s-scale-testing/etcd-operator:${GIT_VERSION}"
-export TEST_NAMESPACE="e2e-test-${BUILD_ID}"
 
 echo "operator image: ${OPERATOR_IMAGE}"
 echo "test namespace: ${TEST_NAMESPACE}"

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -45,7 +45,7 @@ func testClusterRestore(t *testing.T, sameName bool) {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 
-	pod, err := f.KubeClient.Pods(f.Namespace.Name).Get(names[0])
+	pod, err := f.KubeClient.Pods(f.Namespace).Get(names[0])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +106,7 @@ func testClusterRestore(t *testing.T, sameName bool) {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 
-	pod, err = f.KubeClient.Pods(f.Namespace.Name).Get(names[0])
+	pod, err = f.KubeClient.Pods(f.Namespace).Get(names[0])
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
We have changed the jenkins setup to create namespace outside.
We don't need to create ns again.
It also doesn't make sense to get the ns object from k8s again.
The 'Namespace' field in framework should be changed to string too
so that we can just use given param directly.