### PR TITLE
backup_spec: remove CleanupOnClusterDelete

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -370,7 +370,7 @@ func (c *Cluster) delete() {
 		}
 	}
 	if c.spec.Backup != nil {
-		k8sutil.DeleteBackupReplicaSetAndService(c.KubeCli, c.Name, c.Namespace, c.spec.Backup.CleanupOnClusterDelete)
+		k8sutil.DeleteBackupReplicaSetAndService(c.KubeCli, c.Name, c.Namespace)
 	}
 
 	err = c.deleteClientServiceLB()

--- a/pkg/spec/backup.go
+++ b/pkg/spec/backup.go
@@ -40,7 +40,4 @@ type BackupPolicy struct {
 	// StorageType specifies the type of storage device to store backup files.
 	// If it's not set by user, the default is "PersistentVolume".
 	StorageType BackupStorageType `json:"storageType"`
-	// CleanupOnClusterDelete specified whether we want to cleanup the backup data if cluster is deleted.
-	// By default, operator will keep the backup data.
-	CleanupOnClusterDelete bool `json:"cleanupOnClusterDelete"`
 }

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -108,6 +108,10 @@ func CreateAndWaitPVC(kubecli *unversioned.Client, clusterName, ns, pvProvisione
 	return nil
 }
 
+func DeletePVC(kubecli *unversioned.Client, ns, clusterName string) error {
+	return kubecli.PersistentVolumeClaims(ns).Delete(makePVCName(clusterName))
+}
+
 var BackupImage = "quay.io/coreos/etcd-operator:latest"
 
 func PodSpecWithPV(ps *api.PodSpec, clusterName string) *api.PodSpec {
@@ -242,7 +246,7 @@ func CreateBackupReplicaSetAndService(kubecli *unversioned.Client, clusterName, 
 	return nil
 }
 
-func DeleteBackupReplicaSetAndService(kubecli *unversioned.Client, clusterName, ns string, cleanup bool) error {
+func DeleteBackupReplicaSetAndService(kubecli *unversioned.Client, clusterName, ns string) error {
 	name := MakeBackupName(clusterName)
 	err := kubecli.Services(ns).Delete(name)
 	if err != nil {
@@ -256,9 +260,6 @@ func DeleteBackupReplicaSetAndService(kubecli *unversioned.Client, clusterName, 
 	})
 	if err != nil {
 		return err
-	}
-	if cleanup {
-		kubecli.PersistentVolumeClaims(ns).Delete(makePVCName(clusterName))
 	}
 	return nil
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd-operator/pkg/spec"
+	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
@@ -191,13 +192,16 @@ func testDisasterRecovery(t *testing.T, numToKill int) {
 func testDisasterRecoveryWithStorageType(t *testing.T, numToKill int, bt spec.BackupStorageType) {
 	f := framework.Global
 	origEtcd := makeEtcdCluster("test-etcd-", 3)
-	bp := backupPolicyWithStorageType(makeBackupPolicy(true), bt)
+	bp := backupPolicyWithStorageType(makeBackupPolicy(), bt)
 	testEtcd, err := createEtcdCluster(f, etcdClusterWithBackup(origEtcd, bp))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
 		if err := deleteEtcdCluster(f, testEtcd.Name); err != nil {
+			t.Fatal(err)
+		}
+		if err := k8sutil.DeletePVC(f.KubeClient, f.Namespace, testEtcd.Name); err != nil {
 			t.Fatal(err)
 		}
 		// TODO: add checking of removal of backup pod

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/constants"
+	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
@@ -36,7 +37,7 @@ func TestClusterRestoreDifferentName(t *testing.T) {
 func testClusterRestore(t *testing.T, sameName bool) {
 	f := framework.Global
 	origEtcd := makeEtcdCluster("test-etcd-", 3)
-	testEtcd, err := createEtcdCluster(f, etcdClusterWithBackup(origEtcd, makeBackupPolicy(false)))
+	testEtcd, err := createEtcdCluster(f, etcdClusterWithBackup(origEtcd, makeBackupPolicy()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,12 +93,15 @@ func testClusterRestore(t *testing.T, sameName bool) {
 		BackupClusterName: testEtcd.Name,
 		StorageType:       spec.BackupStorageTypePersistentVolume,
 	})
-	testEtcd, err = createEtcdCluster(f, etcdClusterWithBackup(origEtcd, makeBackupPolicy(true)))
+	testEtcd, err = createEtcdCluster(f, etcdClusterWithBackup(origEtcd, makeBackupPolicy()))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
 		if err := deleteEtcdCluster(f, testEtcd.Name); err != nil {
+			t.Fatal(err)
+		}
+		if err := k8sutil.DeletePVC(f.KubeClient, f.Namespace, testEtcd.Name); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -136,13 +136,12 @@ func makeEtcdCluster(genName string, size int) *spec.EtcdCluster {
 	}
 }
 
-func makeBackupPolicy(cleanup bool) *spec.BackupPolicy {
+func makeBackupPolicy() *spec.BackupPolicy {
 	return &spec.BackupPolicy{
 		SnapshotIntervalInSecond: 60 * 60,
 		MaxSnapshot:              5,
 		VolumeSizeInMB:           512,
 		StorageType:              spec.BackupStorageTypePersistentVolume,
-		CleanupOnClusterDelete:   cleanup,
 	}
 }
 


### PR DESCRIPTION
This field shouldn't exist.

On e2e test, we delete the PVC explicitly instead.