### PR TITLE
backup_manager: construct storage on controller restore

### DIFF
--- a/pkg/cluster/backupstorage/storage.go
+++ b/pkg/cluster/backupstorage/storage.go
@@ -1,9 +1,5 @@
 package backupstorage
 
-import "errors"
-
-var ErrStorageAlreadyExist = errors.New("backup storage already exist (or created before)")
-
 // Storage defines the underlying storage used by backup sidecar.
 type Storage interface {
 	// Clone will try to clone another storage referenced by cluster name.

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -102,11 +102,9 @@ func new(config Config, s *spec.ClusterSpec, stopC <-chan struct{}, wg *sync.Wai
 	lg := logrus.WithField("pkg", "cluster").WithField("cluster-name", config.Name)
 	var bm *backupManager
 	if b := s.Backup; b != nil && b.MaxBackups > 0 {
-		bm = &backupManager{
-			clusterConfig: config,
-			backupPolicy:  s.Backup,
-			restorePolicy: s.Restore,
-			logger:        lg,
+		bm, err = newBackupManager(config, s.Backup, s.Restore, lg, isNewCluster)
+		if err != nil {
+			return nil, err
 		}
 	}
 	c := &Cluster{


### PR DESCRIPTION
Previously, on controller restore case, backup manager “storage” field will be nil due to not calling setup in “isNewCluster” logic block.

Instead, we always construct “storage” field in newBackupManager(). We also introduce a new logic called “hasExist” to indicate whether we have existing storage created, e.g. not new cluster case, restoring same cluster name case.