### PR TITLE
cluster: pass in EtcdCluster object

### DIFF
--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -26,23 +26,21 @@ import (
 type backupManager struct {
 	logger *logrus.Entry
 
-	clusterConfig Config
-	backupPolicy  *spec.BackupPolicy
-	restorePolicy *spec.RestorePolicy
-	s             backupstorage.Storage
+	config  Config
+	cluster *spec.EtcdCluster
+	s       backupstorage.Storage
 }
 
-func newBackupManager(c Config, b *spec.BackupPolicy, r *spec.RestorePolicy, l *logrus.Entry, isNewCluster bool) (*backupManager, error) {
+func newBackupManager(c Config, cl *spec.EtcdCluster, l *logrus.Entry, isNewCluster bool) (*backupManager, error) {
 	bm := &backupManager{
-		clusterConfig: c,
-		backupPolicy:  b,
-		restorePolicy: r,
-		logger:        l,
+		config:  c,
+		cluster: cl,
+		logger:  l,
 	}
 	hasExist := false
 	if !isNewCluster {
 		hasExist = true
-	} else if r != nil && r.BackupClusterName == c.Name {
+	} else if r := cl.Spec.Restore; r != nil && r.BackupClusterName == cl.Name {
 		hasExist = true // we will reuse the storage to restore cluster
 	}
 	var err error
@@ -54,9 +52,9 @@ func newBackupManager(c Config, b *spec.BackupPolicy, r *spec.RestorePolicy, l *
 }
 
 func (bm *backupManager) setup() error {
-	if r := bm.restorePolicy; r != nil {
+	if r := bm.cluster.Spec.Restore; r != nil {
 		bm.logger.Infof("restoring cluster from existing backup (%s)", r.BackupClusterName)
-		if bm.clusterConfig.Name != r.BackupClusterName {
+		if bm.cluster.Name != r.BackupClusterName {
 			if err := bm.s.Clone(r.BackupClusterName); err != nil {
 				return err
 			}
@@ -67,30 +65,31 @@ func (bm *backupManager) setup() error {
 }
 
 func (bm *backupManager) setupStorage(hasExist bool) (s backupstorage.Storage, err error) {
-	b, c := bm.backupPolicy, bm.clusterConfig
+	cl, c := bm.cluster, bm.config
 
+	b := cl.Spec.Backup
 	switch b.StorageType {
 	case spec.BackupStorageTypePersistentVolume, spec.BackupStorageTypeDefault:
-		s, err = backupstorage.NewPVStorage(c.KubeCli, c.Name, c.Namespace, c.PVProvisioner, *b, hasExist)
+		s, err = backupstorage.NewPVStorage(c.KubeCli, cl.Name, cl.Namespace, c.PVProvisioner, *b, hasExist)
 	case spec.BackupStorageTypeS3:
-		s, err = backupstorage.NewS3Storage(c.S3Context, c.KubeCli, c.Name, c.Namespace, *b, hasExist)
+		s, err = backupstorage.NewS3Storage(c.S3Context, c.KubeCli, cl.Name, cl.Namespace, *b, hasExist)
 	}
 	return s, err
 }
 
 func (bm *backupManager) runSidecar() error {
-	c := bm.clusterConfig
-	podSpec, err := k8sutil.MakeBackupPodSpec(c.Name, bm.backupPolicy)
+	cl, c := bm.cluster, bm.config
+	podSpec, err := k8sutil.MakeBackupPodSpec(cl.Name, cl.Spec.Backup)
 	if err != nil {
 		return err
 	}
-	switch bm.backupPolicy.StorageType {
+	switch cl.Spec.Backup.StorageType {
 	case spec.BackupStorageTypeDefault, spec.BackupStorageTypePersistentVolume:
-		podSpec = k8sutil.PodSpecWithPV(podSpec, c.Name)
+		podSpec = k8sutil.PodSpecWithPV(podSpec, cl.Name)
 	case spec.BackupStorageTypeS3:
 		podSpec = k8sutil.PodSpecWithS3(podSpec, c.S3Context)
 	}
-	err = k8sutil.CreateBackupReplicaSetAndService(c.KubeCli, c.Name, c.Namespace, *podSpec)
+	err = k8sutil.CreateBackupReplicaSetAndService(c.KubeCli, cl.Name, cl.Namespace, *podSpec)
 	if err != nil {
 		return fmt.Errorf("failed to create backup replica set and service: %v", err)
 	}
@@ -99,8 +98,8 @@ func (bm *backupManager) runSidecar() error {
 }
 
 func (bm *backupManager) cleanup() error {
-	c := bm.clusterConfig
-	err := k8sutil.DeleteBackupReplicaSetAndService(c.KubeCli, c.Name, c.Namespace)
+	cl, c := bm.cluster, bm.config
+	err := k8sutil.DeleteBackupReplicaSetAndService(c.KubeCli, cl.Name, cl.Namespace)
 	if err != nil {
 		return fmt.Errorf("fail to delete backup ReplicaSet and Service: %v", err)
 	}

--- a/pkg/cluster/self_hosted.go
+++ b/pkg/cluster/self_hosted.go
@@ -26,16 +26,16 @@ import (
 )
 
 func (c *Cluster) addOneSelfHostedMember() error {
-	newMemberName := fmt.Sprintf("%s-%04d", c.Name, c.idCounter)
+	newMemberName := fmt.Sprintf("%s-%04d", c.cluster.Name, c.idCounter)
 	c.idCounter++
 
 	peerURL := "http://$(MY_POD_IP):2380"
 	initialCluster := append(c.members.PeerURLPairs(), newMemberName+"="+peerURL)
 
-	pod := k8sutil.MakeSelfHostedEtcdPod(newMemberName, initialCluster, c.Name, "existing", "", c.spec)
-	pod = k8sutil.PodWithAddMemberInitContainer(pod, c.members.ClientURLs(), newMemberName, []string{peerURL}, c.spec)
+	pod := k8sutil.MakeSelfHostedEtcdPod(newMemberName, initialCluster, c.cluster.Name, "existing", "", c.cluster.Spec)
+	pod = k8sutil.PodWithAddMemberInitContainer(pod, c.members.ClientURLs(), newMemberName, []string{peerURL}, c.cluster.Spec)
 
-	_, err := c.KubeCli.Pods(c.Namespace).Create(pod)
+	_, err := c.config.KubeCli.Pods(c.cluster.Namespace).Create(pod)
 	if err != nil {
 		return err
 	}
@@ -70,12 +70,12 @@ func (c *Cluster) addOneSelfHostedMember() error {
 }
 
 func (c *Cluster) newSelfHostedSeedMember() error {
-	newMemberName := fmt.Sprintf("%s-%04d", c.Name, c.idCounter)
+	newMemberName := fmt.Sprintf("%s-%04d", c.cluster.Name, c.idCounter)
 	c.idCounter++
 	initialCluster := []string{newMemberName + "=http://$(MY_POD_IP):2380"}
 
-	pod := k8sutil.MakeSelfHostedEtcdPod(newMemberName, initialCluster, c.Name, "new", uuid.New(), c.spec)
-	_, err := k8sutil.CreateAndWaitPod(c.KubeCli, c.Namespace, pod, 30*time.Second)
+	pod := k8sutil.MakeSelfHostedEtcdPod(newMemberName, initialCluster, c.cluster.Name, "new", uuid.New(), c.cluster.Spec)
+	_, err := k8sutil.CreateAndWaitPod(c.config.KubeCli, c.cluster.Namespace, pod, 30*time.Second)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (c *Cluster) newSelfHostedSeedMember() error {
 }
 
 func (c *Cluster) migrateBootMember() error {
-	endpoint := c.spec.SelfHosted.BootMemberClientEndpoint
+	endpoint := c.cluster.Spec.SelfHosted.BootMemberClientEndpoint
 
 	c.logger.Infof("migrating boot member (%s)", endpoint)
 
@@ -104,15 +104,15 @@ func (c *Cluster) migrateBootMember() error {
 	}
 
 	// create the  member inside Kubernetes for migration
-	newMemberName := fmt.Sprintf("%s-%04d", c.Name, c.idCounter)
+	newMemberName := fmt.Sprintf("%s-%04d", c.cluster.Name, c.idCounter)
 	c.idCounter++
 
 	peerURL := "http://$(MY_POD_IP):2380"
 	initialCluster = append(initialCluster, newMemberName+"="+peerURL)
 
-	pod := k8sutil.MakeSelfHostedEtcdPod(newMemberName, initialCluster, c.Name, "existing", "", c.spec)
-	pod = k8sutil.PodWithAddMemberInitContainer(pod, []string{endpoint}, newMemberName, []string{peerURL}, c.spec)
-	pod, err = k8sutil.CreateAndWaitPod(c.KubeCli, c.Namespace, pod, 30*time.Second)
+	pod := k8sutil.MakeSelfHostedEtcdPod(newMemberName, initialCluster, c.cluster.Name, "existing", "", c.cluster.Spec)
+	pod = k8sutil.PodWithAddMemberInitContainer(pod, []string{endpoint}, newMemberName, []string{peerURL}, c.cluster.Spec)
+	pod, err = k8sutil.CreateAndWaitPod(c.config.KubeCli, c.cluster.Namespace, pod, 30*time.Second)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -22,14 +22,14 @@ import (
 )
 
 func (c *Cluster) upgradeOneMember(m *etcdutil.Member) error {
-	pod, err := c.KubeCli.Pods(c.Namespace).Get(m.Name)
+	pod, err := c.config.KubeCli.Pods(c.cluster.Namespace).Get(m.Name)
 	if err != nil {
 		return fmt.Errorf("fail to get pod (%s): %v", m.Name, err)
 	}
-	c.logger.Infof("upgrading the etcd member %v from %s to %s", m.Name, k8sutil.GetEtcdVersion(pod), c.spec.Version)
-	pod.Spec.Containers[0].Image = k8sutil.MakeEtcdImage(c.spec.Version)
-	k8sutil.SetEtcdVersion(pod, c.spec.Version)
-	_, err = c.KubeCli.Pods(c.Namespace).Update(pod)
+	c.logger.Infof("upgrading the etcd member %v from %s to %s", m.Name, k8sutil.GetEtcdVersion(pod), c.cluster.Spec.Version)
+	pod.Spec.Containers[0].Image = k8sutil.MakeEtcdImage(c.cluster.Spec.Version)
+	k8sutil.SetEtcdVersion(pod, c.cluster.Spec.Version)
+	_, err = c.config.KubeCli.Pods(c.cluster.Namespace).Update(pod)
 	if err != nil {
 		return fmt.Errorf("fail to update the etcd member (%s): %v", m.Name, err)
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -142,7 +142,7 @@ func (c *Controller) Run() error {
 			switch event.Type {
 			case "ADDED":
 				stopC := make(chan struct{})
-				nc, err := cluster.New(c.makeClusterConfig(clusterName), event.Object.Spec, stopC, &c.waitCluster)
+				nc, err := cluster.New(c.makeClusterConfig(), event.Object, stopC, &c.waitCluster)
 				if err != nil {
 					c.logger.Errorf("cluster (%q) is dead: %v", clusterName, err)
 					continue
@@ -157,7 +157,7 @@ func (c *Controller) Run() error {
 					c.logger.Warningf("ignore modification: cluster %q not found (or dead)", clusterName)
 					break
 				}
-				c.clusters[clusterName].Update(event.Object.Spec)
+				c.clusters[clusterName].Update(event.Object)
 			case "DELETED":
 				if c.clusters[clusterName] == nil {
 					c.logger.Warningf("ignore deletion: cluster %q not found (or dead)", clusterName)
@@ -186,7 +186,7 @@ func (c *Controller) findAllClusters() (string, error) {
 	for _, item := range list.Items {
 		clusterName := item.Name
 		stopC := make(chan struct{})
-		nc, err := cluster.Restore(c.makeClusterConfig(clusterName), item.Spec, stopC, &c.waitCluster)
+		nc, err := cluster.Restore(c.makeClusterConfig(), &item, stopC, &c.waitCluster)
 		if err != nil {
 			c.logger.Errorf("cluster (%q) is dead: %v", clusterName, err)
 			continue
@@ -197,10 +197,8 @@ func (c *Controller) findAllClusters() (string, error) {
 	return list.ListMeta.ResourceVersion, nil
 }
 
-func (c *Controller) makeClusterConfig(clusterName string) cluster.Config {
+func (c *Controller) makeClusterConfig() cluster.Config {
 	return cluster.Config{
-		Name:          clusterName,
-		Namespace:     c.Namespace,
 		PVProvisioner: c.PVProvisioner,
 		S3Context:     c.S3Context,
 		KubeCli:       c.KubeCli,


### PR DESCRIPTION
In details, we will need both TypeMeta and ObjectMeta of EtcdCluster to set OwnerRef.

Conceptually, the cluster should have a EtcdCluster obj as its knowledge. The entire object provides more than Spec.