### PR TITLE
e2e: ignore get container logs error

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -247,12 +247,13 @@ func deleteEtcdCluster(f *framework.Framework, name string) error {
 	fmt.Println("etcd pods ======")
 	for i := range podList.Items {
 		pod := &podList.Items[i]
-		fmt.Printf("pod (%v): status (%v)\n", pod.Name, pod.Status.Phase)
+		fmt.Printf("pod (%v): status (%v), cmd (%v)\n", pod.Name, pod.Status.Phase, pod.Spec.Containers[0].Command)
 		buf := bytes.NewBuffer(nil)
 
 		if pod.Status.Phase == api.PodFailed {
 			if err := getLogs(f.KubeClient, f.Namespace, pod.Name, "etcd", buf); err != nil {
-				return err
+				fmt.Printf("fail to get (%s)'s log: %v", pod.Name, err)
+				continue
 			}
 			fmt.Println(pod.Name, "logs ===")
 			fmt.Println(buf.String())


### PR DESCRIPTION
When a pod failed, we want to know what happen and print its logs.

However, container itself could have not started at all due to command line error.
We should ignore the error otherwise it could cause unrelated test failure.

Also add print out etcd container’s cmd
