### PR TITLE
cluster: verify backup setup on controller Restore

### DIFF
--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -101,6 +101,11 @@ func (bm *backupManager) runSidecar() error {
 	return nil
 }
 
+func (bm *backupManager) verifyBackupSetup() error {
+	_, err := bm.config.KubeCli.Services(bm.cluster.Namespace).Get(k8sutil.MakeBackupName(bm.cluster.Name))
+	return err
+}
+
 func (bm *backupManager) createBackupReplicaSet(podSpec api.PodSpec) error {
 	rs := k8sutil.MakeBackupReplicaSet(bm.cluster.Name, podSpec, bm.cluster.AsOwner())
 	_, err := bm.config.KubeCli.ReplicaSets(bm.cluster.Namespace).Create(rs)

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -133,6 +133,12 @@ func new(config Config, e *spec.EtcdCluster, stopC <-chan struct{}, wg *sync.Wai
 		if err := c.createClientServiceLB(); err != nil {
 			return nil, fmt.Errorf("fail to create client service LB: %v", err)
 		}
+	} else {
+		if c.bm != nil {
+			if err := c.bm.verifyBackupSetup(); err != nil {
+				return nil, fmt.Errorf("fail to verify backup's setup: %v", err)
+			}
+		}
 	}
 
 	wg.Add(1)


### PR DESCRIPTION
Might relate to #534

Currently, if a cluster enter the cluser.Restore() case due to some race in creating a cluster, it could reconcile again and again and print out confusing disaster recovery message.

We should just let it die at the beginning.