### PR TITLE
cluster: make logging unique

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -186,7 +186,7 @@ func (c *Cluster) run(stopC <-chan struct{}, wg *sync.WaitGroup) {
 			for {
 				err := c.updateStatus()
 				if err != nil {
-					c.logger.Warningf("failed to update TPR status: %v", err)
+					c.logger.Warningf("cluster delete: failed to update TPR status: %v", err)
 					return false, nil
 				}
 				return true, nil


### PR DESCRIPTION
Recently we have test failure in https://jenkins-etcd.prod.coreos.systems/job/etcd-operator/981/console,

It has messages like:
```
failed to update TPR status: unexpected status: 409 Conflict
…
```

However, there are two places that have the same message. We need to differentiate them.