### PR TITLE
cluster: use status phase to detect new cluster

### DIFF
--- a/pkg/cluster/backupstorage/pv.go
+++ b/pkg/cluster/backupstorage/pv.go
@@ -15,7 +15,7 @@ type pv struct {
 	kubecli       *unversioned.Client
 }
 
-func NewPVStorage(kc *unversioned.Client, cn, ns, pvp string, backupPolicy spec.BackupPolicy, hasExist bool) (Storage, error) {
+func NewPVStorage(kc *unversioned.Client, cn, ns, pvp string, backupPolicy spec.BackupPolicy) (Storage, error) {
 	s := &pv{
 		clusterName:   cn,
 		namespace:     ns,
@@ -23,15 +23,10 @@ func NewPVStorage(kc *unversioned.Client, cn, ns, pvp string, backupPolicy spec.
 		backupPolicy:  backupPolicy,
 		kubecli:       kc,
 	}
-	if !hasExist {
-		if err := s.create(); err != nil {
-			return nil, err
-		}
-	}
 	return s, nil
 }
 
-func (s *pv) create() error {
+func (s *pv) Create() error {
 	return k8sutil.CreateAndWaitPVC(s.kubecli, s.clusterName, s.namespace, s.pvProvisioner, s.backupPolicy.VolumeSizeInMB)
 }
 

--- a/pkg/cluster/backupstorage/s3.go
+++ b/pkg/cluster/backupstorage/s3.go
@@ -21,7 +21,7 @@ type s3 struct {
 	s3cli        *backups3.S3
 }
 
-func NewS3Storage(s3Ctx s3config.S3Context, kubecli *unversioned.Client, clusterName, ns string, p spec.BackupPolicy, hasExist bool) (Storage, error) {
+func NewS3Storage(s3Ctx s3config.S3Context, kubecli *unversioned.Client, clusterName, ns string, p spec.BackupPolicy) (Storage, error) {
 	cm, err := kubecli.ConfigMaps(ns).Get(s3Ctx.AWSConfig)
 	if err != nil {
 		return nil, err
@@ -50,15 +50,10 @@ func NewS3Storage(s3Ctx s3config.S3Context, kubecli *unversioned.Client, cluster
 		namespace:    ns,
 		s3cli:        s3cli,
 	}
-	if !hasExist {
-		if err := s.create(); err != nil {
-			return nil, err
-		}
-	}
 	return s, nil
 }
 
-func (s *s3) create() error {
+func (s *s3) Create() error {
 	// TODO: check if bucket/folder exists?
 	return nil
 }

--- a/pkg/cluster/backupstorage/storage.go
+++ b/pkg/cluster/backupstorage/storage.go
@@ -2,6 +2,10 @@ package backupstorage
 
 // Storage defines the underlying storage used by backup sidecar.
 type Storage interface {
+	// Create creates the actual persistent storage.
+	// We need this method because this has side effect, e.g. creating PVC.
+	// We might not create the persistent storage again when we know it already exists.
+	Create() error
 	// Clone will try to clone another storage referenced by cluster name.
 	// It takes place on restore path.
 	Clone(from string) error

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -142,9 +142,8 @@ func (c *Controller) Run() error {
 			switch event.Type {
 			case "ADDED":
 				stopC := make(chan struct{})
-				nc, err := cluster.New(c.makeClusterConfig(), event.Object, stopC, &c.waitCluster)
-				if err != nil {
-					c.logger.Errorf("cluster (%q) is dead: %v", clusterName, err)
+				nc := cluster.New(c.makeClusterConfig(), event.Object, stopC, &c.waitCluster)
+				if nc == nil {
 					continue
 				}
 
@@ -191,9 +190,8 @@ func (c *Controller) findAllClusters() (string, error) {
 	for _, item := range clusters {
 		clusterName := item.Name
 		stopC := make(chan struct{})
-		nc, err := cluster.Restore(c.makeClusterConfig(), &item, stopC, &c.waitCluster)
-		if err != nil {
-			c.logger.Errorf("cluster (%q) is dead: %v", clusterName, err)
+		nc := cluster.New(c.makeClusterConfig(), &item, stopC, &c.waitCluster)
+		if nc == nil {
 			continue
 		}
 		c.stopChMap[clusterName] = stopC

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -113,8 +113,9 @@ func (c *ClusterSpec) Validate() error {
 type ClusterPhase string
 
 const (
-	ClusterPhaseRunning = "Running"
-	ClusterPhaseFailed  = "Failed"
+	ClusterPhaseCreating = "Creating"
+	ClusterPhaseRunning  = "Running"
+	ClusterPhaseFailed   = "Failed"
 )
 
 type ClusterCondition struct {
@@ -158,12 +159,8 @@ type ClusterStatus struct {
 	TargetVersion string `json:"targetVersion"`
 }
 
-func (cs *ClusterStatus) SetPhaseRunning() {
-	cs.Phase = ClusterPhaseRunning
-}
-
-func (cs *ClusterStatus) SetPhaseFailed() {
-	cs.Phase = ClusterPhaseFailed
+func (cs *ClusterStatus) SetPhase(p ClusterPhase) {
+	cs.Phase = p
 }
 
 func (cs *ClusterStatus) PauseControl() {


### PR DESCRIPTION
Previously, controller list TPR could potentially restore a cluster
that was created fresh.

Previously, we also didn’t do failed status reporting on failure to new
and didn’t set running status immediately.

https://github.com/coreos/etcd-operator/pull/553#issuecomment-269705792