### PR TITLE
cluster: handle unready member

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -265,7 +265,13 @@ func (c *Cluster) run(stopC <-chan struct{}, wg *sync.WaitGroup) {
 			if rerr != nil || c.members == nil {
 				rerr = c.updateMembers(podsToMemberSet(running, c.cluster.Spec.SelfHosted))
 				if rerr != nil {
-					c.logger.Errorf("failed to update members: %v", rerr)
+					c.logger.Errorf("failed to update members: %v. Will retry update members...", rerr)
+					if rerr == errMemberNotReady {
+						err := c.handleUnreadyMember(running)
+						if err != nil {
+							c.logger.Errorf("fail to handle unready member: %v", err)
+						}
+					}
 					continue
 				}
 			}

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -162,7 +162,7 @@ func (c *Cluster) removeOneMember() error {
 }
 
 func (c *Cluster) removeMember(toRemove *etcdutil.Member) error {
-	err := removeMember(c.members.ClientURLs(), toRemove.ID)
+	err := etcdutil.RemoveMember(c.members.ClientURLs(), toRemove.ID)
 	if err != nil {
 		switch err {
 		case rpctypes.ErrMemberNotFound:
@@ -177,25 +177,6 @@ func (c *Cluster) removeMember(toRemove *etcdutil.Member) error {
 		return err
 	}
 	c.logger.Infof("removed member (%v) with ID (%d)", toRemove.Name, toRemove.ID)
-	return nil
-}
-
-// TODO: move removeMember to etcdutil
-func removeMember(clientURLs []string, id uint64) error {
-	cfg := clientv3.Config{
-		Endpoints:   clientURLs,
-		DialTimeout: constants.DefaultDialTimeout,
-	}
-	etcdcli, err := clientv3.New(cfg)
-	if err != nil {
-		return err
-	}
-	defer etcdcli.Close()
-
-	ctx, _ := context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
-	if _, err = etcdcli.Cluster.MemberRemove(ctx, id); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/pkg/cluster/self_hosted.go
+++ b/pkg/cluster/self_hosted.go
@@ -117,7 +117,7 @@ func (c *Cluster) migrateBootMember() error {
 	c.logger.Infof("wait %v before removing the boot member", delay)
 	time.Sleep(delay)
 
-	err = removeMember([]string{"http://" + pod.Status.PodIP + ":2379"}, bootMember.ID)
+	err = etcdutil.RemoveMember([]string{"http://" + pod.Status.PodIP + ":2379"}, bootMember.ID)
 	if err != nil {
 		return fmt.Errorf("etcdcli failed to remove boot member: %v", err)
 	}

--- a/pkg/util/etcdutil/etcdutil.go
+++ b/pkg/util/etcdutil/etcdutil.go
@@ -37,3 +37,20 @@ func ListMembers(endpoints []string) (*clientv3.MemberListResponse, error) {
 	etcdcli.Close()
 	return resp, err
 }
+
+func RemoveMember(clientURLs []string, id uint64) error {
+	cfg := clientv3.Config{
+		Endpoints:   clientURLs,
+		DialTimeout: constants.DefaultDialTimeout,
+	}
+	etcdcli, err := clientv3.New(cfg)
+	if err != nil {
+		return err
+	}
+	defer etcdcli.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
+	_, err = etcdcli.Cluster.MemberRemove(ctx, id)
+	cancel()
+	return err
+}


### PR DESCRIPTION
Submitting early thoughts for feedback.

Problem statement: We could fail in MemberAdd() due to context deadline
exceeded and thus not creating related pod/service. But we could have
actually added the member. Then we would end up infinitely looping on
updateMembers() with not ready member error.

The fix is to have some intelligence when encountering unready member.
We would check the running pods and see if the member is in running
pods:
- If yes, we will take this as really not ready and back off
- otherwise, we will remove this member from membership