### PR TITLE
cluster: refactor error handling in run

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -248,16 +248,12 @@ func (c *Cluster) run(stopC <-chan struct{}, wg *sync.WaitGroup) {
 			}
 			if len(running) == 0 {
 				c.logger.Warningf("all etcd pods are dead. Trying to recover from a previous backup")
-				err := c.disasterRecovery(nil)
-				if err != nil {
-					if err == errNoBackupExist {
-						c.logger.Error("cluster cannot be recovered: all members are dead and there is no backup")
-						c.status.SetReason(spec.FailedReasonNoBackup)
-						return
-					}
-					c.logger.Errorf("fail to recover. Will retry later: %v", err)
+				rerr = c.disasterRecovery(nil)
+				if rerr != nil {
+					c.logger.Errorf("fail to do disaster recovery: %v", rerr)
 				}
-				continue // Back-off, either on normal recovery or error.
+				// On normal recovery case, we need backoff. On error case, this could be either backoff or leading to cluster delete.
+				break
 			}
 
 			// TODO: The case "c.members = nil" only happens on creating seed member.
@@ -266,21 +262,24 @@ func (c *Cluster) run(stopC <-chan struct{}, wg *sync.WaitGroup) {
 				rerr = c.updateMembers(podsToMemberSet(running, c.cluster.Spec.SelfHosted))
 				if rerr != nil {
 					c.logger.Errorf("failed to update members: %v", rerr)
-					continue
+					break
 				}
 			}
 			rerr = c.reconcile(running)
 			if rerr != nil {
 				c.logger.Errorf("failed to reconcile: %v", rerr)
-				if isFatalError(rerr) {
-					c.logger.Errorf("exiting for fatal error: %v", rerr)
-					return
-				}
+				break
 			}
 
 			if err := c.updateStatus(); err != nil {
 				c.logger.Warningf("failed to update TPR status: %v", err)
 			}
+		}
+
+		if isFatalError(rerr) {
+			c.cluster.Status.SetReason(rerr.Error())
+			c.logger.Errorf("exiting for fatal error: %v", rerr)
+			return
 		}
 	}
 }

--- a/pkg/cluster/error.go
+++ b/pkg/cluster/error.go
@@ -1,0 +1,21 @@
+// Copyright 2016 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import "errors"
+
+var (
+	errNoBackupExist = errors.New("no backup exist for disaster recovery")
+)

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -32,10 +32,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-var (
-	errNoBackupExist = errors.New("No backup exist for a disaster recovery")
-)
-
 // reconcile reconciles cluster current state to desired state specified by spec.
 // - it tries to reconcile the cluster to desired size.
 // - if the cluster needs for upgrade, it tries to upgrade old member one by one.

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -26,8 +26,6 @@ import (
 
 var (
 	ErrBackupUnsetRestoreSet = errors.New("spec: backup policy must be set if restore policy is set")
-
-	FailedReasonNoBackup = "all members are failed, no backup for recovery"
 )
 
 type EtcdCluster struct {


### PR DESCRIPTION
Centralize error handling:
- disaster recovery
- update members
- reconcile

We'd better do further refactoring work to combine these into reconcile(). But I have other changes on top to carry right now. Will do it later.