### PR TITLE
cluster: get name from PeerURL if member unready

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -284,7 +284,7 @@ func (c *Cluster) run(stopC <-chan struct{}, wg *sync.WaitGroup) {
 
 func isFatalError(err error) bool {
 	switch err {
-	case errNoBackupExist:
+	case errNoBackupExist, errInvalidMemberName, errUnexpectedUnreadyMember:
 		return true
 	default:
 		return false

--- a/pkg/cluster/error.go
+++ b/pkg/cluster/error.go
@@ -19,4 +19,6 @@ import "errors"
 var (
 	errNoBackupExist     = errors.New("no backup exist for disaster recovery")
 	errInvalidMemberName = errors.New("the format of member's name is invalid")
+
+	errUnexpectedUnreadyMember = errors.New("unexpected unready member for selfhosted cluster")
 )

--- a/pkg/cluster/self_hosted.go
+++ b/pkg/cluster/self_hosted.go
@@ -16,6 +16,7 @@ package cluster
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
@@ -43,11 +44,11 @@ func (c *Cluster) addOneSelfHostedMember() error {
 	}
 	// wait for the new pod to start and add itself into the etcd cluster.
 	oldN := c.members.Size()
-	err = retryutil.Retry(5*time.Second, 10, func() (bool, error) {
+	err = retryutil.Retry(5*time.Second, math.MaxInt64, func() (bool, error) {
 		err = c.updateMembers(c.members)
 		if err != nil {
 			c.logger.Errorf("add self hosted member: fail to update members: %v", err)
-			if err == errMemberNotReady {
+			if err == errUnexpectedUnreadyMember {
 				return false, nil
 			}
 			return false, err

--- a/pkg/util/etcdutil/etcdutil_test.go
+++ b/pkg/util/etcdutil/etcdutil_test.go
@@ -1,0 +1,65 @@
+// Copyright 2016 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcdutil
+
+import "testing"
+
+func TestMemberNameFromPeerURL(t *testing.T) {
+	tests := []struct {
+		purl  string
+		wName string
+		wErr  bool
+	}{{
+		purl:  "http://test-cluster:2379",
+		wName: "test-cluster",
+	}, {
+		purl:  "https://test-cluster:2379",
+		wName: "test-cluster",
+	}, {
+		purl:  "http://test-cluster",
+		wName: "test-cluster",
+	}, {
+		purl: "test-cluster",
+		wErr: true,
+	}, {
+		purl: "test-cluster:2379",
+		wErr: true,
+	}, {
+		purl: "",
+		wErr: true,
+	}, {
+		purl: "http://",
+		wErr: true,
+	}, {
+		purl: "http://a:a",
+		wErr: true,
+	}}
+
+	for i, tt := range tests {
+		get, err := MemberNameFromPeerURL(tt.purl)
+		if tt.wErr {
+			if err == nil {
+				t.Errorf("#%d: should be error case", i)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("#%d: want err = nil, got %v", i, err)
+		}
+		if get != tt.wName {
+			t.Errorf("#%d: member name get=%s, want=%s", i, get, tt.wName)
+		}
+	}
+}


### PR DESCRIPTION
Problem statement: We could fail in MemberAdd() due to context deadline
exceeded and thus not creating related pod/service. But we could have
added the member. Then we would end up infinitely looping on updateMembers()
on "not ready member" error.

One idea is that we can get name from member's PeerURL.

For self hosted case, it's more complicated because it's host IP.
We currently loop wait until the member has been added successfully.
In the future we could use pod IP to match.