### PR TITLE
spec: allow image to be set in ClusterSpec

### DIFF
--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -29,7 +29,7 @@ func (c *Cluster) upgradeOneMember(m *etcdutil.Member) error {
 		return fmt.Errorf("fail to get pod (%s): %v", m.Name, err)
 	}
 	c.logger.Infof("upgrading the etcd member %v from %s to %s", m.Name, k8sutil.GetEtcdVersion(pod), c.cluster.Spec.Version)
-	pod.Spec.Containers[0].Image = k8sutil.MakeEtcdImage(c.cluster.Spec.Version)
+	pod.Spec.Containers[0].Image = k8sutil.MakeEtcdImage(c.cluster.Spec)
 	k8sutil.SetEtcdVersion(pod, c.cluster.Spec.Version)
 	_, err = c.config.KubeCli.Pods(c.cluster.Namespace).Update(pod)
 	if err != nil {

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -60,6 +60,9 @@ type ClusterSpec struct {
 	// equal to the expected version.
 	Version string `json:"version"`
 
+	// Image is the name of the docker image used for pods created by the etcd controller.
+	Image string `json:"image,omitempty"`
+
 	// Backup defines the policy to backup data of etcd cluster if not nil.
 	// If backup policy is set but restore policy not, and if a previous backup exists,
 	// this cluster would face conflict and fail to start.

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/coreos/etcd-operator/pkg/spec"
+
 	"k8s.io/kubernetes/pkg/api"
 	unversionedAPI "k8s.io/kubernetes/pkg/api/unversioned"
 )
@@ -33,13 +35,13 @@ var (
 	}
 )
 
-func etcdContainer(commands, version string) api.Container {
+func etcdContainer(commands string, cs *spec.ClusterSpec) api.Container {
 	c := api.Container{
 		// TODO: fix "sleep 5".
 		// Without waiting some time, there is highly probable flakes in network setup.
 		Command: []string{"/bin/sh", "-c", fmt.Sprintf("sleep 5; %s", commands)},
 		Name:    "etcd",
-		Image:   MakeEtcdImage(version),
+		Image:   MakeEtcdImage(cs),
 		Ports: []api.ContainerPort{
 			{
 				Name:          "server",

--- a/pkg/util/k8sutil/self_hosted.go
+++ b/pkg/util/k8sutil/self_hosted.go
@@ -52,7 +52,7 @@ func MakeSelfHostedEtcdPod(name string, initialCluster []string, clusterName, st
 		},
 		Spec: api.PodSpec{
 			Containers: []api.Container{
-				etcdContainer(commands, cs.Version),
+				etcdContainer(commands, cs),
 			},
 			// Self-hosted etcd pod need to endure node restart.
 			// If we set it to Never, the pod won't restart. If etcd won't come up, nor does other k8s API components.


### PR DESCRIPTION
This makes it possible for the user to run a custom build of etcd. It does not interact with version management in any way, meaning that users will need to modify the Version field to roll out a new image.