### PR TITLE
cluster: centralize reconcile logic

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -251,40 +251,23 @@ func (c *Cluster) run(stopC <-chan struct{}, wg *sync.WaitGroup) {
 				c.logger.Infof("skip reconciliation: running (%v), pending (%v)", k8sutil.GetPodNames(running), k8sutil.GetPodNames(pending))
 				continue
 			}
-			if len(running) == 0 {
-				c.logger.Warningf("all etcd pods are dead. Trying to recover from a previous backup")
-				rerr = c.disasterRecovery(nil)
-				if rerr != nil {
-					c.logger.Errorf("fail to do disaster recovery: %v", rerr)
-				}
-				// On normal recovery case, we need backoff. On error case, this could be either backoff or leading to cluster delete.
-				break
-			}
 
-			// TODO: The case "c.members = nil" only happens on creating seed member.
-			//       We should just set the member directly if successful.
-			if rerr != nil || c.members == nil {
-				rerr = c.updateMembers(podsToMemberSet(running, c.cluster.Spec.SelfHosted))
-				if rerr != nil {
-					c.logger.Errorf("failed to update members: %v", rerr)
-					break
-				}
-			}
-			rerr = c.reconcile(running)
+			// TODO: The case "c.members = nil" only happens on creating seed member. We should just set the member directly if successful.
+			needUpdateMember := rerr != nil || c.members == nil
+			rerr = c.reconcile(running, needUpdateMember)
 			if rerr != nil {
 				c.logger.Errorf("failed to reconcile: %v", rerr)
+				if isFatalError(rerr) {
+					c.status.SetReason(rerr.Error())
+					c.logger.Errorf("exiting for fatal error: %v", rerr)
+					return
+				}
 				break
 			}
 
 			if err := c.updateStatus(); err != nil {
 				c.logger.Warningf("failed to update TPR status: %v", err)
 			}
-		}
-
-		if isFatalError(rerr) {
-			c.status.SetReason(rerr.Error())
-			c.logger.Errorf("exiting for fatal error: %v", rerr)
-			return
 		}
 	}
 }

--- a/pkg/cluster/error.go
+++ b/pkg/cluster/error.go
@@ -16,6 +16,8 @@ package cluster
 
 import "errors"
 
+// TODO: We can't wrap the error in many places because we could be returning fatal error.
+//       Use custom error type and separate fatal level and message.
 var (
 	errNoBackupExist     = errors.New("no backup exist for disaster recovery")
 	errInvalidMemberName = errors.New("the format of member's name is invalid")


### PR DESCRIPTION
combine 1. zero pods disaster recovery; 2. update members; 3. original
reconcile, into reconcile func. This helps centralize error handling.