### PR TITLE
e2e: add pod name info on err msg

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -82,7 +82,11 @@ func makeBackup(f *framework.Framework, clusterName string) error {
 
 	// We are assuming pod ip is accessible from test machine.
 	addr := fmt.Sprintf("%s:%d", podList.Items[0].Status.PodIP, constants.DefaultBackupPodHTTPPort)
-	return cluster.RequestBackupNow(f.KubeClient.Client, addr)
+	err = cluster.RequestBackupNow(f.KubeClient.Client, addr)
+	if err != nil {
+		return fmt.Errorf("backup pod (%s): %v", podList.Items[0].Name, err)
+	}
+	return nil
 }
 
 func waitUntilSizeReached(f *framework.Framework, clusterName string, size int, timeout time.Duration) ([]string, error) {


### PR DESCRIPTION
Error message didn’t tell us what pod it is. We can’t query the log from cloud.
```
failed: Get http://10.36.0.228:19999/backupnow: EOF
```