### PR TITLE
cluster: New() made async

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -140,9 +140,6 @@ func (c *Controller) Run() error {
 			case "ADDED":
 				stopC := make(chan struct{})
 				nc := cluster.New(c.makeClusterConfig(), event.Object, stopC, &c.waitCluster)
-				if nc == nil {
-					continue
-				}
 
 				c.stopChMap[clusterName] = stopC
 				c.clusters[clusterName] = nc
@@ -152,20 +149,10 @@ func (c *Controller) Run() error {
 				clustersTotal.Inc()
 
 			case "MODIFIED":
-				if c.clusters[clusterName] == nil {
-					c.logger.Warningf("ignore modification: cluster %q not found (or dead)", clusterName)
-					break
-				}
-
 				c.clusters[clusterName].Update(event.Object)
 				clustersModified.Inc()
 
 			case "DELETED":
-				if c.clusters[clusterName] == nil {
-					c.logger.Warningf("ignore deletion: cluster %q not found (or dead)", clusterName)
-					break
-				}
-
 				c.clusters[clusterName].Delete()
 				delete(c.clusters, clusterName)
 				analytics.ClusterDeleted()
@@ -192,9 +179,6 @@ func (c *Controller) findAllClusters() (string, error) {
 		clusterName := item.Name
 		stopC := make(chan struct{})
 		nc := cluster.New(c.makeClusterConfig(), &item, stopC, &c.waitCluster)
-		if nc == nil {
-			continue
-		}
 		c.stopChMap[clusterName] = stopC
 		c.clusters[clusterName] = nc
 	}


### PR DESCRIPTION
Previously, we have New() be sync because we need to handle error on
creating cluster. We don’t need this assumption anymore since now we
report failure status.

This also fix test interference:
https://github.com/coreos/etcd-operator/issues/588