### PR TITLE
cluster: don't report failed on controller restore

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -211,11 +211,10 @@ func (c *Cluster) run(stopC <-chan struct{}, wg *sync.WaitGroup) {
 		if needDeleteCluster {
 			c.logger.Infof("deleting cluster")
 			c.delete()
+			go c.reportFailedStatus()
 		}
 		close(c.stopCh)
 		wg.Done()
-
-		c.reportFailedStatus()
 	}()
 
 	c.status.SetPhase(spec.ClusterPhaseRunning)


### PR DESCRIPTION
If needDeleteCluster is false, it's controller restore case.
On controller restore, we didn’t delete or fail the cluster, and shouldn't report failed.