### PR TITLE
*: simplify status recovery logic

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -185,10 +185,16 @@ func (c *Controller) findAllClusters() (string, error) {
 	}
 
 	for _, item := range clusterList.Items {
+		if item.Status.IsFailed() {
+			c.logger.Infof("ignore failed cluster %s", item.GetName())
+			continue
+		}
+
 		if s := item.Spec; len(s.Version) == 0 {
 			// TODO: set version in spec in apiserver
 			s.Version = defaultVersion
 		}
+
 		clusterName := item.Name
 		stopC := make(chan struct{})
 		nc := cluster.New(c.makeClusterConfig(), &item, stopC, &c.waitCluster)

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -111,9 +111,10 @@ func (c *ClusterSpec) Validate() error {
 type ClusterPhase string
 
 const (
-	ClusterPhaseCreating = "Creating"
-	ClusterPhaseRunning  = "Running"
-	ClusterPhaseFailed   = "Failed"
+	ClusterPhaseNone     ClusterPhase = ""
+	ClusterPhaseCreating              = "Creating"
+	ClusterPhaseRunning               = "Running"
+	ClusterPhaseFailed                = "Failed"
 )
 
 type ClusterCondition struct {
@@ -157,6 +158,13 @@ type ClusterStatus struct {
 	// TargetVersion is the version the cluster upgrading to.
 	// If the cluster is not upgrading, TargetVersion is empty.
 	TargetVersion string `json:"targetVersion"`
+}
+
+func (cs *ClusterStatus) IsFailed() bool {
+	if cs == nil {
+		return false
+	}
+	return cs.Phase == ClusterPhaseFailed
 }
 
 func (cs *ClusterStatus) SetPhase(p ClusterPhase) {


### PR DESCRIPTION
1. do not recover any failed cluster

2. always recover status from the existing etcd cluster TPR item if possible

3. make status the source of truth after the cluster struct is materialized 