### PR TITLE
e2e: print out pods to delete

### DIFF
--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -134,6 +134,7 @@ func testDisasterRecoveryWithStorageType(t *testing.T, numToKill int, bt spec.Ba
 	}
 	// TODO: There might be race that operator will recover members between
 	// 		these members are deleted individually.
+	t.Logf("killing pods: %v", names)
 	if err := killMembers(f, toKill...); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Print out what we have deleted. Helps debug https://github.com/coreos/etcd-operator/issues/627