### PR TITLE
controller: pass copied cluster obj and refactor

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -185,6 +185,7 @@ func (c *Controller) findAllClusters() (string, error) {
 	}
 
 	for _, item := range clusterList.Items {
+		clusterObj := item
 		if item.Status.IsFailed() {
 			c.logger.Infof("ignore failed cluster %s", item.GetName())
 			continue
@@ -197,7 +198,7 @@ func (c *Controller) findAllClusters() (string, error) {
 
 		clusterName := item.Name
 		stopC := make(chan struct{})
-		nc := cluster.New(c.makeClusterConfig(), &item, stopC, &c.waitCluster)
+		nc := cluster.New(c.makeClusterConfig(), &clusterObj, stopC, &c.waitCluster)
 		if nc == nil {
 			continue
 		}


### PR DESCRIPTION
We should pass in copied EtcdCluster obj instead of passing “item”. item is from the for loop and could be changed if running concurrently.

Also make naming better by changing all event.Object, item into clusterObj.