### PR TITLE
AWS: config/creds setup should init only once

### DIFF
--- a/pkg/controller/s3.go
+++ b/pkg/controller/s3.go
@@ -1,0 +1,48 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/coreos/etcd-operator/pkg/backup/s3/s3config"
+
+	"k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+func setupS3Env(kubecli *unversioned.Client, s3Ctx s3config.S3Context, ns string) error {
+	cm, err := kubecli.ConfigMaps(ns).Get(s3Ctx.AWSConfig)
+	if err != nil {
+		return err
+	}
+	se, err := kubecli.Secrets(ns).Get(s3Ctx.AWSSecret)
+	if err != nil {
+		return err
+	}
+
+	config := []byte(cm.Data["config"])
+	creds := se.Data["credentials"]
+
+	homedir := os.Getenv("HOME")
+	if err := os.MkdirAll(path.Join(homedir, "/.aws"), 0700); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(path.Join(homedir, "/.aws/config"), config, 0600); err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path.Join(homedir, "/.aws/credentials"), creds, 0600)
+}


### PR DESCRIPTION
On operator side, some clusters’ S3 backup manager will talk to AWS/S3
and manage storage. However, previously we will setup the credentials/config
for each cluster and they share the same path. This will cause
concurrency issue.

Instead, we should initialize AWS config/creds only once at controller
startup. It will be shared and used by potential cluster's S3 backup
manager to manage storage on operator side.