### PR TITLE
Revert "*: add glide install options"

### DIFF
--- a/hack/jenkins
+++ b/hack/jenkins
@@ -27,7 +27,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-glide install --strip-vendor --skip-test 1>/dev/null
+glide install 1>/dev/null
 
 GIT_VERSION=$(git rev-parse HEAD)
 export OPERATOR_IMAGE="gcr.io/coreos-k8s-scale-testing/etcd-operator:${GIT_VERSION}"

--- a/hack/release/README.md
+++ b/hack/release/README.md
@@ -21,7 +21,7 @@ Working directory is root of "etcd-operator/".
 
 Install dependency if none exists:
 ```
-$ glide install --strip-vendor --skip-test
+$ glide install
 ```
 You should see "vendor/".
 


### PR DESCRIPTION
Reverts coreos/etcd-operator#646

The build becomes flaky today. I tried that reverting this will make build stable again. Let's not break the master first.

As mentioned in https://github.com/coreos/etcd-operator/issues/649, it's still broken.