### PR TITLE
cluster: set members if seed member created successfully

### DIFF
--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -226,7 +226,6 @@ func (c *Cluster) disasterRecovery(left etcdutil.MemberSet) error {
 			return err
 		}
 	}
-	c.members = nil
 	return c.restoreSeedMember()
 }
 


### PR DESCRIPTION
Previously, we reset "members = nil" on creating seed member (including
disaster recovery case) and use this state to decide to call
updateMembers(). Now if seed member is created successfully,
we just set membership and optimize one round of member listing.