### PR TITLE
migrate to client-go/1.5

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"time"
 
@@ -31,12 +32,15 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"golang.org/x/time/rate"
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.5/kubernetes"
+	"k8s.io/client-go/1.5/pkg/labels"
+	"k8s.io/client-go/1.5/rest"
+	k8sapi "k8s.io/kubernetes/pkg/api"
+	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	"k8s.io/kubernetes/pkg/client/leaderelection"
+	"k8s.io/kubernetes/pkg/client/leaderelection/resourcelock"
 	"k8s.io/kubernetes/pkg/client/record"
 	"k8s.io/kubernetes/pkg/client/restclient"
-	"k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/labels"
 )
 
 var (
@@ -105,18 +109,26 @@ func main() {
 		logrus.Fatalf("failed to get hostname: %v", err)
 	}
 
-	leaderelection.RunOrDie(leaderelection.LeaderElectionConfig{
-		EndpointsMeta: api.ObjectMeta{
+	// TODO: replace this to client-go once leader election pacakge is imported
+	//       https://github.com/kubernetes/client-go/issues/28
+	rl := &resourcelock.EndpointsLock{
+		EndpointsMeta: k8sapi.ObjectMeta{
 			Namespace: namespace,
 			Name:      "etcd-operator",
 		},
-		Client: k8sutil.MustCreateClient(masterHost, tlsInsecure, &restclient.TLSClientConfig{
+		Client: mustCreateLeaderElectionClient(masterHost, tlsInsecure, &restclient.TLSClientConfig{
 			CertFile: certFile,
 			KeyFile:  keyFile,
 			CAFile:   caFile,
 		}),
-		EventRecorder: &record.FakeRecorder{},
-		Identity:      id,
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity:      id,
+			EventRecorder: &record.FakeRecorder{},
+		},
+	}
+
+	leaderelection.RunOrDie(leaderelection.LeaderElectionConfig{
+		Lock:          rl,
 		LeaseDuration: leaseDuration,
 		RenewDeadline: renewDuration,
 		RetryPeriod:   retryPeriod,
@@ -136,7 +148,7 @@ func run(stop <-chan struct{}) {
 		logrus.Fatalf("invalid operator config: %v", err)
 	}
 
-	go periodicFullGC(cfg.KubeCli, cfg.MasterHost, cfg.Namespace, gcInterval)
+	go periodicFullGC(cfg.KubeCli, cfg.Namespace, gcInterval)
 
 	startChaos(context.Background(), cfg.KubeCli, cfg.Namespace, chaosLevel)
 
@@ -152,7 +164,7 @@ func run(stop <-chan struct{}) {
 }
 
 func newControllerConfig() controller.Config {
-	tlsConfig := restclient.TLSClientConfig{
+	tlsConfig := rest.TLSClientConfig{
 		CertFile: certFile,
 		KeyFile:  keyFile,
 		CAFile:   caFile,
@@ -176,8 +188,8 @@ func newControllerConfig() controller.Config {
 	return cfg
 }
 
-func periodicFullGC(k8s *unversioned.Client, host, ns string, d time.Duration) {
-	gc := garbagecollection.New(k8s, host, ns)
+func periodicFullGC(k8s kubernetes.Interface, ns string, d time.Duration) {
+	gc := garbagecollection.New(k8s, ns)
 	timer := time.NewTimer(d)
 	defer timer.Stop()
 	for {
@@ -189,7 +201,7 @@ func periodicFullGC(k8s *unversioned.Client, host, ns string, d time.Duration) {
 	}
 }
 
-func startChaos(ctx context.Context, k8s *unversioned.Client, ns string, chaosLevel int) {
+func startChaos(ctx context.Context, k8s kubernetes.Interface, ns string, chaosLevel int) {
 	m := chaos.NewMonkeys(k8s)
 	ls := labels.SelectorFromSet(map[string]string{"app": "etcd"})
 
@@ -222,4 +234,31 @@ func startChaos(ctx context.Context, k8s *unversioned.Client, ns string, chaosLe
 
 	default:
 	}
+}
+
+func mustCreateLeaderElectionClient(host string, tlsInsecure bool, tlsConfig *restclient.TLSClientConfig) clientset.Interface {
+	var cfg *restclient.Config
+	if len(host) == 0 {
+		var err error
+		cfg, err = restclient.InClusterConfig()
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		cfg = &restclient.Config{
+			Host:  host,
+			QPS:   100,
+			Burst: 100,
+		}
+		hostUrl, err := url.Parse(host)
+		if err != nil {
+			panic(fmt.Sprintf("failed to parse host url %s : %v", host, err))
+		}
+		if hostUrl.Scheme == "https" {
+			cfg.TLSClientConfig = *tlsConfig
+			cfg.Insecure = tlsInsecure
+		}
+	}
+
+	return clientset.NewForConfigOrDie(cfg)
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: a16ff29a0c383d5ce298f4676845aaaecc4783d51ffcd02b87a70001f939b762
-updated: 2016-12-27T09:56:57.085659082-08:00
+hash: 215fe6c15d5746fa231f5e3077711e1da4453267df2152df0a81b6499eee35bc
+updated: 2017-01-19T18:17:25.194978397-08:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -9,7 +9,7 @@ imports:
   - compute/metadata
   - internal
 - name: github.com/aws/aws-sdk-go
-  version: eb0af7afd2cea3310a21a13e1868644991c5af92
+  version: f25c58028ccaa4be2726c172d970ba1cc0f26c99
   subpackages:
   - aws
   - aws/awserr
@@ -23,10 +23,10 @@ imports:
   - aws/credentials/stscreds
   - aws/defaults
   - aws/ec2metadata
+  - aws/endpoints
   - aws/request
   - aws/session
   - aws/signer/v4
-  - private/endpoints
   - private/protocol
   - private/protocol/query
   - private/protocol/query/queryutil
@@ -102,7 +102,7 @@ imports:
   - wal
   - wal/walpb
 - name: github.com/coreos/go-oidc
-  version: 5cf2aa52da8c574d3aa4458f471ad6ae2240fe6b
+  version: 5644a2f50e2d2d5ba0b474bc5bc55fea1925936d
   subpackages:
   - http
   - jose
@@ -148,34 +148,19 @@ imports:
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
   version: 2e44421e256d82ebbf3d4d4fcabe8930b905eff3
+- name: github.com/go-openapi/jsonpointer
+  version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
+- name: github.com/go-openapi/jsonreference
+  version: 13c6e3589ad90f49bd3e3bbe2c2cb3d7a4142272
+- name: github.com/go-openapi/spec
+  version: 6aced65f8501fe1217321abf0749d354824ba2ff
+- name: github.com/go-openapi/swag
+  version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
 - name: github.com/gogo/protobuf
   version: e18d7aa8f8c624c915db340349aad4c49b10d173
   subpackages:
-  - gogoproto
-  - plugin/compare
-  - plugin/defaultcheck
-  - plugin/description
-  - plugin/embedcheck
-  - plugin/enumstringer
-  - plugin/equal
-  - plugin/face
-  - plugin/gostring
-  - plugin/marshalto
-  - plugin/oneofcheck
-  - plugin/populate
-  - plugin/size
-  - plugin/stringer
-  - plugin/testgen
-  - plugin/union
-  - plugin/unmarshal
   - proto
-  - protoc-gen-gogo/descriptor
-  - protoc-gen-gogo/generator
-  - protoc-gen-gogo/grpc
-  - protoc-gen-gogo/plugin
   - sortkeys
-  - vanity
-  - vanity/command
 - name: github.com/golang/glog
   version: 44145f04b68cf362d9c4df2182967c2275eaefed
 - name: github.com/golang/groupcache
@@ -189,50 +174,6 @@ imports:
   - proto
 - name: github.com/google/btree
   version: 7d79101e329e5a3adf994758c578dab82b90c017
-- name: github.com/google/cadvisor
-  version: a726d13de8cb32860e73d72a78dc8e0124267709
-  subpackages:
-  - api
-  - cache/memory
-  - client/v2
-  - collector
-  - container
-  - container/common
-  - container/docker
-  - container/libcontainer
-  - container/raw
-  - container/rkt
-  - container/systemd
-  - devicemapper
-  - events
-  - fs
-  - healthz
-  - http
-  - http/mux
-  - info/v1
-  - info/v1/test
-  - info/v2
-  - machine
-  - manager
-  - manager/watcher
-  - manager/watcher/raw
-  - manager/watcher/rkt
-  - metrics
-  - pages
-  - pages/static
-  - storage
-  - summary
-  - utils
-  - utils/cloudinfo
-  - utils/cpuload
-  - utils/cpuload/netlink
-  - utils/docker
-  - utils/oomparser
-  - utils/sysfs
-  - utils/sysinfo
-  - utils/tail
-  - validate
-  - version
 - name: github.com/google/gofuzz
   version: bbcb9da2d746f8bdbd6a936686a0a6067ada0ec5
 - name: github.com/grpc-ecosystem/grpc-gateway
@@ -241,6 +182,8 @@ imports:
   - runtime
   - runtime/internal
   - utilities
+- name: github.com/howeyc/gopass
+  version: 3ca23474a7c7203e0a0a070fd33508f6efdb9b3d
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/jmespath/go-jmespath
@@ -251,6 +194,12 @@ imports:
   version: 49dbddd69887519886adf7763e0306e1f33ba50f
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
+- name: github.com/mailru/easyjson
+  version: d5b7844b561a7bc640052f1b935f7b800330d7e0
+  subpackages:
+  - buffer
+  - jlexer
+  - jwriter
 - name: github.com/matttproud/golang_protobuf_extensions
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
@@ -272,15 +221,18 @@ imports:
   - model
 - name: github.com/prometheus/procfs
   version: 454a56f35412459b5e684fd5ec0f9211b94f002a
+- name: github.com/PuerkitoBio/purell
+  version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
+- name: github.com/PuerkitoBio/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/Sirupsen/logrus
-  version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
+  version: d26492970760ca5d33129d2d799e34be5c4782eb
 - name: github.com/spf13/pflag
-  version: 1560c1005499d61b80f865c04d39ca7505bf7f0b
+  version: 5ccb023bc27df288a957c5e994cd44fd19619465
 - name: github.com/ugorji/go
   version: f1f1a805ed361a0e078bb537e4ea78cd37dcf065
   subpackages:
   - codec
-  - codec/codecgen
 - name: github.com/xiang90/probing
   version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
 - name: golang.org/x/crypto
@@ -292,6 +244,7 @@ imports:
   - pkcs12
   - pkcs12/internal/rc2
   - ssh
+  - ssh/terminal
 - name: golang.org/x/net
   version: e90d6d0afc4c315a0d87a568ae68577cc15149a0
   subpackages:
@@ -299,6 +252,7 @@ imports:
   - context/ctxhttp
   - http2
   - http2/hpack
+  - idna
   - internal/timeseries
   - lex/httplex
   - trace
@@ -313,6 +267,19 @@ imports:
   version: 9c60d1c508f5134d1ca726b4641db998f2523357
   subpackages:
   - unix
+- name: golang.org/x/text
+  version: 2910a502d2bf9e43193af9d68ca516529614eed3
+  subpackages:
+  - cases
+  - internal/tag
+  - language
+  - runes
+  - secure/bidirule
+  - secure/precis
+  - transform
+  - unicode/bidi
+  - unicode/norm
+  - width
 - name: golang.org/x/time
   version: a4bde12657593d5e90d0533a3e4fd95e635124cb
   subpackages:
@@ -345,95 +312,133 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
 - name: k8s.io/client-go
-  version: 6631b2769fbf8fd8ff6b2074d64774b010c7d37a
+  version: 843f7c4f28b1f647f664f883697107d5c02c5acc
   subpackages:
-  - 1.4/pkg/api
-  - 1.4/pkg/api/endpoints
-  - 1.4/pkg/api/errors
-  - 1.4/pkg/api/meta
-  - 1.4/pkg/api/meta/metatypes
-  - 1.4/pkg/api/pod
-  - 1.4/pkg/api/resource
-  - 1.4/pkg/api/service
-  - 1.4/pkg/api/unversioned
-  - 1.4/pkg/api/unversioned/validation
-  - 1.4/pkg/api/util
-  - 1.4/pkg/api/v1
-  - 1.4/pkg/api/validation
-  - 1.4/pkg/apimachinery
-  - 1.4/pkg/apimachinery/registered
-  - 1.4/pkg/apis/autoscaling
-  - 1.4/pkg/apis/batch
-  - 1.4/pkg/apis/extensions
-  - 1.4/pkg/auth/user
-  - 1.4/pkg/capabilities
-  - 1.4/pkg/conversion
-  - 1.4/pkg/conversion/queryparams
-  - 1.4/pkg/fields
-  - 1.4/pkg/labels
-  - 1.4/pkg/runtime
-  - 1.4/pkg/runtime/serializer
-  - 1.4/pkg/runtime/serializer/json
-  - 1.4/pkg/runtime/serializer/protobuf
-  - 1.4/pkg/runtime/serializer/recognizer
-  - 1.4/pkg/runtime/serializer/streaming
-  - 1.4/pkg/runtime/serializer/versioning
-  - 1.4/pkg/security/apparmor
-  - 1.4/pkg/selection
-  - 1.4/pkg/third_party/forked/golang/reflect
-  - 1.4/pkg/types
-  - 1.4/pkg/util
-  - 1.4/pkg/util/clock
-  - 1.4/pkg/util/config
-  - 1.4/pkg/util/crypto
-  - 1.4/pkg/util/errors
-  - 1.4/pkg/util/flowcontrol
-  - 1.4/pkg/util/framer
-  - 1.4/pkg/util/hash
-  - 1.4/pkg/util/integer
-  - 1.4/pkg/util/intstr
-  - 1.4/pkg/util/json
-  - 1.4/pkg/util/labels
-  - 1.4/pkg/util/net
-  - 1.4/pkg/util/net/sets
-  - 1.4/pkg/util/parsers
-  - 1.4/pkg/util/rand
-  - 1.4/pkg/util/runtime
-  - 1.4/pkg/util/sets
-  - 1.4/pkg/util/uuid
-  - 1.4/pkg/util/validation
-  - 1.4/pkg/util/validation/field
-  - 1.4/pkg/util/wait
-  - 1.4/pkg/util/yaml
-  - 1.4/pkg/version
-  - 1.4/pkg/watch
-  - 1.4/pkg/watch/versioned
-  - 1.4/rest
-  - 1.4/tools/clientcmd/api
-  - 1.4/tools/metrics
-  - 1.4/transport
+  - 1.5/discovery
+  - 1.5/kubernetes
+  - 1.5/kubernetes/typed/apps/v1alpha1
+  - 1.5/kubernetes/typed/authentication/v1beta1
+  - 1.5/kubernetes/typed/authorization/v1beta1
+  - 1.5/kubernetes/typed/autoscaling/v1
+  - 1.5/kubernetes/typed/batch/v1
+  - 1.5/kubernetes/typed/certificates/v1alpha1
+  - 1.5/kubernetes/typed/core/v1
+  - 1.5/kubernetes/typed/extensions/v1beta1
+  - 1.5/kubernetes/typed/policy/v1alpha1
+  - 1.5/kubernetes/typed/rbac/v1alpha1
+  - 1.5/kubernetes/typed/storage/v1beta1
+  - 1.5/pkg/api
+  - 1.5/pkg/api/errors
+  - 1.5/pkg/api/install
+  - 1.5/pkg/api/meta
+  - 1.5/pkg/api/meta/metatypes
+  - 1.5/pkg/api/resource
+  - 1.5/pkg/api/unversioned
+  - 1.5/pkg/api/v1
+  - 1.5/pkg/api/validation/path
+  - 1.5/pkg/apimachinery
+  - 1.5/pkg/apimachinery/announced
+  - 1.5/pkg/apimachinery/registered
+  - 1.5/pkg/apis/apps
+  - 1.5/pkg/apis/apps/install
+  - 1.5/pkg/apis/apps/v1alpha1
+  - 1.5/pkg/apis/authentication
+  - 1.5/pkg/apis/authentication/install
+  - 1.5/pkg/apis/authentication/v1beta1
+  - 1.5/pkg/apis/authorization
+  - 1.5/pkg/apis/authorization/install
+  - 1.5/pkg/apis/authorization/v1beta1
+  - 1.5/pkg/apis/autoscaling
+  - 1.5/pkg/apis/autoscaling/install
+  - 1.5/pkg/apis/autoscaling/v1
+  - 1.5/pkg/apis/batch
+  - 1.5/pkg/apis/batch/install
+  - 1.5/pkg/apis/batch/v1
+  - 1.5/pkg/apis/batch/v2alpha1
+  - 1.5/pkg/apis/certificates
+  - 1.5/pkg/apis/certificates/install
+  - 1.5/pkg/apis/certificates/v1alpha1
+  - 1.5/pkg/apis/extensions
+  - 1.5/pkg/apis/extensions/install
+  - 1.5/pkg/apis/extensions/v1beta1
+  - 1.5/pkg/apis/policy
+  - 1.5/pkg/apis/policy/install
+  - 1.5/pkg/apis/policy/v1alpha1
+  - 1.5/pkg/apis/rbac
+  - 1.5/pkg/apis/rbac/install
+  - 1.5/pkg/apis/rbac/v1alpha1
+  - 1.5/pkg/apis/storage
+  - 1.5/pkg/apis/storage/install
+  - 1.5/pkg/apis/storage/v1beta1
+  - 1.5/pkg/auth/user
+  - 1.5/pkg/conversion
+  - 1.5/pkg/conversion/queryparams
+  - 1.5/pkg/fields
+  - 1.5/pkg/genericapiserver/openapi/common
+  - 1.5/pkg/labels
+  - 1.5/pkg/runtime
+  - 1.5/pkg/runtime/serializer
+  - 1.5/pkg/runtime/serializer/json
+  - 1.5/pkg/runtime/serializer/protobuf
+  - 1.5/pkg/runtime/serializer/recognizer
+  - 1.5/pkg/runtime/serializer/streaming
+  - 1.5/pkg/runtime/serializer/versioning
+  - 1.5/pkg/selection
+  - 1.5/pkg/third_party/forked/golang/reflect
+  - 1.5/pkg/types
+  - 1.5/pkg/util
+  - 1.5/pkg/util/cert
+  - 1.5/pkg/util/clock
+  - 1.5/pkg/util/errors
+  - 1.5/pkg/util/flowcontrol
+  - 1.5/pkg/util/framer
+  - 1.5/pkg/util/homedir
+  - 1.5/pkg/util/integer
+  - 1.5/pkg/util/intstr
+  - 1.5/pkg/util/json
+  - 1.5/pkg/util/labels
+  - 1.5/pkg/util/net
+  - 1.5/pkg/util/parsers
+  - 1.5/pkg/util/rand
+  - 1.5/pkg/util/runtime
+  - 1.5/pkg/util/sets
+  - 1.5/pkg/util/uuid
+  - 1.5/pkg/util/validation
+  - 1.5/pkg/util/validation/field
+  - 1.5/pkg/util/wait
+  - 1.5/pkg/util/yaml
+  - 1.5/pkg/version
+  - 1.5/pkg/watch
+  - 1.5/pkg/watch/versioned
+  - 1.5/plugin/pkg/client/auth
+  - 1.5/plugin/pkg/client/auth/gcp
+  - 1.5/plugin/pkg/client/auth/oidc
+  - 1.5/rest
+  - 1.5/tools/auth
+  - 1.5/tools/clientcmd
+  - 1.5/tools/clientcmd/api
+  - 1.5/tools/clientcmd/api/latest
+  - 1.5/tools/clientcmd/api/v1
+  - 1.5/tools/metrics
+  - 1.5/transport
 - name: k8s.io/kubernetes
-  version: e569a27d02001e343cb68086bc06d47804f62af6
+  version: 08e099554f3c31f6e6f07b448ab3ed78d0520507
   subpackages:
   - pkg/api
-  - pkg/api/endpoints
   - pkg/api/errors
   - pkg/api/install
   - pkg/api/meta
   - pkg/api/meta/metatypes
-  - pkg/api/pod
   - pkg/api/resource
-  - pkg/api/service
   - pkg/api/unversioned
-  - pkg/api/unversioned/validation
-  - pkg/api/util
   - pkg/api/v1
-  - pkg/api/validation
+  - pkg/api/validation/path
   - pkg/apimachinery
+  - pkg/apimachinery/announced
   - pkg/apimachinery/registered
   - pkg/apis/apps
   - pkg/apis/apps/install
-  - pkg/apis/apps/v1alpha1
+  - pkg/apis/apps/v1beta1
   - pkg/apis/authentication
   - pkg/apis/authentication/install
   - pkg/apis/authentication/v1beta1
@@ -458,7 +463,7 @@ imports:
   - pkg/apis/extensions/v1beta1
   - pkg/apis/policy
   - pkg/apis/policy/install
-  - pkg/apis/policy/v1alpha1
+  - pkg/apis/policy/v1beta1
   - pkg/apis/rbac
   - pkg/apis/rbac/install
   - pkg/apis/rbac/v1alpha1
@@ -466,22 +471,30 @@ imports:
   - pkg/apis/storage/install
   - pkg/apis/storage/v1beta1
   - pkg/auth/user
-  - pkg/capabilities
+  - pkg/client/clientset_generated/internalclientset
+  - pkg/client/clientset_generated/internalclientset/typed/apps/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authentication/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/batch/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/core/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/policy/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion
+  - pkg/client/clientset_generated/internalclientset/typed/storage/internalversion
   - pkg/client/leaderelection
+  - pkg/client/leaderelection/resourcelock
   - pkg/client/metrics
   - pkg/client/record
   - pkg/client/restclient
   - pkg/client/transport
   - pkg/client/typed/discovery
-  - pkg/client/unversioned
-  - pkg/client/unversioned/auth
-  - pkg/client/unversioned/clientcmd
   - pkg/client/unversioned/clientcmd/api
-  - pkg/client/unversioned/clientcmd/api/latest
-  - pkg/client/unversioned/clientcmd/api/v1
   - pkg/conversion
   - pkg/conversion/queryparams
   - pkg/fields
+  - pkg/genericapiserver/openapi/common
   - pkg/kubelet/qos
   - pkg/kubelet/types
   - pkg/labels
@@ -493,24 +506,21 @@ imports:
   - pkg/runtime/serializer/recognizer
   - pkg/runtime/serializer/streaming
   - pkg/runtime/serializer/versioning
-  - pkg/security/apparmor
   - pkg/selection
   - pkg/types
   - pkg/util
+  - pkg/util/cert
   - pkg/util/clock
   - pkg/util/config
-  - pkg/util/crypto
   - pkg/util/errors
   - pkg/util/flowcontrol
   - pkg/util/framer
-  - pkg/util/hash
-  - pkg/util/homedir
   - pkg/util/integer
   - pkg/util/intstr
   - pkg/util/json
+  - pkg/util/jsonpath
   - pkg/util/labels
   - pkg/util/net
-  - pkg/util/net/sets
   - pkg/util/parsers
   - pkg/util/rand
   - pkg/util/runtime
@@ -529,4 +539,5 @@ imports:
   - plugin/pkg/client/auth/oidc
   - third_party/forked/golang/json
   - third_party/forked/golang/reflect
+  - third_party/forked/golang/template
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,42 +1,21 @@
 package: github.com/coreos/etcd-operator
 import:
 - package: github.com/Sirupsen/logrus
-  version: v0.10.0
-- package: github.com/pborman/uuid
-  version: v1.0
-- package: golang.org/x/net
-  subpackages:
-  - context
-- package: github.com/coreos/etcd
-  version: v3.1.0-alpha.1
-  subpackages:
-  - clientv3
-  - etcdserver/api/v3rpc/rpctypes
-- package: github.com/xiang90/probing
-  version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
-- package: k8s.io/kubernetes
-  version: v1.4.6
-  subpackages:
-  - pkg/api
-  - pkg/api/errors
-  - pkg/api/resource
-  - pkg/api/unversioned
-  - pkg/api/v1
-  - pkg/apis/extensions
-  - pkg/apis/storage
-  - pkg/client/restclient
-  - pkg/client/unversioned
-  - pkg/client/unversioned/clientcmd
-  - pkg/labels
-  - pkg/util/intstr
-  - pkg/util/wait
-  - pkg/watch
+  version: v0.11.0
 - package: github.com/aws/aws-sdk-go
-  version: v1.3.0
-- package: github.com/jpillora/go-ogle-analytics
+  version: v1.6.13
 - package: github.com/coreos/go-semver
   version: v0.2.0
+- package: github.com/jpillora/go-ogle-analytics
+- package: github.com/pborman/uuid
+  version: v1.0
 - package: github.com/prometheus/client_golang
   version: v0.8.0
-  subpackages:
-  - prometheus
+- package: golang.org/x/net
+- package: golang.org/x/time
+- package: github.com/coreos/etcd
+  version: v3.1.0-alpha.1
+- package: k8s.io/client-go
+  version: v1.5.0
+- package: k8s.io/kubernetes
+  version: v1.5.2

--- a/hack/jenkins
+++ b/hack/jenkins
@@ -27,7 +27,8 @@ cleanup() {
 
 trap cleanup EXIT
 
-glide install 1>/dev/null
+# glog would complain "flag redefined: log_dir" without stripping vendor
+glide install --strip-vendor 1>/dev/null
 
 GIT_VERSION=$(git rev-parse HEAD)
 export OPERATOR_IMAGE="gcr.io/coreos-k8s-scale-testing/etcd-operator:${GIT_VERSION}"

--- a/hack/release/README.md
+++ b/hack/release/README.md
@@ -21,7 +21,7 @@ Working directory is root of "etcd-operator/".
 
 Install dependency if none exists:
 ```
-$ glide install
+$ glide install --strip-vendor
 ```
 You should see "vendor/".
 

--- a/pkg/chaos/chaos.go
+++ b/pkg/chaos/chaos.go
@@ -20,17 +20,17 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"golang.org/x/time/rate"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/client-go/1.5/kubernetes"
+	"k8s.io/client-go/1.5/pkg/api"
+	"k8s.io/client-go/1.5/pkg/labels"
 )
 
 // Monkeys knows how to crush pods and nodes.
 type Monkeys struct {
-	k8s *unversioned.Client
+	k8s kubernetes.Interface
 }
 
-func NewMonkeys(k8s *unversioned.Client) *Monkeys {
+func NewMonkeys(k8s kubernetes.Interface) *Monkeys {
 	return &Monkeys{k8s: k8s}
 }
 
@@ -64,7 +64,7 @@ func (m *Monkeys) CrushPods(ctx context.Context, c *CrashConfig) {
 			continue
 		}
 
-		pods, err := m.k8s.Pods(ns).List(api.ListOptions{LabelSelector: ls})
+		pods, err := m.k8s.Core().Pods(ns).List(api.ListOptions{LabelSelector: ls})
 		if err != nil {
 			logrus.Errorf("failed to list pods for selector %v: %v", ls.String(), err)
 			continue
@@ -88,7 +88,7 @@ func (m *Monkeys) CrushPods(ctx context.Context, c *CrashConfig) {
 		}
 
 		for tokill := range tokills {
-			err = m.k8s.Pods(ns).Delete(tokill, api.NewDeleteOptions(0))
+			err = m.k8s.Core().Pods(ns).Delete(tokill, api.NewDeleteOptions(0))
 			if err != nil {
 				logrus.Errorf("failed to kill pod %v: %v", tokill, err)
 				continue

--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -22,7 +22,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 
 	"github.com/Sirupsen/logrus"
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.5/pkg/api/v1"
 )
 
 type backupManager struct {
@@ -109,9 +109,9 @@ func (bm *backupManager) runSidecar() error {
 	return nil
 }
 
-func (bm *backupManager) createBackupReplicaSet(podSpec api.PodSpec) error {
+func (bm *backupManager) createBackupReplicaSet(podSpec v1.PodSpec) error {
 	rs := k8sutil.MakeBackupReplicaSet(bm.cluster.Name, podSpec, bm.cluster.AsOwner())
-	_, err := bm.config.KubeCli.ReplicaSets(bm.cluster.Namespace).Create(rs)
+	_, err := bm.config.KubeCli.Extensions().ReplicaSets(bm.cluster.Namespace).Create(rs)
 	if err != nil {
 		if !k8sutil.IsKubernetesResourceAlreadyExistError(err) {
 			return err
@@ -122,7 +122,7 @@ func (bm *backupManager) createBackupReplicaSet(podSpec api.PodSpec) error {
 
 func (bm *backupManager) createBackupService() error {
 	svc := k8sutil.MakeBackupService(bm.cluster.Name, bm.cluster.AsOwner())
-	_, err := bm.config.KubeCli.Services(bm.cluster.Namespace).Create(svc)
+	_, err := bm.config.KubeCli.Core().Services(bm.cluster.Namespace).Create(svc)
 	if err != nil {
 		if !k8sutil.IsKubernetesResourceAlreadyExistError(err) {
 			return err

--- a/pkg/cluster/backupstorage/pv.go
+++ b/pkg/cluster/backupstorage/pv.go
@@ -4,7 +4,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 
-	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/client-go/1.5/kubernetes"
 )
 
 type pv struct {
@@ -12,16 +12,16 @@ type pv struct {
 	namespace     string
 	pvProvisioner string
 	backupPolicy  spec.BackupPolicy
-	kubecli       *unversioned.Client
+	kubecli       kubernetes.Interface
 }
 
-func NewPVStorage(kc *unversioned.Client, cn, ns, pvp string, backupPolicy spec.BackupPolicy) (Storage, error) {
+func NewPVStorage(kubecli kubernetes.Interface, cn, ns, pvp string, backupPolicy spec.BackupPolicy) (Storage, error) {
 	s := &pv{
 		clusterName:   cn,
 		namespace:     ns,
 		pvProvisioner: pvp,
 		backupPolicy:  backupPolicy,
-		kubecli:       kc,
+		kubecli:       kubecli,
 	}
 	return s, nil
 }

--- a/pkg/cluster/backupstorage/s3.go
+++ b/pkg/cluster/backupstorage/s3.go
@@ -6,7 +6,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/spec"
 
 	"github.com/aws/aws-sdk-go/aws/session"
-	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/client-go/1.5/kubernetes"
 )
 
 type s3 struct {
@@ -14,11 +14,11 @@ type s3 struct {
 	clusterName  string
 	namespace    string
 	backupPolicy spec.BackupPolicy
-	kubecli      *unversioned.Client
+	kubecli      kubernetes.Interface
 	s3cli        *backups3.S3
 }
 
-func NewS3Storage(s3Ctx s3config.S3Context, kubecli *unversioned.Client, clusterName, ns string, p spec.BackupPolicy) (Storage, error) {
+func NewS3Storage(s3Ctx s3config.S3Context, kubecli kubernetes.Interface, clusterName, ns string, p spec.BackupPolicy) (Storage, error) {
 	s3cli, err := backups3.New(s3Ctx.S3Bucket, clusterName+"/", session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})

--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -19,8 +19,7 @@ import (
 
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
-
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.5/pkg/api/v1"
 )
 
 func (c *Cluster) updateMembers(known etcdutil.MemberSet) error {
@@ -70,7 +69,7 @@ func (c *Cluster) updateMembers(known etcdutil.MemberSet) error {
 	return nil
 }
 
-func podsToMemberSet(pods []*api.Pod, selfHosted *spec.SelfHostedPolicy) etcdutil.MemberSet {
+func podsToMemberSet(pods []*v1.Pod, selfHosted *spec.SelfHostedPolicy) etcdutil.MemberSet {
 	members := etcdutil.MemberSet{}
 	for _, pod := range pods {
 		m := &etcdutil.Member{Name: pod.Name}

--- a/pkg/cluster/self_hosted.go
+++ b/pkg/cluster/self_hosted.go
@@ -38,7 +38,7 @@ func (c *Cluster) addOneSelfHostedMember() error {
 	pod := k8sutil.MakeSelfHostedEtcdPod(newMemberName, initialCluster, c.cluster.Name, "existing", "", c.cluster.Spec, c.cluster.AsOwner())
 	pod = k8sutil.PodWithAddMemberInitContainer(pod, c.members.ClientURLs(), newMemberName, []string{peerURL}, c.cluster.Spec)
 
-	_, err := c.config.KubeCli.Pods(c.cluster.Namespace).Create(pod)
+	_, err := c.config.KubeCli.Core().Pods(c.cluster.Namespace).Create(pod)
 	if err != nil {
 		return err
 	}

--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -24,14 +24,14 @@ import (
 func (c *Cluster) upgradeOneMember(m *etcdutil.Member) error {
 	c.status.AppendUpgradingCondition(c.cluster.Spec.Version, m.Name)
 
-	pod, err := c.config.KubeCli.Pods(c.cluster.Namespace).Get(m.Name)
+	pod, err := c.config.KubeCli.Core().Pods(c.cluster.Namespace).Get(m.Name)
 	if err != nil {
 		return fmt.Errorf("fail to get pod (%s): %v", m.Name, err)
 	}
 	c.logger.Infof("upgrading the etcd member %v from %s to %s", m.Name, k8sutil.GetEtcdVersion(pod), c.cluster.Spec.Version)
 	pod.Spec.Containers[0].Image = k8sutil.MakeEtcdImage(c.cluster.Spec.Version)
 	k8sutil.SetEtcdVersion(pod, c.cluster.Spec.Version)
-	_, err = c.config.KubeCli.Pods(c.cluster.Namespace).Update(pod)
+	_, err = c.config.KubeCli.Core().Pods(c.cluster.Namespace).Update(pod)
 	if err != nil {
 		return fmt.Errorf("fail to update the etcd member (%s): %v", m.Name, err)
 	}

--- a/pkg/controller/s3.go
+++ b/pkg/controller/s3.go
@@ -21,15 +21,15 @@ import (
 
 	"github.com/coreos/etcd-operator/pkg/backup/s3/s3config"
 
-	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/client-go/1.5/kubernetes"
 )
 
-func setupS3Env(kubecli *unversioned.Client, s3Ctx s3config.S3Context, ns string) error {
-	cm, err := kubecli.ConfigMaps(ns).Get(s3Ctx.AWSConfig)
+func setupS3Env(kubecli kubernetes.Interface, s3Ctx s3config.S3Context, ns string) error {
+	cm, err := kubecli.Core().ConfigMaps(ns).Get(s3Ctx.AWSConfig)
 	if err != nil {
 		return err
 	}
-	se, err := kubecli.Secrets(ns).Get(s3Ctx.AWSSecret)
+	se, err := kubecli.Core().Secrets(ns).Get(s3Ctx.AWSSecret)
 	if err != nil {
 		return err
 	}

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -19,9 +19,9 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/kubernetes/pkg/api"
-	metatypes "k8s.io/kubernetes/pkg/api/meta/metatypes"
-	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/pkg/api/meta/metatypes"
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/pkg/api/v1"
 )
 
 var (
@@ -30,14 +30,14 @@ var (
 
 type EtcdCluster struct {
 	unversioned.TypeMeta `json:",inline"`
-	api.ObjectMeta       `json:"metadata,omitempty"`
+	v1.ObjectMeta        `json:"metadata,omitempty"`
 	Spec                 *ClusterSpec   `json:"spec"`
 	Status               *ClusterStatus `json:"status"`
 }
 
 func (e *EtcdCluster) AsOwner() metatypes.OwnerReference {
 	trueVar := true
-	// TODO: In 1.5 this is gonna be "k8s.io/kubernetes/pkg/apis/meta/v1"
+	// TODO: In 1.6 this is gonna be "k8s.io/kubernetes/pkg/apis/meta/v1"
 	// Both api.OwnerReference and metatypes.OwnerReference are combined into that.
 	return metatypes.OwnerReference{
 		APIVersion: e.APIVersion,

--- a/pkg/spec/etcd_cluster_list.go
+++ b/pkg/spec/etcd_cluster_list.go
@@ -14,9 +14,7 @@
 
 package spec
 
-import (
-	"k8s.io/kubernetes/pkg/api/unversioned"
-)
+import "k8s.io/client-go/1.5/pkg/api/unversioned"
 
 // EtcdClusterList is a list of etcd clusters.
 type EtcdClusterList struct {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -17,7 +17,6 @@ package k8sutil
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -26,18 +25,17 @@ import (
 	"github.com/coreos/etcd-operator/pkg/util"
 	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
+	"github.com/coreos/etcd-operator/pkg/util/retryutil"
 
-	"k8s.io/kubernetes/pkg/api"
-	apierrors "k8s.io/kubernetes/pkg/api/errors"
-	"k8s.io/kubernetes/pkg/api/meta"
-	"k8s.io/kubernetes/pkg/api/meta/metatypes"
-	unversionedAPI "k8s.io/kubernetes/pkg/api/unversioned"
-	k8sv1api "k8s.io/kubernetes/pkg/api/v1"
-	"k8s.io/kubernetes/pkg/client/restclient"
-	"k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/labels"
-	"k8s.io/kubernetes/pkg/util/intstr"
-	"k8s.io/kubernetes/pkg/watch"
+	"k8s.io/client-go/1.5/kubernetes"
+	"k8s.io/client-go/1.5/pkg/api"
+	apierrors "k8s.io/client-go/1.5/pkg/api/errors"
+	"k8s.io/client-go/1.5/pkg/api/meta"
+	"k8s.io/client-go/1.5/pkg/api/meta/metatypes"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+	"k8s.io/client-go/1.5/pkg/labels"
+	"k8s.io/client-go/1.5/pkg/util/intstr"
+	"k8s.io/client-go/1.5/rest"
 )
 
 const (
@@ -50,15 +48,15 @@ const (
 	annotationPrometheusPort   = "prometheus.io/port"
 )
 
-func GetEtcdVersion(pod *api.Pod) string {
+func GetEtcdVersion(pod *v1.Pod) string {
 	return pod.Annotations[etcdVersionAnnotationKey]
 }
 
-func SetEtcdVersion(pod *api.Pod, version string) {
+func SetEtcdVersion(pod *v1.Pod, version string) {
 	pod.Annotations[etcdVersionAnnotationKey] = version
 }
 
-func GetPodNames(pods []*api.Pod) []string {
+func GetPodNames(pods []*v1.Pod) []string {
 	res := []string{}
 	for _, p := range pods {
 		res = append(res, p.Name)
@@ -67,7 +65,7 @@ func GetPodNames(pods []*api.Pod) []string {
 }
 
 func makeRestoreInitContainerSpec(backupAddr, name, token, version string) string {
-	spec := []api.Container{
+	spec := []v1.Container{
 		{
 			Name:  "fetch-backup",
 			Image: "tutum/curl",
@@ -75,7 +73,7 @@ func makeRestoreInitContainerSpec(backupAddr, name, token, version string) strin
 				"/bin/sh", "-c",
 				fmt.Sprintf("curl -o %s %s", backupFile, util.MakeBackupURL(backupAddr, version)),
 			},
-			VolumeMounts: []api.VolumeMount{
+			VolumeMounts: []v1.VolumeMount{
 				{Name: "etcd-data", MountPath: etcdDir},
 			},
 		},
@@ -91,7 +89,7 @@ func makeRestoreInitContainerSpec(backupAddr, name, token, version string) strin
 					" --initial-advertise-peer-urls http://%[2]s:2380"+
 					" --data-dir %[4]s", backupFile, name, token, dataDir),
 			},
-			VolumeMounts: []api.VolumeMount{
+			VolumeMounts: []v1.VolumeMount{
 				{Name: "etcd-data", MountPath: etcdDir},
 			},
 		},
@@ -107,7 +105,7 @@ func MakeEtcdImage(version string) string {
 	return fmt.Sprintf("quay.io/coreos/etcd:%v", version)
 }
 
-func GetNodePortString(srv *api.Service) string {
+func GetNodePortString(srv *v1.Service) string {
 	return fmt.Sprint(srv.Spec.Ports[0].NodePort)
 }
 
@@ -115,7 +113,7 @@ func MakeBackupHostPort(clusterName string) string {
 	return fmt.Sprintf("%s:%d", MakeBackupName(clusterName), constants.DefaultBackupPodHTTPPort)
 }
 
-func PodWithNodeSelector(p *api.Pod, ns map[string]string) *api.Pod {
+func PodWithNodeSelector(p *v1.Pod, ns map[string]string) *v1.Pod {
 	p.Spec.NodeSelector = ns
 	return p
 }
@@ -124,60 +122,69 @@ func MakeBackupName(clusterName string) string {
 	return fmt.Sprintf("%s-backup-tool", clusterName)
 }
 
-func CreateEtcdMemberService(kclient *unversioned.Client, ns string, svc *api.Service) (*api.Service, error) {
-	retSvc, err := kclient.Services(ns).Create(svc)
+func CreateEtcdMemberService(kubecli kubernetes.Interface, ns string, svc *v1.Service) (*v1.Service, error) {
+	retSvc, err := kubecli.Core().Services(ns).Create(svc)
 	if err != nil {
 		return nil, err
 	}
 	return retSvc, nil
 }
 
-func CreateEtcdService(kclient *unversioned.Client, clusterName, ns string, owner metatypes.OwnerReference) (*api.Service, error) {
+func CreateEtcdService(kubecli kubernetes.Interface, clusterName, ns string, owner metatypes.OwnerReference) (*v1.Service, error) {
 	svc := makeEtcdService(clusterName)
 	addOwnerRefToObject(svc.GetObjectMeta(), owner)
-	retSvc, err := kclient.Services(ns).Create(svc)
+	retSvc, err := kubecli.Core().Services(ns).Create(svc)
 	if err != nil {
 		return nil, err
 	}
 	return retSvc, nil
 }
 
-func CreateAndWaitPod(kclient *unversioned.Client, ns string, pod *api.Pod, timeout time.Duration) (*api.Pod, error) {
-	if _, err := kclient.Pods(ns).Create(pod); err != nil {
-		return nil, err
-	}
-	// TODO: cleanup pod on failure
-	w, err := kclient.Pods(ns).Watch(api.SingleObject(api.ObjectMeta{Name: pod.Name}))
-	if err != nil {
-		return nil, err
-	}
-	_, err = watch.Until(timeout, w, unversioned.PodRunning)
-
-	pod, err = kclient.Pods(ns).Get(pod.Name)
+// CreateAndWaitPod is a workaround for self hosted and util for testing.
+// We should eventually get rid of this in critical code path and move it to test util.
+func CreateAndWaitPod(kubecli kubernetes.Interface, ns string, pod *v1.Pod, timeout time.Duration) (*v1.Pod, error) {
+	_, err := kubecli.Core().Pods(ns).Create(pod)
 	if err != nil {
 		return nil, err
 	}
 
-	return pod, nil
+	interval := 3 * time.Second
+	var retPod *v1.Pod
+	retryutil.Retry(interval, int(timeout/(interval)), func() (bool, error) {
+		retPod, err = kubecli.Core().Pods(ns).Get(pod.Name)
+		if err != nil {
+			return false, err
+		}
+		switch retPod.Status.Phase {
+		case v1.PodRunning:
+			return true, nil
+		case v1.PodPending:
+			return false, nil
+		default:
+			return false, fmt.Errorf("unexpected pod status.phase: %v", retPod.Status.Phase)
+		}
+	})
+
+	return retPod, nil
 }
 
-func makeEtcdService(clusterName string) *api.Service {
+func makeEtcdService(clusterName string) *v1.Service {
 	labels := map[string]string{
 		"app":          "etcd",
 		"etcd_cluster": clusterName,
 	}
-	svc := &api.Service{
-		ObjectMeta: api.ObjectMeta{
+	svc := &v1.Service{
+		ObjectMeta: v1.ObjectMeta{
 			Name:   clusterName,
 			Labels: labels,
 		},
-		Spec: api.ServiceSpec{
-			Ports: []api.ServicePort{
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
 				{
 					Name:       "client",
 					Port:       2379,
 					TargetPort: intstr.FromInt(2379),
-					Protocol:   api.ProtocolTCP,
+					Protocol:   v1.ProtocolTCP,
 				},
 			},
 			Selector: labels,
@@ -187,14 +194,14 @@ func makeEtcdService(clusterName string) *api.Service {
 }
 
 // TODO: converge the port logic with member ClientAddr() and PeerAddr()
-func MakeEtcdMemberService(etcdName, clusterName string, owner metatypes.OwnerReference) *api.Service {
+func MakeEtcdMemberService(etcdName, clusterName string, owner metatypes.OwnerReference) *v1.Service {
 	labels := map[string]string{
 		"app":          "etcd",
 		"etcd_node":    etcdName,
 		"etcd_cluster": clusterName,
 	}
-	svc := &api.Service{
-		ObjectMeta: api.ObjectMeta{
+	svc := &v1.Service{
+		ObjectMeta: v1.ObjectMeta{
 			Name:   etcdName,
 			Labels: labels,
 			Annotations: map[string]string{
@@ -202,19 +209,19 @@ func MakeEtcdMemberService(etcdName, clusterName string, owner metatypes.OwnerRe
 				annotationPrometheusPort:   "2379",
 			},
 		},
-		Spec: api.ServiceSpec{
-			Ports: []api.ServicePort{
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
 				{
 					Name:       "server",
 					Port:       2380,
 					TargetPort: intstr.FromInt(2380),
-					Protocol:   api.ProtocolTCP,
+					Protocol:   v1.ProtocolTCP,
 				},
 				{
 					Name:       "client",
 					Port:       2379,
 					TargetPort: intstr.FromInt(2379),
-					Protocol:   api.ProtocolTCP,
+					Protocol:   v1.ProtocolTCP,
 				},
 			},
 			Selector: labels,
@@ -224,8 +231,8 @@ func MakeEtcdMemberService(etcdName, clusterName string, owner metatypes.OwnerRe
 	return svc
 }
 
-func AddRecoveryToPod(pod *api.Pod, clusterName, name, token string, cs *spec.ClusterSpec) {
-	pod.Annotations[k8sv1api.PodInitContainersBetaAnnotationKey] =
+func AddRecoveryToPod(pod *v1.Pod, clusterName, name, token string, cs *spec.ClusterSpec) {
+	pod.Annotations[v1.PodInitContainersBetaAnnotationKey] =
 		makeRestoreInitContainerSpec(MakeBackupHostPort(clusterName), name, token, cs.Version)
 }
 
@@ -233,7 +240,7 @@ func addOwnerRefToObject(o meta.Object, r metatypes.OwnerReference) {
 	o.SetOwnerReferences(append(o.GetOwnerReferences(), r))
 }
 
-func MakeEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state, token string, cs *spec.ClusterSpec, owner metatypes.OwnerReference) *api.Pod {
+func MakeEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state, token string, cs *spec.ClusterSpec, owner metatypes.OwnerReference) *v1.Pod {
 	commands := fmt.Sprintf("/usr/local/bin/etcd --data-dir=%s --name=%s --initial-advertise-peer-urls=%s "+
 		"--listen-peer-urls=http://0.0.0.0:2380 --listen-client-urls=http://0.0.0.0:2379 --advertise-client-urls=%s "+
 		"--initial-cluster=%s --initial-cluster-state=%s",
@@ -242,8 +249,8 @@ func MakeEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state
 		commands = fmt.Sprintf("%s --initial-cluster-token=%s", commands, token)
 	}
 	container := containerWithLivenessProbe(etcdContainer(commands, cs.Version), etcdLivenessProbe())
-	pod := &api.Pod{
-		ObjectMeta: api.ObjectMeta{
+	pod := &v1.Pod{
+		ObjectMeta: v1.ObjectMeta{
 			Name: m.Name,
 			Labels: map[string]string{
 				"app":          "etcd",
@@ -252,11 +259,11 @@ func MakeEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state
 			},
 			Annotations: map[string]string{},
 		},
-		Spec: api.PodSpec{
-			Containers:    []api.Container{container},
-			RestartPolicy: api.RestartPolicyNever,
-			Volumes: []api.Volume{
-				{Name: "etcd-data", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}},
+		Spec: v1.PodSpec{
+			Containers:    []v1.Container{container},
+			RestartPolicy: v1.RestartPolicyNever,
+			Volumes: []v1.Volume{
+				{Name: "etcd-data", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
 			},
 		},
 	}
@@ -275,7 +282,7 @@ func MakeEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state
 }
 
 func MustGetInClusterMasterHost() string {
-	cfg, err := restclient.InClusterConfig()
+	cfg, err := rest.InClusterConfig()
 	if err != nil {
 		panic(err)
 	}
@@ -284,28 +291,31 @@ func MustGetInClusterMasterHost() string {
 
 // tlsConfig isn't modified inside this function.
 // The reason it's a pointer is that it's not necessary to have tlsconfig to create a client.
-func MustCreateClient(host string, tlsInsecure bool, tlsConfig *restclient.TLSClientConfig) *unversioned.Client {
+func MustCreateClient(host string, tlsInsecure bool, tlsConfig *rest.TLSClientConfig) kubernetes.Interface {
+	var cfg *rest.Config
 	if len(host) == 0 {
-		c, err := unversioned.NewInCluster()
+		var err error
+		cfg, err = rest.InClusterConfig()
 		if err != nil {
 			panic(err)
 		}
-		return c
+	} else {
+		cfg = &rest.Config{
+			Host:  host,
+			QPS:   100,
+			Burst: 100,
+		}
+		hostUrl, err := url.Parse(host)
+		if err != nil {
+			panic(fmt.Sprintf("failed to parse host url %s : %v", host, err))
+		}
+		if hostUrl.Scheme == "https" {
+			cfg.TLSClientConfig = *tlsConfig
+			cfg.Insecure = tlsInsecure
+		}
 	}
-	cfg := &restclient.Config{
-		Host:  host,
-		QPS:   100,
-		Burst: 100,
-	}
-	hostUrl, err := url.Parse(host)
-	if err != nil {
-		panic(fmt.Sprintf("error parsing host url %s : %v", host, err))
-	}
-	if hostUrl.Scheme == "https" {
-		cfg.TLSClientConfig = *tlsConfig
-		cfg.Insecure = tlsInsecure
-	}
-	c, err := unversioned.New(cfg)
+
+	c, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		panic(err)
 	}
@@ -313,27 +323,14 @@ func MustCreateClient(host string, tlsInsecure bool, tlsConfig *restclient.TLSCl
 }
 
 func IsKubernetesResourceAlreadyExistError(err error) bool {
-	se, ok := err.(*apierrors.StatusError)
-	if !ok {
-		return false
-	}
-	if se.Status().Code == http.StatusConflict && se.Status().Reason == unversionedAPI.StatusReasonAlreadyExists {
-		return true
-	}
-	return false
+	return apierrors.IsAlreadyExists(err)
 }
 
 func IsKubernetesResourceNotFoundError(err error) bool {
-	se, ok := err.(*apierrors.StatusError)
-	if !ok {
-		return false
-	}
-	if se.Status().Code == http.StatusNotFound && se.Status().Reason == unversionedAPI.StatusReasonNotFound {
-		return true
-	}
-	return false
+	return apierrors.IsNotFound(err)
 }
 
+// We are using internal api types for cluster related.
 func ClusterListOpt(clusterName string) api.ListOptions {
 	return api.ListOptions{
 		LabelSelector: labels.SelectorFromSet(map[string]string{

--- a/pkg/util/k8sutil/self_hosted.go
+++ b/pkg/util/k8sutil/self_hosted.go
@@ -21,9 +21,8 @@ import (
 
 	"github.com/coreos/etcd-operator/pkg/spec"
 
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/meta/metatypes"
-	k8sv1api "k8s.io/kubernetes/pkg/api/v1"
+	"k8s.io/client-go/1.5/pkg/api/meta/metatypes"
+	"k8s.io/client-go/1.5/pkg/api/v1"
 )
 
 const (
@@ -31,10 +30,10 @@ const (
 )
 
 var (
-	envPodIP = api.EnvVar{
+	envPodIP = v1.EnvVar{
 		Name: "MY_POD_IP",
-		ValueFrom: &api.EnvVarSource{
-			FieldRef: &api.ObjectFieldSelector{
+		ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{
 				APIVersion: "v1",
 				FieldPath:  "status.podIP",
 			},
@@ -42,8 +41,8 @@ var (
 	}
 )
 
-func PodWithAddMemberInitContainer(p *api.Pod, endpoints []string, name string, peerURLs []string, cs *spec.ClusterSpec) *api.Pod {
-	containerSpec := []api.Container{
+func PodWithAddMemberInitContainer(p *v1.Pod, endpoints []string, name string, peerURLs []string, cs *spec.ClusterSpec) *v1.Pod {
+	containerSpec := []v1.Container{
 		{
 			Name:  "add-member",
 			Image: MakeEtcdImage(cs.Version),
@@ -51,18 +50,18 @@ func PodWithAddMemberInitContainer(p *api.Pod, endpoints []string, name string, 
 				"/bin/sh", "-c",
 				fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=%s member add %s --peer-urls=%s", strings.Join(endpoints, ","), name, strings.Join(peerURLs, ",")),
 			},
-			Env: []api.EnvVar{envPodIP},
+			Env: []v1.EnvVar{envPodIP},
 		},
 	}
 	b, err := json.Marshal(containerSpec)
 	if err != nil {
 		panic(err)
 	}
-	p.Annotations[k8sv1api.PodInitContainersBetaAnnotationKey] = string(b)
+	p.Annotations[v1.PodInitContainersBetaAnnotationKey] = string(b)
 	return p
 }
 
-func MakeSelfHostedEtcdPod(name string, initialCluster []string, clusterName, state, token string, cs *spec.ClusterSpec, owner metatypes.OwnerReference) *api.Pod {
+func MakeSelfHostedEtcdPod(name string, initialCluster []string, clusterName, state, token string, cs *spec.ClusterSpec, owner metatypes.OwnerReference) *v1.Pod {
 	commands := fmt.Sprintf("/usr/local/bin/etcd --data-dir=%s --name=%s --initial-advertise-peer-urls=http://$(MY_POD_IP):2380 "+
 		"--listen-peer-urls=http://$(MY_POD_IP):2380 --listen-client-urls=http://$(MY_POD_IP):2379 --advertise-client-urls=http://$(MY_POD_IP):2379 "+
 		"--initial-cluster=%s --initial-cluster-state=%s",
@@ -73,9 +72,9 @@ func MakeSelfHostedEtcdPod(name string, initialCluster []string, clusterName, st
 	}
 
 	c := etcdContainer(commands, cs.Version)
-	c.Env = []api.EnvVar{envPodIP}
-	pod := &api.Pod{
-		ObjectMeta: api.ObjectMeta{
+	c.Env = []v1.EnvVar{envPodIP}
+	pod := &v1.Pod{
+		ObjectMeta: v1.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
 				"app":          "etcd",
@@ -86,16 +85,14 @@ func MakeSelfHostedEtcdPod(name string, initialCluster []string, clusterName, st
 				shouldCheckpointAnnotation: "true",
 			},
 		},
-		Spec: api.PodSpec{
-			Containers: []api.Container{c},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{c},
 			// Self-hosted etcd pod need to endure node restart.
 			// If we set it to Never, the pod won't restart. If etcd won't come up, nor does other k8s API components.
-			RestartPolicy: api.RestartPolicyAlways,
-			SecurityContext: &api.PodSecurityContext{
-				HostNetwork: true,
-			},
-			Volumes: []api.Volume{
-				{Name: "etcd-data", VolumeSource: api.VolumeSource{EmptyDir: &api.EmptyDirVolumeSource{}}},
+			RestartPolicy: v1.RestartPolicyAlways,
+			HostNetwork:   true,
+			Volumes: []v1.Volume{
+				{Name: "etcd-data", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
 			},
 		},
 	}

--- a/pkg/util/k8sutil/tpr_util.go
+++ b/pkg/util/k8sutil/tpr_util.go
@@ -15,146 +15,93 @@
 package k8sutil
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
 
-	"k8s.io/kubernetes/pkg/client/unversioned"
+	apierrors "k8s.io/client-go/1.5/pkg/api/errors"
+	"k8s.io/client-go/1.5/rest"
 )
 
-var (
-	ErrTPRObjectNotFound        = errors.New("TPR object not found")
-	ErrTPRObjectVersionConflict = errors.New("TPR object's resource version conflicts")
-)
+// TODO: replace this package with Operator client
 
 func WatchClusters(host, ns string, httpClient *http.Client, resourceVersion string) (*http.Response, error) {
 	return httpClient.Get(fmt.Sprintf("%s/apis/coreos.com/v1/namespaces/%s/etcdclusters?watch=true&resourceVersion=%s",
 		host, ns, resourceVersion))
 }
 
-func GetClusterList(k8s *unversioned.Client, host, ns string) (*spec.EtcdClusterList, error) {
-	resp, err := httpGetClusterList(k8s.Client, host, ns)
+func GetClusterList(restcli *rest.RESTClient, ns string) (*spec.EtcdClusterList, error) {
+	b, err := restcli.Get().RequestURI(listClustersURI(ns)).DoRaw()
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		return nil, toTPRError(resp.StatusCode)
-	}
-
-	d := json.NewDecoder(resp.Body)
 	clusters := &spec.EtcdClusterList{}
-	if err := d.Decode(clusters); err != nil {
+	if err := json.Unmarshal(b, clusters); err != nil {
 		return nil, err
 	}
 	return clusters, nil
 }
 
-func WaitEtcdTPRReady(k8s *unversioned.Client, interval, timeout time.Duration, host, ns string) error {
+func WaitEtcdTPRReady(restcli *rest.RESTClient, interval, timeout time.Duration, ns string) error {
 	return retryutil.Retry(interval, int(timeout/interval), func() (bool, error) {
-		resp, err := httpGetClusterList(k8s.Client, host, ns)
+		_, err := restcli.Get().RequestURI(listClustersURI(ns)).DoRaw()
 		if err != nil {
+			if apierrors.IsNotFound(err) { // not set up yet. wait more.
+				return false, nil
+			}
 			return false, err
 		}
-		defer resp.Body.Close()
-
-		switch resp.StatusCode {
-		case http.StatusOK:
-			return true, nil
-		case http.StatusNotFound: // not set up yet. wait.
-			return false, nil
-		default:
-			return false, fmt.Errorf("invalid status code: %v", resp.Status)
-		}
+		return true, nil
 	})
 }
 
-func httpGetClusterList(httpcli *http.Client, host, ns string) (*http.Response, error) {
-	return httpcli.Get(fmt.Sprintf("%s/apis/coreos.com/v1/namespaces/%s/etcdclusters",
-		host, ns))
+func listClustersURI(ns string) string {
+	return fmt.Sprintf("/apis/coreos.com/v1/namespaces/%s/etcdclusters", ns)
 }
 
-func GetClusterTPRObject(k8s *unversioned.Client, host, ns, name string) (*spec.EtcdCluster, error) {
-	req, err := http.NewRequest(http.MethodGet,
-		fmt.Sprintf("%s/apis/coreos.com/v1/namespaces/%s/etcdclusters/%s", host, ns, name), nil)
+func GetClusterTPRObject(restcli *rest.RESTClient, ns, name string) (*spec.EtcdCluster, error) {
+	uri := fmt.Sprintf("/apis/coreos.com/v1/namespaces/%s/etcdclusters/%s", ns, name)
+	b, err := restcli.Get().RequestURI(uri).DoRaw()
 	if err != nil {
 		return nil, err
 	}
-
-	resp, err := k8s.Client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, toTPRError(resp.StatusCode)
-	}
-	return readOutCluster(resp.Body)
+	return readOutCluster(b)
 }
 
 // UpdateClusterTPRObject updates the given TPR object.
 // ResourceVersion of the object MUST be set or update will fail.
-func UpdateClusterTPRObject(k8s *unversioned.Client, host, ns string, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
+func UpdateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
 	if len(e.ResourceVersion) == 0 {
 		return nil, errors.New("k8sutil: resource version is not provided")
 	}
-	return updateClusterTPRObject(k8s, host, ns, e)
+	return updateClusterTPRObject(restcli, ns, e)
 }
 
 // UpdateClusterTPRObjectUnconditionally updates the given TPR object.
 // This should only be used in tests.
-func UpdateClusterTPRObjectUnconditionally(k8s *unversioned.Client, host, ns string, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
+func UpdateClusterTPRObjectUnconditionally(restcli *rest.RESTClient, ns string, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
 	e.ResourceVersion = ""
-	return updateClusterTPRObject(k8s, host, ns, e)
+	return updateClusterTPRObject(restcli, ns, e)
 }
 
-func updateClusterTPRObject(k8s *unversioned.Client, host, ns string, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
-	b, err := json.Marshal(e)
+func updateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
+	uri := fmt.Sprintf("/apis/coreos.com/v1/namespaces/%s/etcdclusters/%s", ns, e.Name)
+	b, err := restcli.Put().RequestURI(uri).Body(e).DoRaw()
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest(http.MethodPut,
-		fmt.Sprintf("%s/apis/coreos.com/v1/namespaces/%s/etcdclusters/%s", host, ns, e.Name),
-		bytes.NewReader(b))
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := k8s.Client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, toTPRError(resp.StatusCode)
-	}
-	return readOutCluster(resp.Body)
+	return readOutCluster(b)
 }
 
-func toTPRError(code int) error {
-	switch code {
-	case http.StatusNotFound:
-		return ErrTPRObjectNotFound
-	case http.StatusConflict:
-		return ErrTPRObjectVersionConflict
-	default:
-		return fmt.Errorf("unexpected status code: %v", code)
-	}
-}
-
-func readOutCluster(r io.Reader) (*spec.EtcdCluster, error) {
-	decoder := json.NewDecoder(r)
+func readOutCluster(b []byte) (*spec.EtcdCluster, error) {
 	cluster := &spec.EtcdCluster{}
-	if err := decoder.Decode(cluster); err != nil {
+	if err := json.Unmarshal(b, cluster); err != nil {
 		return nil, err
 	}
 	return cluster, nil

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 
-	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/client-go/1.5/pkg/api/v1"
 )
 
 func TestBasic(t *testing.T) {
@@ -124,7 +124,7 @@ func testEtcdUpgrade(t *testing.T) {
 		}
 	}()
 
-	_, err = waitSizeReachedWithAccept(t, f, testEtcd.Name, 3, 60*time.Second, func(pod *api.Pod) bool {
+	_, err = waitSizeReachedWithAccept(t, f, testEtcd.Name, 3, 60*time.Second, func(pod *v1.Pod) bool {
 		return k8sutil.GetEtcdVersion(pod) == "v3.0.12"
 	})
 	if err != nil {
@@ -137,7 +137,7 @@ func testEtcdUpgrade(t *testing.T) {
 		t.Fatalf("fail to update cluster version: %v", err)
 	}
 
-	_, err = waitSizeReachedWithAccept(t, f, testEtcd.Name, 3, 60*time.Second, func(pod *api.Pod) bool {
+	_, err = waitSizeReachedWithAccept(t, f, testEtcd.Name, 3, 60*time.Second, func(pod *v1.Pod) bool {
 		return k8sutil.GetEtcdVersion(pod) == "v3.1.0-alpha.1"
 	})
 	if err != nil {

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -75,7 +75,7 @@ func testClusterRestoreWithStorageType(t *testing.T, needDataClone bool, bt spec
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 
-	pod, err := f.KubeClient.Pods(f.Namespace).Get(names[0])
+	pod, err := f.KubeClient.Core().Pods(f.Namespace).Get(names[0])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +126,7 @@ func testClusterRestoreWithStorageType(t *testing.T, needDataClone bool, bt spec
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 
-	pod, err = f.KubeClient.Pods(f.Namespace).Get(names[0])
+	pod, err = f.KubeClient.Core().Pods(f.Namespace).Get(names[0])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -22,13 +22,13 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/api/unversioned"
-
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 	"github.com/coreos/etcd/embed"
 	"github.com/coreos/etcd/pkg/netutil"
+
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+	"k8s.io/client-go/1.5/pkg/api/v1"
 )
 
 func TestSelfHosted(t *testing.T) {
@@ -99,7 +99,7 @@ func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
 			Kind:       "EtcdCluster",
 			APIVersion: "coreos.com/v1",
 		},
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			GenerateName: "etcd-test-seed-",
 		},
 		Spec: &spec.ClusterSpec{
@@ -132,7 +132,7 @@ func makeSelfHostedEnabledCluster(genName string, size int) *spec.EtcdCluster {
 			Kind:       "EtcdCluster",
 			APIVersion: "coreos.com/v1",
 		},
-		ObjectMeta: api.ObjectMeta{
+		ObjectMeta: v1.ObjectMeta{
 			GenerateName: genName,
 		},
 		Spec: &spec.ClusterSpec{


### PR DESCRIPTION
This PR includes:
- vendoring change
- k8s client migration change towards client-go/1.5

Most of the client has been changed except leader election package. Expect maybe 2 more weeks before upstream import that.

I have the PR also tested on jenkins for a couple of rounds. All green.