### PR TITLE
k8sutil: make backup service labels same as ClusterListOpt()

### DIFF
--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -110,7 +110,7 @@ func (bm *backupManager) runSidecar() error {
 }
 
 func (bm *backupManager) createBackupReplicaSet(podSpec v1.PodSpec) error {
-	rs := k8sutil.MakeBackupReplicaSet(bm.cluster.Name, podSpec, bm.cluster.AsOwner())
+	rs := k8sutil.NewBackupReplicaSetManifest(bm.cluster.Name, podSpec, bm.cluster.AsOwner())
 	_, err := bm.config.KubeCli.Extensions().ReplicaSets(bm.cluster.Namespace).Create(rs)
 	if err != nil {
 		if !k8sutil.IsKubernetesResourceAlreadyExistError(err) {
@@ -121,7 +121,7 @@ func (bm *backupManager) createBackupReplicaSet(podSpec v1.PodSpec) error {
 }
 
 func (bm *backupManager) createBackupService() error {
-	svc := k8sutil.MakeBackupService(bm.cluster.Name, bm.cluster.AsOwner())
+	svc := k8sutil.NewBackupServiceManifest(bm.cluster.Name, bm.cluster.AsOwner())
 	_, err := bm.config.KubeCli.Core().Services(bm.cluster.Namespace).Create(svc)
 	if err != nil {
 		if !k8sutil.IsKubernetesResourceAlreadyExistError(err) {

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -200,15 +200,12 @@ func backupNameAndLabel(clusterName string) (string, map[string]string) {
 	return name, labels
 }
 
-func MakeBackupReplicaSet(clusterName string, ps v1.PodSpec, owner metatypes.OwnerReference) *v1beta1extensions.ReplicaSet {
+func NewBackupReplicaSetManifest(clusterName string, ps v1.PodSpec, owner metatypes.OwnerReference) *v1beta1extensions.ReplicaSet {
 	name, labels := backupNameAndLabel(clusterName)
 	rs := &v1beta1extensions.ReplicaSet{
 		ObjectMeta: v1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"etcd_cluster": clusterName,
-				"app":          "etcd",
-			},
+			Name:   name,
+			Labels: newLablesForCluster(clusterName),
 		},
 		Spec: v1beta1extensions.ReplicaSetSpec{
 			Selector: &v1beta1extensions.LabelSelector{MatchLabels: labels},
@@ -224,12 +221,12 @@ func MakeBackupReplicaSet(clusterName string, ps v1.PodSpec, owner metatypes.Own
 	return rs
 }
 
-func MakeBackupService(clusterName string, owner metatypes.OwnerReference) *v1.Service {
+func NewBackupServiceManifest(clusterName string, owner metatypes.OwnerReference) *v1.Service {
 	name, labels := backupNameAndLabel(clusterName)
 	svc := &v1.Service{
 		ObjectMeta: v1.ObjectMeta{
 			Name:   name,
-			Labels: labels,
+			Labels: newLablesForCluster(clusterName),
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -333,9 +333,13 @@ func IsKubernetesResourceNotFoundError(err error) bool {
 // We are using internal api types for cluster related.
 func ClusterListOpt(clusterName string) api.ListOptions {
 	return api.ListOptions{
-		LabelSelector: labels.SelectorFromSet(map[string]string{
-			"etcd_cluster": clusterName,
-			"app":          "etcd",
-		}),
+		LabelSelector: labels.SelectorFromSet(newLablesForCluster(clusterName)),
+	}
+}
+
+func newLablesForCluster(clusterName string) map[string]string {
+	return map[string]string{
+		"etcd_cluster": clusterName,
+		"app":          "etcd",
 	}
 }


### PR DESCRIPTION
Since it’s owned by the cluster TPR, backup service should be list-able
in GC.
Backup pods doesn’t need to because replica set manages it.

Also do some refactoring, renaming stuff.