### PR TITLE
s3: refactor prefix code

### DIFF
--- a/pkg/backup/s3_backend_test.go
+++ b/pkg/backup/s3_backend_test.go
@@ -33,7 +33,7 @@ func TestS3BackendPurge(t *testing.T) {
 	if os.Getenv("RUN_INTEGRATION_TEST") != "true" {
 		t.Skip("skipping integration test due to RUN_INTEGRATION_TEST not set")
 	}
-	prefix := randString(8) + "/"
+	prefix := randString(8)
 	s3cli, err := s3.New("test-bucket", prefix, session.Options{
 		Config: aws.Config{
 			Credentials:      credentials.NewStaticCredentials(os.Getenv("MINIO_ACCESS_KEY_ID"), os.Getenv("MINIO_SECRET_ACCESS_KEY"), ""),

--- a/pkg/cluster/backupstorage/s3.go
+++ b/pkg/cluster/backupstorage/s3.go
@@ -19,7 +19,7 @@ type s3 struct {
 }
 
 func NewS3Storage(s3Ctx s3config.S3Context, kubecli kubernetes.Interface, clusterName, ns string, p spec.BackupPolicy) (Storage, error) {
-	s3cli, err := backups3.New(s3Ctx.S3Bucket, clusterName+"/", session.Options{
+	s3cli, err := backups3.New(s3Ctx.S3Bucket, clusterName, session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 	})
 	if err != nil {


### PR DESCRIPTION
Trying to contain the prefix logic in the package itself.

This would help https://github.com/coreos/etcd-operator/pull/689