### PR TITLE
e2e: don't block forever on etcd server ReadyNotify()

### DIFF
--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -89,7 +89,11 @@ func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
 	}
 	defer e.Close()
 
-	<-e.Server.ReadyNotify()
+	select {
+	case <-e.Server.ReadyNotify():
+	case <-time.After(30 * time.Second):
+		t.Fatal("timeout: wait etcd server ready")
+	}
 
 	t.Log("etcdserver is ready")
 


### PR DESCRIPTION
ref: https://github.com/coreos/etcd-operator/issues/693

This would make it not blocking and have better error message