### PR TITLE
backup: add metadata to GET response header

### DIFF
--- a/doc/user/backup_service.md
+++ b/doc/user/backup_service.md
@@ -20,3 +20,7 @@ Request Parameters
 - etcdVersion (optional): backup service checks the compatibility between the latest backup and the etcd server with passed in `etcdVersion`.
 For example, if we want to get a backup for etcd server 3.1.0, we should set etcdVersion to 3.1.0. Backup service will check the if its latest backup can be used to restore a 3.1.0 etcd cluster.
 
+Response Headers
+
+- X-etcd-Version: the etcd cluster version tht the backup was made from
+- X-Revision: the etcd store revision when the backup was made

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -26,6 +26,28 @@ import (
 	"github.com/coreos/etcd-operator/pkg/util"
 )
 
+func TestResponseHeader(t *testing.T) {
+	d, err := setupBackupDir("3.1.0_000000000000000a_etcd.backup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(d)
+	b := &Backup{
+		be: &fileBackend{dir: d},
+	}
+	req := &http.Request{
+		URL: util.MakeBackupURL("ignore", ""),
+	}
+	rr := httptest.NewRecorder()
+	b.serveSnap(rr, req)
+	if get := rr.Header().Get(HTTPHeaderEtcdVersion); get != "3.1.0" {
+		t.Errorf("etcd version want=%s, get=%s", "3.1.0", get)
+	}
+	if get := rr.Header().Get(HTTPHeaderRevision); get != "10" {
+		t.Errorf("revision want=%s, get=%s", "10", get)
+	}
+}
+
 func TestBackupVersionCompatiblity(t *testing.T) {
 	d, err := setupBackupDir("3.0.15_0000000000000002_etcd.backup")
 	if err != nil {

--- a/pkg/backup/version.go
+++ b/pkg/backup/version.go
@@ -26,8 +26,12 @@ var compatibilityMap = map[string]map[string]struct{}{
 	"3.1": {"3.0": struct{}{}, "3.1": struct{}{}},
 }
 
-func getVersionFromBackupName(name string) (string, error) {
-	return getMajorAndMinorVersion(strings.SplitN(name, "_", 2)[0])
+func getMajorMinorVersionFromBackup(name string) (string, error) {
+	return getMajorAndMinorVersion(getVersionFromBackup(name))
+}
+
+func getVersionFromBackup(name string) string {
+	return strings.SplitN(name, "_", 2)[0]
 }
 
 func isVersionCompatible(req, serve string) bool {


### PR DESCRIPTION
For GET /backup requests, set EtcdVersion and Revision in headers.