### PR TITLE
cluster: remove pod with grace period

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -38,7 +38,10 @@ import (
 	"k8s.io/client-go/1.5/pkg/api/v1"
 )
 
-var reconcileInterval = 8 * time.Second
+var (
+	reconcileInterval         = 8 * time.Second
+	podTerminationGracePeriod = int64(5)
+)
 
 type clusterEventType string
 
@@ -433,7 +436,11 @@ func (c *Cluster) removePodAndService(name string) error {
 			return err
 		}
 	}
-	err = c.config.KubeCli.Core().Pods(c.cluster.Namespace).Delete(name, api.NewDeleteOptions(0))
+
+	err = c.config.KubeCli.Core().Pods(c.cluster.Namespace).Delete(
+		name,
+		api.NewDeleteOptions(podTerminationGracePeriod),
+	)
 	if err != nil {
 		if !k8sutil.IsKubernetesResourceNotFoundError(err) {
 			return err

--- a/pkg/garbagecollection/gc.go
+++ b/pkg/garbagecollection/gc.go
@@ -99,6 +99,7 @@ func (gc *GC) collectPods(option api.ListOptions, runningSet map[types.UID]bool)
 			continue
 		}
 		if !runningSet[p.OwnerReferences[0].UID] {
+			// kill bad pods without grace period to kill it immediately
 			err = gc.k8s.Core().Pods(gc.ns).Delete(p.GetName(), api.NewDeleteOptions(0))
 			if err != nil {
 				return err


### PR DESCRIPTION
Give time to etcd to react on SIGTERM. This allows leader transfer to
happen before etcd gets SIGKILLed.

Fix https://github.com/coreos/etcd-operator/issues/677