### PR TITLE
cluster: remove panic

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -211,9 +211,11 @@ func (c *Cluster) Delete() {
 func (c *Cluster) send(ev *clusterEvent) {
 	select {
 	case c.eventCh <- ev:
+		l, ecap := len(c.eventCh), cap(c.eventCh)
+		if l > int(float64(ecap)*0.8) {
+			c.logger.Warningf("eventCh buffer is almost full [%d/%d]", l, ecap)
+		}
 	case <-c.stopCh:
-	default:
-		panic("TODO: too many events queued...")
 	}
 }
 


### PR DESCRIPTION
After second thought, I believe we should simply block the
operator if one of the cluster cannot make progress.

It is either caused by a bug in client-go (unlimited request waiting)
or in our code (forget to set timeout?). If that happens, the best solution
(or simplest solution) would be restarted the operator. That should be
handled at the controller layer.

So in short, we should just let it blocking when it blocks.

Fix https://github.com/coreos/etcd-operator/issues/624