### PR TITLE
controller: best effort recovery on watch failure

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -1,0 +1,60 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/coreos/etcd-operator/pkg/spec"
+
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+)
+
+type rawEvent struct {
+	Type   string
+	Object json.RawMessage
+}
+
+func pollEvent(decoder *json.Decoder) (*Event, *unversioned.Status, error) {
+	re := &rawEvent{}
+	err := decoder.Decode(re)
+	if err != nil {
+		if err == io.EOF {
+			return nil, nil, err
+		}
+		return nil, nil, fmt.Errorf("fail to decode raw event from apiserver (%v)", err)
+	}
+
+	if re.Type == "ERROR" {
+		status := &unversioned.Status{}
+		err = json.Unmarshal(re.Object, status)
+		if err != nil {
+			return nil, nil, fmt.Errorf("fail to decode (%s) into unversioned.Status (%v)", re.Object, err)
+		}
+		return nil, status, nil
+	}
+
+	ev := &Event{
+		Type:   re.Type,
+		Object: &spec.EtcdCluster{},
+	}
+	err = json.Unmarshal(re.Object, ev.Object)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fail to unmarshal EtcdCluster object from data (%s): %v", re.Object, err)
+	}
+	return ev, nil, nil
+}


### PR DESCRIPTION
If this patch works, then operator will not restart when there is not external issues.

Fix https://github.com/coreos/etcd-operator/issues/652.

