### PR TITLE
*: set grace period on pod delete option

### DIFF
--- a/pkg/chaos/chaos.go
+++ b/pkg/chaos/chaos.go
@@ -88,7 +88,7 @@ func (m *Monkeys) CrushPods(ctx context.Context, c *CrashConfig) {
 		}
 
 		for tokill := range tokills {
-			err = m.k8s.Core().Pods(ns).Delete(tokill, api.NewDeleteOptions(0))
+			err = m.k8s.Core().Pods(ns).Delete(tokill, api.NewDeleteOptions(1))
 			if err != nil {
 				logrus.Errorf("failed to kill pod %v: %v", tokill, err)
 				continue

--- a/pkg/garbagecollection/gc.go
+++ b/pkg/garbagecollection/gc.go
@@ -99,8 +99,8 @@ func (gc *GC) collectPods(option api.ListOptions, runningSet map[types.UID]bool)
 			continue
 		}
 		if !runningSet[p.OwnerReferences[0].UID] {
-			// kill bad pods without grace period to kill it immediately
-			err = gc.k8s.Core().Pods(gc.ns).Delete(p.GetName(), api.NewDeleteOptions(0))
+			// use shorter grace period to kill bad pods faster
+			err = gc.k8s.Core().Pods(gc.ns).Delete(p.GetName(), api.NewDeleteOptions(1))
 			if err != nil {
 				return err
 			}

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -333,7 +333,7 @@ func CopyVolume(kubecli kubernetes.Interface, fromClusterName, toClusterName, ns
 		return fmt.Errorf("failed to wait backup copy pod (%s, phase: %s) to succeed: %v", pod.Name, phase, err)
 	}
 	// Delete the pod to detach the volume from the node
-	return kubecli.Core().Pods(ns).Delete(pod.Name, api.NewDeleteOptions(0))
+	return kubecli.Core().Pods(ns).Delete(pod.Name, api.NewDeleteOptions(1))
 }
 
 func copyVolumePodName(clusterName string) string {


### PR DESCRIPTION
We should always set delete option. Otherwise, it would break the
guarantee of “at most one” pod. We definitely don’t want to see that.