### PR TITLE
e2e: disable parallel of self hosted test

### DIFF
--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -37,9 +37,6 @@ func TestSelfHosted(t *testing.T) {
 }
 
 func testCreateSelfHostedCluster(t *testing.T) {
-	if os.Getenv(envParallelTest) == envParallelTestTrue {
-		t.Parallel()
-	}
 	f := framework.Global
 	c := newClusterSpec("test-etcd-", 3)
 	c = clusterWithSelfHosted(c, &spec.SelfHostedPolicy{})
@@ -60,9 +57,6 @@ func testCreateSelfHostedCluster(t *testing.T) {
 }
 
 func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
-	if os.Getenv(envParallelTest) == envParallelTestTrue {
-		t.Parallel()
-	}
 	dir, err := ioutil.TempDir("", "embed-etcd")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Over the past few days, I have observed that self hosted tests failed
due to two tests run at same time, e.g. PR and master, flaketest and
PR. When this happened, it requires 6 nodes for each test and
concurrent tests will exceed our current node size.

Disable it now. Once we have larger jenkins cluster, we can enable it.