### PR TITLE
gc: ignore not found, and not stop on one error

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -161,9 +161,7 @@ func (c *Cluster) create() error {
 		return fmt.Errorf("cluster create: failed to update cluster phase (%v): %v", spec.ClusterPhaseCreating, err)
 	}
 
-	if err := c.gc.CollectCluster(c.cluster.Name, c.cluster.UID); err != nil {
-		return fmt.Errorf("cluster create: failed to clean up conflict resources: %v", err)
-	}
+	c.gc.CollectCluster(c.cluster.Name, c.cluster.UID)
 
 	if c.bm != nil {
 		if err := c.bm.setup(); err != nil {
@@ -367,9 +365,7 @@ func (c *Cluster) Update(e *spec.EtcdCluster) {
 }
 
 func (c *Cluster) delete() {
-	if err := c.gc.CollectCluster(c.cluster.Name, garbagecollection.NullUID); err != nil {
-		c.logger.Errorf("cluster delete: fail to clean up resources %v", err)
-	}
+	c.gc.CollectCluster(c.cluster.Name, garbagecollection.NullUID)
 
 	if c.bm != nil {
 		if err := c.bm.cleanup(); err != nil {


### PR DESCRIPTION
fix https://github.com/coreos/etcd-operator/issues/732

First of all, we should ignore not found error, this could happen if
the full GC also takes place.

Second, on encountering error, we should log the error, but don’t stop
and continue to gc other objects.