### PR TITLE
TPR: change group and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ $ kubectl create -f example/deployment.yaml
 deployment "etcd-operator" created
 ```
 
-etcd operator will create a Kubernetes *Third-Party Resource* (TPR) "EtcdCluster" automatically.
+etcd operator will automatically create a Kubernetes *Third-Party Resource* (TPR) as followed:
 
 ```bash
 $ kubectl get thirdpartyresources
 NAME                      DESCRIPTION             VERSION(S)
-etcd-cluster.coreos.com   Managed etcd clusters   v1
+cluster.etcd.coreos.com   Managed etcd clusters   v1beta1
 ```
 
 ## Create and destroy an etcd cluster
@@ -74,9 +74,9 @@ If you are working with [minikube locally](https://github.com/kubernetes/minikub
 
 ```bash
 $ kubectl create -f example/example-etcd-cluster-nodeport-service.json
-export ETCDCTL_API=3
-export ETCDCTL_ENDPOINTS=$(minikube service example-etcd-cluster-client-service --url)
-etcdctl put foo bar
+$ export ETCDCTL_API=3
+$ export ETCDCTL_ENDPOINTS=$(minikube service example-etcd-cluster-client-service --url)
+$ etcdctl put foo bar
 ```
 
 Destroy etcd cluster:
@@ -109,8 +109,8 @@ Create a json file with the new configuration:
 ```
 $ cat body.json
 {
-  "apiVersion": "coreos.com/v1",
-  "kind": "EtcdCluster",
+  "apiVersion": "etcd.coreos.com/v1beta1",
+  "kind": "Cluster",
   "metadata": {
     "name": "example-etcd-cluster",
     "namespace": "default"
@@ -124,7 +124,7 @@ $ cat body.json
 In another terminal, use the following command to change the cluster size from 3 to 5.
 
 ```
-$ curl -H 'Content-Type: application/json' -X PUT --data @body.json http://127.0.0.1:8080/apis/coreos.com/v1/namespaces/default/etcdclusters/example-etcd-cluster
+$ curl -H 'Content-Type: application/json' -X PUT --data @body.json http://127.0.0.1:8080/apis/etcd.coreos.com/v1beta1/namespaces/default/clusters/example-etcd-cluster
 ```
 
 We should see
@@ -146,8 +146,8 @@ Create a json file with cluster size of 3:
 ```
 $ cat body.json
 {
-  "apiVersion": "coreos.com/v1",
-  "kind": "EtcdCluster",
+  "apiVersion": "etcd.coreos.com/v1beta1",
+  "kind": "Cluster",
   "metadata": {
     "name": "example-etcd-cluster",
     "namespace": "default"
@@ -161,7 +161,7 @@ $ cat body.json
 Apply it to API Server:
 
 ```
-$ curl -H 'Content-Type: application/json' -X PUT --data @body.json http://127.0.0.1:8080/apis/coreos.com/v1/namespaces/default/etcdclusters/example-etcd-cluster
+$ curl -H 'Content-Type: application/json' -X PUT --data @body.json http://127.0.0.1:8080/apis/etcd.coreos.com/v1beta1/namespaces/default/clusters/example-etcd-cluster
 ```
 
 We should see that etcd cluster will eventually reduce to 3 pods:
@@ -314,8 +314,8 @@ Have the following yaml file ready:
 
 ```
 $ cat 3.0-etcd-cluster.yaml
-apiVersion: "coreos.com/v1"
-kind: "EtcdCluster"
+apiVersion: "etcd.coreos.com/v1beta1"
+kind: "Cluster"
 metadata:
   name: "etcd-cluster"
 spec:
@@ -357,8 +357,8 @@ Have following json file ready:
 ```
 $ cat body.json
 {
-  "apiVersion": "coreos.com/v1",
-  "kind": "EtcdCluster",
+  "apiVersion": "etcd.coreos.com/v1beta1",
+  "kind": "Cluster",
   "metadata": {
     "name": "etcd-cluster"
   },
@@ -373,7 +373,7 @@ Then we update the version in spec.
 
 ```
 $ curl -H 'Content-Type: application/json' -X PUT --data @body.json \
-    http://127.0.0.1:8080/apis/coreos.com/v1/namespaces/default/etcdclusters/etcd-cluster
+    http://127.0.0.1:8080/apis/etcd.coreos.com/v1beta1/namespaces/default/clusters/etcd-cluster
 ```
 
 Wait ~30 seconds. The container image version should be updated to v3.1.0:

--- a/client/experimental/client.go
+++ b/client/experimental/client.go
@@ -35,8 +35,8 @@ type Operator interface {
 
 var (
 	groupversion = unversioned.GroupVersion{
-		Group:   "coreos.com",
-		Version: "v1",
+		Group:   spec.TPRGroup,
+		Version: spec.TPRVersion,
 	}
 )
 
@@ -76,7 +76,7 @@ func NewOperator(namespace string) (Operator, error) {
 
 	return &operator{
 		tprClient: tprclient,
-		tprName:   spec.TPRName,
+		tprName:   spec.TPRName(),
 		ns:        namespace,
 	}, nil
 

--- a/doc/design/cluster_restore.md
+++ b/doc/design/cluster_restore.md
@@ -27,8 +27,8 @@ valid BackupPolicy and saved with backup. Now, user can restore the cluster by a
 to previous yaml file:
 
 ```yaml
-apiVersion: "coreos.com/v1"
-kind: "EtcdCluster"
+apiVersion: "etcd.coreos.com/v1beta1"
+kind: "Cluster"
 metadata:
   name: "etcd-A"
 spec:

--- a/doc/design/s3_backup.md
+++ b/doc/design/s3_backup.md
@@ -56,8 +56,8 @@ Or just login into aws console to view it.
 When we create a cluster with backup, we set the backup.storageType to "S3".
 For example, a yaml file would look like:
 ```
-apiVersion: "coreos.com/v1"
-kind: "EtcdCluster"
+apiVersion: "etcd.coreos.com/v1beta1"
+kind: "Cluster"
 metadata:
   name: "etcd-cluster-with-backup"
 spec:

--- a/example/example-etcd-cluster-with-backup.yaml
+++ b/example/example-etcd-cluster-with-backup.yaml
@@ -1,5 +1,5 @@
-apiVersion: "coreos.com/v1"
-kind: "EtcdCluster"
+apiVersion: "etcd.coreos.com/v1beta1"
+kind: "Cluster"
 metadata:
   name: "etcd-cluster-with-backup"
 spec:

--- a/example/example-etcd-cluster.yaml
+++ b/example/example-etcd-cluster.yaml
@@ -1,5 +1,5 @@
-apiVersion: "coreos.com/v1"
-kind: "EtcdCluster"
+apiVersion: "etcd.coreos.com/v1beta1"
+kind: "Cluster"
 metadata:
   name: "example-etcd-cluster"
 spec:

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -234,10 +234,10 @@ func (c *Controller) initResource() (string, error) {
 func (c *Controller) createTPR() error {
 	tpr := &v1beta1extensions.ThirdPartyResource{
 		ObjectMeta: v1.ObjectMeta{
-			Name: spec.TPRName,
+			Name: spec.TPRName(),
 		},
 		Versions: []v1beta1extensions.APIVersion{
-			{Name: "v1"},
+			{Name: spec.TPRVersion},
 		},
 		Description: "Managed etcd clusters",
 	}

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -29,12 +29,18 @@ import (
 const (
 	defaultVersion = "3.1.0"
 
-	TPRName = "etcd-cluster.coreos.com"
+	TPRKind    = "cluster"
+	TPRGroup   = "etcd.coreos.com"
+	TPRVersion = "v1beta1"
 )
 
 var (
 	ErrBackupUnsetRestoreSet = errors.New("spec: backup policy must be set if restore policy is set")
 )
+
+func TPRName() string {
+	return fmt.Sprintf("%s.%s", TPRKind, TPRGroup)
+}
 
 type EtcdCluster struct {
 	unversioned.TypeMeta `json:",inline"`

--- a/pkg/util/k8sutil/tpr_util.go
+++ b/pkg/util/k8sutil/tpr_util.go
@@ -31,8 +31,8 @@ import (
 // TODO: replace this package with Operator client
 
 func WatchClusters(host, ns string, httpClient *http.Client, resourceVersion string) (*http.Response, error) {
-	return httpClient.Get(fmt.Sprintf("%s/apis/coreos.com/v1/namespaces/%s/etcdclusters?watch=true&resourceVersion=%s",
-		host, ns, resourceVersion))
+	return httpClient.Get(fmt.Sprintf("%s/apis/%s/%s/namespaces/%s/clusters?watch=true&resourceVersion=%s",
+		host, spec.TPRGroup, spec.TPRVersion, ns, resourceVersion))
 }
 
 func GetClusterList(restcli *rest.RESTClient, ns string) (*spec.EtcdClusterList, error) {
@@ -62,11 +62,11 @@ func WaitEtcdTPRReady(restcli *rest.RESTClient, interval, timeout time.Duration,
 }
 
 func listClustersURI(ns string) string {
-	return fmt.Sprintf("/apis/coreos.com/v1/namespaces/%s/etcdclusters", ns)
+	return fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters", spec.TPRGroup, spec.TPRVersion, ns)
 }
 
 func GetClusterTPRObject(restcli *rest.RESTClient, ns, name string) (*spec.EtcdCluster, error) {
-	uri := fmt.Sprintf("/apis/coreos.com/v1/namespaces/%s/etcdclusters/%s", ns, name)
+	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters/%s", spec.TPRGroup, spec.TPRVersion, ns, name)
 	b, err := restcli.Get().RequestURI(uri).DoRaw()
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func UpdateClusterTPRObjectUnconditionally(restcli *rest.RESTClient, ns string, 
 }
 
 func updateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
-	uri := fmt.Sprintf("/apis/coreos.com/v1/namespaces/%s/etcdclusters/%s", ns, e.Name)
+	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters/%s", spec.TPRGroup, spec.TPRVersion, ns, e.Name)
 	b, err := restcli.Put().RequestURI(uri).Body(e).DoRaw()
 	if err != nil {
 		return nil, err

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -137,8 +137,8 @@ func killMembers(f *framework.Framework, names ...string) error {
 func newClusterSpec(genName string, size int) *spec.EtcdCluster {
 	return &spec.EtcdCluster{
 		TypeMeta: unversioned.TypeMeta{
-			Kind:       "EtcdCluster",
-			APIVersion: "coreos.com/v1",
+			Kind:       "Cluster",
+			APIVersion: spec.TPRGroup + "/" + spec.TPRVersion,
 		},
 		ObjectMeta: v1.ObjectMeta{
 			GenerateName: genName,
@@ -194,7 +194,7 @@ func clusterWithSelfHosted(ec *spec.EtcdCluster, sh *spec.SelfHostedPolicy) *spe
 }
 
 func createCluster(t *testing.T, f *framework.Framework, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
-	uri := fmt.Sprintf("/apis/coreos.com/v1/namespaces/%s/etcdclusters", f.Namespace)
+	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters", spec.TPRGroup, spec.TPRVersion, f.Namespace)
 	b, err := f.KubeClient.Core().GetRESTClient().Post().Body(e).RequestURI(uri).DoRaw()
 	if err != nil {
 		return nil, err
@@ -221,7 +221,7 @@ func deleteEtcdCluster(t *testing.T, f *framework.Framework, e *spec.EtcdCluster
 		t.Logf("pod (%v): status (%v), node (%v) cmd (%v)", pod.Name, pod.Status.Phase, pod.Spec.NodeName, pod.Spec.Containers[0].Command)
 	}
 
-	uri := fmt.Sprintf("/apis/coreos.com/v1/namespaces/%s/etcdclusters/%s", f.Namespace, e.Name)
+	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters/%s", spec.TPRGroup, spec.TPRVersion, f.Namespace, e.Name)
 	if _, err := f.KubeClient.Core().GetRESTClient().Delete().RequestURI(uri).DoRaw(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Change group to “etcd.coreos.com”; change version to “v1beta1”.

We made this change because it’s impossible to have multiple versions
in one group