### PR TITLE
spec: change EtcdCluster to Cluster

### DIFF
--- a/client/experimentalclient/client.go
+++ b/client/experimentalclient/client.go
@@ -27,10 +27,10 @@ type Operator interface {
 	Update(ctx context.Context, name string, spec spec.ClusterSpec) error
 
 	// Get gets the etcd cluster information.
-	Get(ctx context.Context, name string) (*spec.EtcdCluster, error)
+	Get(ctx context.Context, name string) (*spec.Cluster, error)
 
 	// List lists all etcd clusters.
-	List(ctx context.Context) (*spec.EtcdClusterList, error)
+	List(ctx context.Context) (*spec.ClusterList, error)
 }
 
 var (
@@ -52,8 +52,8 @@ func init() {
 		func(scheme *runtime.Scheme) error {
 			scheme.AddKnownTypes(
 				groupversion,
-				&spec.EtcdCluster{},
-				&spec.EtcdClusterList{},
+				&spec.Cluster{},
+				&spec.ClusterList{},
 				&v1.ListOptions{},
 				&v1.DeleteOptions{},
 			)
@@ -90,7 +90,7 @@ func NewOperator(namespace string) (Operator, error) {
 }
 
 func (o *operator) Create(ctx context.Context, name string, cspec spec.ClusterSpec) error {
-	cluster := &spec.EtcdCluster{
+	cluster := &spec.Cluster{
 		ObjectMeta: v1.ObjectMeta{
 			Name: name,
 		},
@@ -137,8 +137,8 @@ func (o *operator) Update(ctx context.Context, name string, spec spec.ClusterSpe
 	}
 }
 
-func (o *operator) Get(ctx context.Context, name string) (*spec.EtcdCluster, error) {
-	cluster := &spec.EtcdCluster{}
+func (o *operator) Get(ctx context.Context, name string) (*spec.Cluster, error) {
+	cluster := &spec.Cluster{}
 
 	err := o.tprClient.Get().
 		Resource(o.tprName).
@@ -153,8 +153,8 @@ func (o *operator) Get(ctx context.Context, name string) (*spec.EtcdCluster, err
 	return cluster, nil
 }
 
-func (o *operator) List(ctx context.Context) (*spec.EtcdClusterList, error) {
-	clusters := &spec.EtcdClusterList{}
+func (o *operator) List(ctx context.Context) (*spec.ClusterList, error) {
+	clusters := &spec.ClusterList{}
 
 	err := o.tprClient.Get().
 		Resource(o.tprName).

--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -29,11 +29,11 @@ type backupManager struct {
 	logger *logrus.Entry
 
 	config  Config
-	cluster *spec.EtcdCluster
+	cluster *spec.Cluster
 	s       backupstorage.Storage
 }
 
-func newBackupManager(c Config, cl *spec.EtcdCluster, l *logrus.Entry) (*backupManager, error) {
+func newBackupManager(c Config, cl *spec.Cluster, l *logrus.Entry) (*backupManager, error) {
 	bm := &backupManager{
 		config:  c,
 		cluster: cl,

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -52,7 +52,7 @@ const (
 
 type clusterEvent struct {
 	typ     clusterEventType
-	cluster *spec.EtcdCluster
+	cluster *spec.Cluster
 }
 
 type Config struct {
@@ -68,7 +68,7 @@ type Cluster struct {
 
 	config Config
 
-	cluster *spec.EtcdCluster
+	cluster *spec.Cluster
 
 	// in memory state of the cluster
 	// status is the source of truth after Cluster struct is materialized.
@@ -89,7 +89,7 @@ type Cluster struct {
 	gc *garbagecollection.GC
 }
 
-func New(config Config, e *spec.EtcdCluster, stopC <-chan struct{}, wg *sync.WaitGroup) *Cluster {
+func New(config Config, e *spec.Cluster, stopC <-chan struct{}, wg *sync.WaitGroup) *Cluster {
 	lg := logrus.WithField("pkg", "cluster").WithField("cluster-name", e.Name)
 	c := &Cluster{
 		logger:  lg,
@@ -357,7 +357,7 @@ func (c *Cluster) restoreSeedMember() error {
 	return c.startSeedMember(true)
 }
 
-func (c *Cluster) Update(e *spec.EtcdCluster) {
+func (c *Cluster) Update(e *spec.Cluster) {
 	c.send(&clusterEvent{
 		typ:     eventModifyCluster,
 		cluster: e,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -48,7 +48,7 @@ var (
 
 type Event struct {
 	Type   string
-	Object *spec.EtcdCluster
+	Object *spec.Cluster
 }
 
 type Controller struct {
@@ -323,7 +323,7 @@ func (c *Controller) monitor(watchVersion string) (<-chan *Event, <-chan error) 
 	return eventCh, errCh
 }
 
-func (c *Controller) isClustersCacheStale(currentClusters []spec.EtcdCluster) bool {
+func (c *Controller) isClustersCacheStale(currentClusters []spec.Cluster) bool {
 	if len(c.clusterRVs) != len(currentClusters) {
 		return true
 	}

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -50,11 +50,11 @@ func pollEvent(decoder *json.Decoder) (*Event, *unversioned.Status, error) {
 
 	ev := &Event{
 		Type:   re.Type,
-		Object: &spec.EtcdCluster{},
+		Object: &spec.Cluster{},
 	}
 	err = json.Unmarshal(re.Object, ev.Object)
 	if err != nil {
-		return nil, nil, fmt.Errorf("fail to unmarshal EtcdCluster object from data (%s): %v", re.Object, err)
+		return nil, nil, fmt.Errorf("fail to unmarshal Cluster object from data (%s): %v", re.Object, err)
 	}
 	return ev, nil, nil
 }

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -42,14 +42,14 @@ func TPRName() string {
 	return fmt.Sprintf("%s.%s", TPRKind, TPRGroup)
 }
 
-type EtcdCluster struct {
+type Cluster struct {
 	unversioned.TypeMeta `json:",inline"`
 	v1.ObjectMeta        `json:"metadata,omitempty"`
 	Spec                 ClusterSpec   `json:"spec"`
 	Status               ClusterStatus `json:"status"`
 }
 
-func (e *EtcdCluster) AsOwner() metatypes.OwnerReference {
+func (e *Cluster) AsOwner() metatypes.OwnerReference {
 	trueVar := true
 	// TODO: In 1.6 this is gonna be "k8s.io/kubernetes/pkg/apis/meta/v1"
 	// Both api.OwnerReference and metatypes.OwnerReference are combined into that.

--- a/pkg/spec/etcd_cluster_list.go
+++ b/pkg/spec/etcd_cluster_list.go
@@ -16,12 +16,12 @@ package spec
 
 import "k8s.io/client-go/1.5/pkg/api/unversioned"
 
-// EtcdClusterList is a list of etcd clusters.
-type EtcdClusterList struct {
+// ClusterList is a list of etcd clusters.
+type ClusterList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
 	unversioned.ListMeta `json:"metadata,omitempty"`
 	// Items is a list of third party objects
-	Items []EtcdCluster `json:"items"`
+	Items []Cluster `json:"items"`
 }

--- a/pkg/util/k8sutil/tpr_util.go
+++ b/pkg/util/k8sutil/tpr_util.go
@@ -35,13 +35,13 @@ func WatchClusters(host, ns string, httpClient *http.Client, resourceVersion str
 		host, spec.TPRGroup, spec.TPRVersion, ns, resourceVersion))
 }
 
-func GetClusterList(restcli *rest.RESTClient, ns string) (*spec.EtcdClusterList, error) {
+func GetClusterList(restcli *rest.RESTClient, ns string) (*spec.ClusterList, error) {
 	b, err := restcli.Get().RequestURI(listClustersURI(ns)).DoRaw()
 	if err != nil {
 		return nil, err
 	}
 
-	clusters := &spec.EtcdClusterList{}
+	clusters := &spec.ClusterList{}
 	if err := json.Unmarshal(b, clusters); err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func listClustersURI(ns string) string {
 	return fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters", spec.TPRGroup, spec.TPRVersion, ns)
 }
 
-func GetClusterTPRObject(restcli *rest.RESTClient, ns, name string) (*spec.EtcdCluster, error) {
+func GetClusterTPRObject(restcli *rest.RESTClient, ns, name string) (*spec.Cluster, error) {
 	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters/%s", spec.TPRGroup, spec.TPRVersion, ns, name)
 	b, err := restcli.Get().RequestURI(uri).DoRaw()
 	if err != nil {
@@ -76,7 +76,7 @@ func GetClusterTPRObject(restcli *rest.RESTClient, ns, name string) (*spec.EtcdC
 
 // UpdateClusterTPRObject updates the given TPR object.
 // ResourceVersion of the object MUST be set or update will fail.
-func UpdateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
+func UpdateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.Cluster) (*spec.Cluster, error) {
 	if len(e.ResourceVersion) == 0 {
 		return nil, errors.New("k8sutil: resource version is not provided")
 	}
@@ -85,12 +85,12 @@ func UpdateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.EtcdClu
 
 // UpdateClusterTPRObjectUnconditionally updates the given TPR object.
 // This should only be used in tests.
-func UpdateClusterTPRObjectUnconditionally(restcli *rest.RESTClient, ns string, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
+func UpdateClusterTPRObjectUnconditionally(restcli *rest.RESTClient, ns string, e *spec.Cluster) (*spec.Cluster, error) {
 	e.ResourceVersion = ""
 	return updateClusterTPRObject(restcli, ns, e)
 }
 
-func updateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
+func updateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.Cluster) (*spec.Cluster, error) {
 	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters/%s", spec.TPRGroup, spec.TPRVersion, ns, e.Name)
 	b, err := restcli.Put().RequestURI(uri).Body(e).DoRaw()
 	if err != nil {
@@ -99,8 +99,8 @@ func updateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.EtcdClu
 	return readOutCluster(b)
 }
 
-func readOutCluster(b []byte) (*spec.EtcdCluster, error) {
-	cluster := &spec.EtcdCluster{}
+func readOutCluster(b []byte) (*spec.Cluster, error) {
+	cluster := &spec.Cluster{}
 	if err := json.Unmarshal(b, cluster); err != nil {
 		return nil, err
 	}

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -185,8 +185,8 @@ func killMembers(f *framework.Framework, names ...string) error {
 	return nil
 }
 
-func newClusterSpec(genName string, size int) *spec.EtcdCluster {
-	return &spec.EtcdCluster{
+func newClusterSpec(genName string, size int) *spec.Cluster {
+	return &spec.Cluster{
 		TypeMeta: unversioned.TypeMeta{
 			Kind:       "Cluster",
 			APIVersion: spec.TPRGroup + "/" + spec.TPRVersion,
@@ -200,7 +200,7 @@ func newClusterSpec(genName string, size int) *spec.EtcdCluster {
 	}
 }
 
-func etcdClusterWithBackup(ec *spec.EtcdCluster, backupPolicy *spec.BackupPolicy) *spec.EtcdCluster {
+func etcdClusterWithBackup(ec *spec.Cluster, backupPolicy *spec.BackupPolicy) *spec.Cluster {
 	ec.Spec.Backup = backupPolicy
 	return ec
 }
@@ -229,28 +229,28 @@ func newBackupPolicyPV() *spec.BackupPolicy {
 	}
 }
 
-func etcdClusterWithRestore(ec *spec.EtcdCluster, restorePolicy *spec.RestorePolicy) *spec.EtcdCluster {
+func etcdClusterWithRestore(ec *spec.Cluster, restorePolicy *spec.RestorePolicy) *spec.Cluster {
 	ec.Spec.Restore = restorePolicy
 	return ec
 }
 
-func etcdClusterWithVersion(ec *spec.EtcdCluster, version string) *spec.EtcdCluster {
+func etcdClusterWithVersion(ec *spec.Cluster, version string) *spec.Cluster {
 	ec.Spec.Version = version
 	return ec
 }
 
-func clusterWithSelfHosted(ec *spec.EtcdCluster, sh *spec.SelfHostedPolicy) *spec.EtcdCluster {
+func clusterWithSelfHosted(ec *spec.Cluster, sh *spec.SelfHostedPolicy) *spec.Cluster {
 	ec.Spec.SelfHosted = sh
 	return ec
 }
 
-func createCluster(t *testing.T, f *framework.Framework, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
+func createCluster(t *testing.T, f *framework.Framework, e *spec.Cluster) (*spec.Cluster, error) {
 	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters", spec.TPRGroup, spec.TPRVersion, f.Namespace)
 	b, err := f.KubeClient.Core().GetRESTClient().Post().Body(e).RequestURI(uri).DoRaw()
 	if err != nil {
 		return nil, err
 	}
-	res := &spec.EtcdCluster{}
+	res := &spec.Cluster{}
 	if err := json.Unmarshal(b, res); err != nil {
 		return nil, err
 	}
@@ -258,11 +258,11 @@ func createCluster(t *testing.T, f *framework.Framework, e *spec.EtcdCluster) (*
 	return res, nil
 }
 
-func updateEtcdCluster(f *framework.Framework, e *spec.EtcdCluster) (*spec.EtcdCluster, error) {
+func updateEtcdCluster(f *framework.Framework, e *spec.Cluster) (*spec.Cluster, error) {
 	return k8sutil.UpdateClusterTPRObjectUnconditionally(f.KubeClient.Core().GetRESTClient(), f.Namespace, e)
 }
 
-func deleteEtcdCluster(t *testing.T, f *framework.Framework, e *spec.EtcdCluster) error {
+func deleteEtcdCluster(t *testing.T, f *framework.Framework, e *spec.Cluster) error {
 	podList, err := f.KubeClient.Core().Pods(f.Namespace).List(k8sutil.ClusterListOpt(e.Name))
 	if err != nil {
 		return err
@@ -279,7 +279,7 @@ func deleteEtcdCluster(t *testing.T, f *framework.Framework, e *spec.EtcdCluster
 	return waitResourcesDeleted(t, f, e)
 }
 
-func waitResourcesDeleted(t *testing.T, f *framework.Framework, e *spec.EtcdCluster) error {
+func waitResourcesDeleted(t *testing.T, f *framework.Framework, e *spec.Cluster) error {
 	err := retryutil.Retry(5*time.Second, 5, func() (done bool, err error) {
 		list, err := f.KubeClient.Core().Pods(f.Namespace).List(k8sutil.ClusterListOpt(e.Name))
 		if err != nil {
@@ -328,7 +328,7 @@ func waitResourcesDeleted(t *testing.T, f *framework.Framework, e *spec.EtcdClus
 	return nil
 }
 
-func waitBackupDeleted(f *framework.Framework, e *spec.EtcdCluster) error {
+func waitBackupDeleted(f *framework.Framework, e *spec.Cluster) error {
 	err := retryutil.Retry(5*time.Second, 5, func() (done bool, err error) {
 		rl, err := f.KubeClient.Extensions().ReplicaSets(f.Namespace).List(k8sutil.ClusterListOpt(e.Name))
 		if err != nil {


### PR DESCRIPTION
So does EtcdClusterList -> ClusterList

Otherwise, tpr client will complain kind unrecognized "EtcdCLuster".
It seems like it's using Go's reflect.