### PR TITLE
*: fix tpr client

### DIFF
--- a/client/experimentalclient/client.go
+++ b/client/experimentalclient/client.go
@@ -91,7 +91,7 @@ func NewOperator(namespace string) (Operator, error) {
 
 func (o *operator) Create(ctx context.Context, name string, cspec spec.ClusterSpec) error {
 	cluster := &spec.Cluster{
-		ObjectMeta: v1.ObjectMeta{
+		Metadata: v1.ObjectMeta{
 			Name: name,
 		},
 		Spec: cspec,

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -128,7 +128,7 @@ func (c *Cluster) addOneMember() error {
 	}
 	defer etcdcli.Close()
 
-	newMemberName := etcdutil.CreateMemberName(c.cluster.Name, c.memberCounter)
+	newMemberName := etcdutil.CreateMemberName(c.cluster.Metadata.Name, c.memberCounter)
 	newMember := &etcdutil.Member{Name: newMemberName}
 	ctx, _ := context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
 	resp, err := etcdcli.MemberAdd(ctx, []string{newMember.PeerAddr()})
@@ -195,7 +195,7 @@ func (c *Cluster) disasterRecovery(left etcdutil.MemberSet) error {
 	backupNow := false
 	if len(left) > 0 {
 		c.logger.Infof("pods are still running (%v). Will try to make a latest backup from one of them.", left)
-		err := requestBackup(c.cluster.Name)
+		err := requestBackup(c.cluster.Metadata.Name)
 		if err != nil {
 			c.logger.Errorln(err)
 		} else {
@@ -207,7 +207,7 @@ func (c *Cluster) disasterRecovery(left etcdutil.MemberSet) error {
 	} else {
 		// We don't return error if backupnow failed. Instead, we ask if there is previous backup.
 		// If so, we can still continue. Otherwise, it's fatal error.
-		exist, err := checkBackupExist(c.cluster.Name, c.cluster.Spec.Version)
+		exist, err := checkBackupExist(c.cluster.Metadata.Name, c.cluster.Spec.Version)
 		if err != nil {
 			c.logger.Errorln(err)
 			return err

--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -24,14 +24,14 @@ import (
 func (c *Cluster) upgradeOneMember(m *etcdutil.Member) error {
 	c.status.AppendUpgradingCondition(c.cluster.Spec.Version, m.Name)
 
-	pod, err := c.config.KubeCli.Core().Pods(c.cluster.Namespace).Get(m.Name)
+	pod, err := c.config.KubeCli.Core().Pods(c.cluster.Metadata.Namespace).Get(m.Name)
 	if err != nil {
 		return fmt.Errorf("fail to get pod (%s): %v", m.Name, err)
 	}
 	c.logger.Infof("upgrading the etcd member %v from %s to %s", m.Name, k8sutil.GetEtcdVersion(pod), c.cluster.Spec.Version)
 	pod.Spec.Containers[0].Image = k8sutil.MakeEtcdImage(c.cluster.Spec.Version)
 	k8sutil.SetEtcdVersion(pod, c.cluster.Spec.Version)
-	_, err = c.config.KubeCli.Core().Pods(c.cluster.Namespace).Update(pod)
+	_, err = c.config.KubeCli.Core().Pods(c.cluster.Metadata.Namespace).Update(pod)
 	if err != nil {
 		return fmt.Errorf("fail to update the etcd member (%s): %v", m.Name, err)
 	}

--- a/pkg/garbagecollection/gc.go
+++ b/pkg/garbagecollection/gc.go
@@ -62,7 +62,7 @@ func (gc *GC) FullyCollect() error {
 
 	clusterUIDSet := make(map[types.UID]bool)
 	for _, c := range clusters.Items {
-		clusterUIDSet[c.GetUID()] = true
+		clusterUIDSet[c.Metadata.UID] = true
 	}
 
 	option := api.ListOptions{

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -44,20 +44,20 @@ func TPRName() string {
 
 type Cluster struct {
 	unversioned.TypeMeta `json:",inline"`
-	v1.ObjectMeta        `json:"metadata,omitempty"`
+	Metadata             v1.ObjectMeta `json:"metadata,omitempty"`
 	Spec                 ClusterSpec   `json:"spec"`
 	Status               ClusterStatus `json:"status"`
 }
 
-func (e *Cluster) AsOwner() metatypes.OwnerReference {
+func (c *Cluster) AsOwner() metatypes.OwnerReference {
 	trueVar := true
 	// TODO: In 1.6 this is gonna be "k8s.io/kubernetes/pkg/apis/meta/v1"
 	// Both api.OwnerReference and metatypes.OwnerReference are combined into that.
 	return metatypes.OwnerReference{
-		APIVersion: e.APIVersion,
-		Kind:       e.Kind,
-		Name:       e.Name,
-		UID:        e.UID,
+		APIVersion: c.APIVersion,
+		Kind:       c.Kind,
+		Name:       c.Metadata.Name,
+		UID:        c.Metadata.UID,
 		Controller: &trueVar,
 	}
 }

--- a/pkg/spec/etcd_cluster_list.go
+++ b/pkg/spec/etcd_cluster_list.go
@@ -14,14 +14,49 @@
 
 package spec
 
-import "k8s.io/client-go/1.5/pkg/api/unversioned"
+import (
+	"encoding/json"
+
+	"k8s.io/client-go/1.5/pkg/api/unversioned"
+)
 
 // ClusterList is a list of etcd clusters.
 type ClusterList struct {
 	unversioned.TypeMeta `json:",inline"`
 	// Standard list metadata
 	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	unversioned.ListMeta `json:"metadata,omitempty"`
+	Metadata unversioned.ListMeta `json:"metadata,omitempty"`
 	// Items is a list of third party objects
 	Items []Cluster `json:"items"`
+}
+
+// There is known issue with TPR in client-go:
+//   https://github.com/kubernetes/client-go/issues/8
+// Workarounds:
+// - We include `Metadata` field in object explicitly.
+// - we have the code below to work around a known problem with third-party resources and ugorji.
+
+type ClusterListCopy ClusterList
+type ClusterCopy Cluster
+
+func (c *Cluster) UnmarshalJSON(data []byte) error {
+	tmp := ClusterCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := Cluster(tmp)
+	*c = tmp2
+	return nil
+}
+
+func (cl *ClusterList) UnmarshalJSON(data []byte) error {
+	tmp := ClusterListCopy{}
+	err := json.Unmarshal(data, &tmp)
+	if err != nil {
+		return err
+	}
+	tmp2 := ClusterList(tmp)
+	*cl = tmp2
+	return nil
 }

--- a/pkg/util/k8sutil/tpr_util.go
+++ b/pkg/util/k8sutil/tpr_util.go
@@ -76,23 +76,23 @@ func GetClusterTPRObject(restcli *rest.RESTClient, ns, name string) (*spec.Clust
 
 // UpdateClusterTPRObject updates the given TPR object.
 // ResourceVersion of the object MUST be set or update will fail.
-func UpdateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.Cluster) (*spec.Cluster, error) {
-	if len(e.ResourceVersion) == 0 {
+func UpdateClusterTPRObject(restcli *rest.RESTClient, ns string, c *spec.Cluster) (*spec.Cluster, error) {
+	if len(c.Metadata.ResourceVersion) == 0 {
 		return nil, errors.New("k8sutil: resource version is not provided")
 	}
-	return updateClusterTPRObject(restcli, ns, e)
+	return updateClusterTPRObject(restcli, ns, c)
 }
 
 // UpdateClusterTPRObjectUnconditionally updates the given TPR object.
 // This should only be used in tests.
-func UpdateClusterTPRObjectUnconditionally(restcli *rest.RESTClient, ns string, e *spec.Cluster) (*spec.Cluster, error) {
-	e.ResourceVersion = ""
-	return updateClusterTPRObject(restcli, ns, e)
+func UpdateClusterTPRObjectUnconditionally(restcli *rest.RESTClient, ns string, c *spec.Cluster) (*spec.Cluster, error) {
+	c.Metadata.ResourceVersion = ""
+	return updateClusterTPRObject(restcli, ns, c)
 }
 
-func updateClusterTPRObject(restcli *rest.RESTClient, ns string, e *spec.Cluster) (*spec.Cluster, error) {
-	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters/%s", spec.TPRGroup, spec.TPRVersion, ns, e.Name)
-	b, err := restcli.Put().RequestURI(uri).Body(e).DoRaw()
+func updateClusterTPRObject(restcli *rest.RESTClient, ns string, c *spec.Cluster) (*spec.Cluster, error) {
+	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters/%s", spec.TPRGroup, spec.TPRVersion, ns, c.Metadata.Name)
+	b, err := restcli.Put().RequestURI(uri).Body(c).DoRaw()
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -50,7 +50,7 @@ func testCreateCluster(t *testing.T) {
 		}
 	}()
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 60*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 }
@@ -76,7 +76,7 @@ func testStopOperator(t *testing.T, kill bool) {
 		}
 	}()
 
-	names, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 60*time.Second)
+	names, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
@@ -102,10 +102,10 @@ func testStopOperator(t *testing.T, kill bool) {
 		t.Fatal(err)
 	}
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 2, 30*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 2, 30*time.Second); err != nil {
 		t.Fatalf("failed to wait for killed member to die: %v", err)
 	}
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 30*time.Second); err == nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 30*time.Second); err == nil {
 		t.Fatalf("cluster should not be recovered: control is paused")
 	}
 
@@ -120,7 +120,7 @@ func testStopOperator(t *testing.T, kill bool) {
 		}
 	}
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 60*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {
 		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
 	}
 }
@@ -143,7 +143,7 @@ func testEtcdUpgrade(t *testing.T) {
 		}
 	}()
 
-	err = waitSizeAndVersionReached(t, f, testEtcd.Name, "3.0.16", 3, 60*time.Second)
+	err = waitSizeAndVersionReached(t, f, testEtcd.Metadata.Name, "3.0.16", 3, 60*time.Second)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
@@ -154,7 +154,7 @@ func testEtcdUpgrade(t *testing.T) {
 		t.Fatalf("fail to update cluster version: %v", err)
 	}
 
-	err = waitSizeAndVersionReached(t, f, testEtcd.Name, "3.1.0", 3, 60*time.Second)
+	err = waitSizeAndVersionReached(t, f, testEtcd.Metadata.Name, "3.1.0", 3, 60*time.Second)
 	if err != nil {
 		t.Fatalf("failed to wait new version etcd cluster: %v", err)
 	}

--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -61,7 +61,7 @@ func testOneMemberRecovery(t *testing.T) {
 		}
 	}()
 
-	names, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 60*time.Second)
+	names, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
@@ -70,7 +70,7 @@ func testOneMemberRecovery(t *testing.T) {
 	if err := killMembers(f, names[0]); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 60*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {
 		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
 	}
 }
@@ -112,18 +112,18 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, numToKill int, backupPol
 		}
 	}()
 
-	names, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 60*time.Second)
+	names, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 	fmt.Println("reached to 3 members cluster")
-	if err := waitBackupPodUp(f, testEtcd.Name, 60*time.Second); err != nil {
+	if err := waitBackupPodUp(f, testEtcd.Metadata.Name, 60*time.Second); err != nil {
 		t.Fatalf("failed to create backup pod: %v", err)
 	}
 	// No left pod to make a backup from. We need to back up ahead.
 	// If there is any left pod, ooperator should be able to make a backup from it.
 	if numToKill == len(names) {
-		if err := makeBackup(f, testEtcd.Name); err != nil {
+		if err := makeBackup(f, testEtcd.Metadata.Name); err != nil {
 			t.Fatalf("fail to make a latest backup: %v", err)
 		}
 	}
@@ -133,7 +133,7 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, numToKill int, backupPol
 	if err := killMembers(f, toKill...); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 120*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 120*time.Second); err != nil {
 		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
 	}
 	// TODO: add checking of data in etcd

--- a/test/e2e/resize_test.go
+++ b/test/e2e/resize_test.go
@@ -46,7 +46,7 @@ func testResizeCluster3to5(t *testing.T) {
 		}
 	}()
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 60*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 	fmt.Println("reached to 3 members cluster")
@@ -56,7 +56,7 @@ func testResizeCluster3to5(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 5, 60*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 5, 60*time.Second); err != nil {
 		t.Fatalf("failed to resize to 5 members etcd cluster: %v", err)
 	}
 }
@@ -77,7 +77,7 @@ func testResizeCluster5to3(t *testing.T) {
 		}
 	}()
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 5, 90*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 5, 90*time.Second); err != nil {
 		t.Fatalf("failed to create 5 members etcd cluster: %v", err)
 	}
 	fmt.Println("reached to 5 members cluster")
@@ -87,7 +87,7 @@ func testResizeCluster5to3(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 60*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {
 		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
 	}
 }

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -72,7 +72,7 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 		t.Fatal(err)
 	}
 
-	names, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 60*time.Second)
+	names, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
@@ -86,10 +86,10 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 		t.Fatal(err)
 	}
 
-	if err := waitBackupPodUp(f, testEtcd.Name, 60*time.Second); err != nil {
+	if err := waitBackupPodUp(f, testEtcd.Metadata.Name, 60*time.Second); err != nil {
 		t.Fatalf("failed to create backup pod: %v", err)
 	}
-	if err := makeBackup(f, testEtcd.Name); err != nil {
+	if err := makeBackup(f, testEtcd.Metadata.Name); err != nil {
 		t.Fatalf("fail to make a backup: %v", err)
 	}
 	if err := deleteEtcdCluster(t, f, testEtcd); err != nil {
@@ -104,13 +104,13 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 		// - set BackupClusterName to the same name in RestorePolicy.
 		// Then operator will use the existing backup in the same storage and
 		// restore cluster with the same data.
-		origEtcd.GenerateName = ""
-		origEtcd.Name = testEtcd.Name
+		origEtcd.Metadata.GenerateName = ""
+		origEtcd.Metadata.Name = testEtcd.Metadata.Name
 	}
 	waitRestoreTimeout := calculateRestoreWaitTime(needDataClone)
 
 	origEtcd = etcdClusterWithRestore(origEtcd, &spec.RestorePolicy{
-		BackupClusterName: testEtcd.Name,
+		BackupClusterName: testEtcd.Metadata.Name,
 		StorageType:       backupPolicy.StorageType,
 	})
 
@@ -125,7 +125,7 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 		}
 	}()
 
-	names, err = waitUntilSizeReached(t, f, testEtcd.Name, 3, waitRestoreTimeout)
+	names, err = waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, waitRestoreTimeout)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -51,7 +51,7 @@ func testCreateSelfHostedCluster(t *testing.T) {
 		}
 	}()
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 240*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 240*time.Second); err != nil {
 		t.Fatalf("failed to create 3 members self-hosted etcd cluster: %v", err)
 	}
 }
@@ -112,7 +112,7 @@ func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
 		}
 	}()
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Name, 3, 120*time.Second); err != nil {
+	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 120*time.Second); err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 }


### PR DESCRIPTION
There is known issue with TPR in client-go:
https://github.com/kubernetes/client-go/issues/8
Workarounds:
- We include `Metadata` field in object explicitly.
- Copy the solutions from client-go TPR examples to work around a
known problem with third-party resources and ugorji.
```go
type ClusterListCopy ClusterList
type ClusterCopy Cluster

func (c *Cluster) UnmarshalJSON(data []byte) error {
	tmp := ClusterCopy{}
	err := json.Unmarshal(data, &tmp)
	if err != nil {
		return err
	}
	tmp2 := Cluster(tmp)
	*c = tmp2
	return nil
}

func (cl *ClusterList) UnmarshalJSON(data []byte) error {
	tmp := ClusterListCopy{}
	err := json.Unmarshal(data, &tmp)
	if err != nil {
		return err
	}
	tmp2 := ClusterList(tmp)
	*cl = tmp2
	return nil
}
```