### PR TITLE
controller: add panicTimer

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -136,7 +136,11 @@ func (c *Controller) Run() error {
 	eventCh, errCh := c.monitor(watchVersion)
 
 	go func() {
+		pt := newPanicTimer(time.Minute, "unexpected long blocking (> 1 Minute) when handling cluster event")
+
 		for event := range eventCh {
+			pt.start()
+
 			clus := event.Object
 			clus.Spec.Cleanup()
 
@@ -166,6 +170,8 @@ func (c *Controller) Run() error {
 				clustersDeleted.Inc()
 				clustersTotal.Dec()
 			}
+
+			pt.stop()
 		}
 	}()
 	return <-errCh

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/coreos/etcd-operator/pkg/spec"
 
@@ -57,4 +58,32 @@ func pollEvent(decoder *json.Decoder) (*Event, *unversioned.Status, error) {
 		return nil, nil, fmt.Errorf("fail to unmarshal Cluster object from data (%s): %v", re.Object, err)
 	}
 	return ev, nil, nil
+}
+
+// panicTimer panics when it reaches the given duration.
+type panicTimer struct {
+	d   time.Duration
+	msg string
+	t   *time.Timer
+}
+
+func newPanicTimer(d time.Duration, msg string) *panicTimer {
+	return &panicTimer{
+		d:   d,
+		msg: msg,
+	}
+}
+
+func (pt *panicTimer) start() {
+	pt.t = time.AfterFunc(pt.d, func() {
+		panic(pt.msg)
+	})
+}
+
+// stop stops the timer and resets the elapsed duration.
+func (pt *panicTimer) stop() {
+	if pt.t != nil {
+		pt.t.Stop()
+		pt.t = nil
+	}
 }


### PR DESCRIPTION
Panic the controller when it blocks on one operation for too long.
The operation should be non-blocking. Kubernetes should be able to
restart the operator when it panics.

This is just a defensive approach.