### PR TITLE
*: fix client

### DIFF
--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -29,9 +29,10 @@ import (
 const (
 	defaultVersion = "3.1.0"
 
-	TPRKind    = "cluster"
-	TPRGroup   = "etcd.coreos.com"
-	TPRVersion = "v1beta1"
+	TPRKind       = "cluster"
+	TPRKindPlural = "clusters"
+	TPRGroup      = "etcd.coreos.com"
+	TPRVersion    = "v1beta1"
 )
 
 var (


### PR DESCRIPTION
Fix client code as a pre-step to client e2e test:
- pass in kind plural instead of tpr name to Resource().

I have verify it work in e2e. Want to separate them in PRs.