### PR TITLE
*: add spec BackupServiceStatus

### DIFF
--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -170,3 +170,17 @@ func (bm *backupManager) getStatus() (*backupapi.ServiceStatus, error) {
 	defer cancel()
 	return bm.bc.ServiceStatus(ctx)
 }
+
+func backupServiceStatusToTPRBackupServiceStatu(s *backupapi.ServiceStatus) *spec.BackupServiceStatus {
+	bs := &spec.BackupServiceStatus{
+		Backups: s.Backups,
+	}
+	if rb := s.RecentBackup; rb != nil {
+		bs.RecentBackup = &spec.BackupStatus{
+			Size:             rb.Size,
+			Version:          rb.Version,
+			TimeTookInSecond: rb.TimeTookInSecond,
+		}
+	}
+	return bs
+}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -497,7 +497,7 @@ func (c *Cluster) updateLocalBackupStatus() error {
 	if err != nil {
 		return err
 	}
-	c.cluster.Status.BackupServiceStatus = bs
+	c.cluster.Status.BackupServiceStatus = backupServiceStatusToTPRBackupServiceStatu(bs)
 
 	return nil
 }

--- a/pkg/spec/backup.go
+++ b/pkg/spec/backup.go
@@ -60,3 +60,23 @@ type PVSource struct {
 
 type S3Source struct {
 }
+
+type BackupServiceStatus struct {
+	// RecentBackup is status of the most recent backup created by
+	// the backup service
+	RecentBackup *BackupStatus `json:"recentBackup,omitempty"`
+
+	// Backups is the totoal number of existing backups
+	Backups int `json:"backups"`
+}
+
+type BackupStatus struct {
+	// Size is the size of the backup.
+	Size int64 `json:"size"`
+
+	// Version is the version of the backup cluster.
+	Version string `json:"version"`
+
+	// TimeTookInSecond is the total time took to create the backup.
+	TimeTookInSecond int `json:"timeTook"`
+}

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -21,8 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coreos/etcd-operator/pkg/backup/backupapi"
-
 	"k8s.io/client-go/pkg/api/meta/metatypes"
 	"k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
@@ -202,8 +200,7 @@ type ClusterStatus struct {
 	// BackupServiceStatus is the status of the backup service.
 	// BackupServiceStatus only exists when backup is enabled in the
 	// cluster spec.
-	// TODO: redefine backup service status in spec pkg?
-	BackupServiceStatus *backupapi.ServiceStatus `json:"backupServiceStatus,omitempty"`
+	BackupServiceStatus *BackupServiceStatus `json:"backupServiceStatus,omitempty"`
 }
 
 func (cs ClusterStatus) Copy() ClusterStatus {


### PR DESCRIPTION
We should have separate backupapi/ and spec/ ’s BackupServiceStatus.