### PR TITLE
e2e: remove check member ready

### DIFF
--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -126,6 +126,11 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, numToKill int, backupPol
 		if err := makeBackup(f, testEtcd.Metadata.Name); err != nil {
 			t.Fatalf("fail to make a latest backup: %v", err)
 		}
+	} else {
+		// Wait 2*5s to make sure the all pods are up and running.
+		// Otherwise, the last member could have not come up yet.
+		// Thus if we delete any member, it loses quorum and also exits.
+		time.Sleep(10 * time.Second)
 	}
 	toKill := names[:numToKill]
 	logfWithTimestamp(t, "killing pods: %v", toKill)

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -99,11 +99,11 @@ func makeBackup(f *framework.Framework, clusterName string) error {
 }
 
 func waitUntilSizeReached(t *testing.T, f *framework.Framework, clusterName string, size int, timeout time.Duration) ([]string, error) {
-	return waitSizeReachedWithAccept(t, f, clusterName, size, timeout, acceptRunningPod, acceptReadyMember)
+	return waitSizeReachedWithAccept(t, f, clusterName, size, timeout)
 }
 
 func waitSizeAndVersionReached(t *testing.T, f *framework.Framework, clusterName, version string, size int, timeout time.Duration) error {
-	_, err := waitSizeReachedWithAccept(t, f, clusterName, size, timeout, acceptRunningPod, acceptReadyMember, func(pod *v1.Pod) bool {
+	_, err := waitSizeReachedWithAccept(t, f, clusterName, size, timeout, func(pod *v1.Pod) bool {
 		return k8sutil.GetEtcdVersion(pod) == version
 	})
 	return err
@@ -120,6 +120,9 @@ func waitSizeReachedWithAccept(t *testing.T, f *framework.Framework, clusterName
 		var nodeNames []string
 		for i := range podList.Items {
 			pod := &podList.Items[i]
+			if pod.Status.Phase != v1.PodRunning {
+				continue
+			}
 			accepted := true
 			for _, acceptPod := range accepts {
 				if !acceptPod(pod) {
@@ -143,33 +146,6 @@ func waitSizeReachedWithAccept(t *testing.T, f *framework.Framework, clusterName
 		return nil, err
 	}
 	return names, nil
-}
-
-func acceptRunningPod(p *v1.Pod) bool {
-	return p.Status.Phase == v1.PodRunning
-}
-
-func acceptReadyMember(p *v1.Pod) bool {
-	return checkMemberReady(fmt.Sprintf("http://%s:2379", p.Status.PodIP))
-}
-
-func checkMemberReady(url string) bool {
-	cfg := clientv3.Config{
-		Endpoints:   []string{url},
-		DialTimeout: constants.DefaultDialTimeout,
-	}
-	etcdcli, err := clientv3.New(cfg)
-	if err != nil {
-		return false
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
-	_, err = etcdcli.Get(ctx, "/", clientv3.WithSerializable())
-	cancel()
-	etcdcli.Close()
-	if err != nil {
-		return false
-	}
-	return true
 }
 
 func killMembers(f *framework.Framework, names ...string) error {


### PR DESCRIPTION
point 4 in issue: https://github.com/coreos/etcd-operator/issues/788

Just sleep a little bit instead of relying on pod IP.