### PR TITLE
hack/test: call codecov bash script from inside unittest

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -60,6 +60,8 @@ function unittest_pass {
 			rm profile.out
 		fi
 	done
+	# Send reports to codecov, CODECOV_TOKEN env must be present in Jenkins
+	curl -s https://codecov.io/bash | bash
 }
 
 for p in $PASSES; do


### PR DESCRIPTION
hack/test: add codecov reporting script

Calls the script to send the coverage reports to codecov everytime the unit tests are run.
Previously part of the jenkins bash script.

fix #719 

/cc @hongchaodeng @xiang90 