### PR TITLE
README.md: add codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # etcd operator
 
 [![Build Status](https://jenkins-etcd-public.prod.coreos.systems/buildStatus/icon?job=etcd-operator-master)](https://jenkins-etcd-public.prod.coreos.systems/job/etcd-operator-master/)
-[![codecov](https://codecov.io/gh/coreos/etcd-operator/branch/master/graph/badge.svg?maxAge=300)](https://codecov.io/gh/coreos/etcd-operator)
+[![codecov](https://codecov.io/gh/coreos/etcd-operator/branch/master/graph/badge.svg?maxAge=300?precision=1)](https://codecov.io/gh/coreos/etcd-operator)
 
 ### Project status: beta
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # etcd operator
 
 [![Build Status](https://jenkins-etcd-public.prod.coreos.systems/buildStatus/icon?job=etcd-operator-master)](https://jenkins-etcd-public.prod.coreos.systems/job/etcd-operator-master/)
+[![codecov](https://codecov.io/gh/coreos/etcd-operator/branch/master/graph/badge.svg?maxAge=300)](https://codecov.io/gh/coreos/etcd-operator)
 
 ### Project status: beta
 


### PR DESCRIPTION
README.md: add codecov badge

Added markdown to show code coverage and more importantly link to the etcd-operator codecov repo for detailed coverage reports.

The coverage percentage shown is not for the entire project since that number is calculated from the pkgs that actually have unit tests (2 at the moment). 

#719 

/cc @hongchaodeng @xiang90 