### PR TITLE
codecov.yaml: turn off pr coverage reports

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,2 @@
+# Pull Request comment report
+comment: off


### PR DESCRIPTION
The [codecov.yaml](https://docs.codecov.io/docs/codecov-yaml) file is used to change the default behavior of the codecov repo.

After this merge the codecov pr comment will be disabled. Will still be generated for this pr.