### PR TITLE
*: add total size into backup status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Backup creation time is added in backup status.
+- Total size of backups time is added in backup service status.
 
 ### Changed
 

--- a/pkg/backup/backend.go
+++ b/pkg/backup/backend.go
@@ -26,5 +26,8 @@ type backend interface {
 	// total returns the total number of available backups.
 	total() (int, error)
 
+	// total returns the total size of the backups.
+	totalSize() (int64, error)
+
 	purge(maxBackupFiles int) error
 }

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -213,7 +213,7 @@ func (b *Backup) writeSnap(m *etcdutil.Member, rev int64) error {
 
 	bs := backupapi.BackupStatus{
 		CreationTime:     time.Now(),
-		Size:             n,
+		Size:             toMB(n),
 		Version:          resp.Version,
 		TimeTookInSecond: int(time.Since(start).Seconds() + 1),
 	}

--- a/pkg/backup/backupapi/types.go
+++ b/pkg/backup/backupapi/types.go
@@ -21,16 +21,19 @@ type ServiceStatus struct {
 	// the backup service
 	RecentBackup *BackupStatus `json:"recentBackup,omitempty"`
 
-	// Backups is the totoal number of existing backups
+	// Backups is the totoal number of existing backups.
 	Backups int `json:"backups"`
+
+	// BackupSize is the total size of existing backups in MB.
+	BackupSize float64 `json:"backupSize"`
 }
 
 type BackupStatus struct {
 	// Creation time of the backup.
 	CreationTime time.Time `json:"creationTime"`
 
-	// Size is the size of the backup.
-	Size int64 `json:"size"`
+	// Size is the size of the backup in MB.
+	Size float64 `json:"size"`
 
 	// Version is the version of the backup cluster.
 	Version string `json:"version"`

--- a/pkg/backup/file.go
+++ b/pkg/backup/file.go
@@ -125,3 +125,17 @@ func (fb *fileBackend) total() (int, error) {
 
 	return len(filterAndSortBackups(names)), nil
 }
+
+func (fb *fileBackend) totalSize() (int64, error) {
+	files, err := ioutil.ReadDir(fb.dir)
+	if err != nil {
+		return -1, err
+	}
+	var size int64
+
+	for _, f := range files {
+		size += f.Size()
+	}
+
+	return size, nil
+}

--- a/pkg/backup/http.go
+++ b/pkg/backup/http.go
@@ -118,8 +118,14 @@ func (b *Backup) serveStatus(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to get total number of backups", http.StatusInternalServerError)
 		return
 	}
+	ts, err := b.be.totalSize()
+	if err != nil {
+		http.Error(w, "failed to get total size of backups", http.StatusInternalServerError)
+		return
+	}
 	s := backupapi.ServiceStatus{
-		Backups: t,
+		Backups:    t,
+		BackupSize: toMB(ts),
 	}
 	if len(b.recentBackupsStatus) != 0 {
 		s.RecentBackup = &b.recentBackupsStatus[len(b.recentBackupsStatus)-1]

--- a/pkg/backup/s3.go
+++ b/pkg/backup/s3.go
@@ -102,3 +102,7 @@ func (sb *s3Backend) total() (int, error) {
 	}
 	return len(filterAndSortBackups(names)), err
 }
+
+func (sb *s3Backend) totalSize() (int64, error) {
+	return sb.S3.TotalSize()
+}

--- a/pkg/backup/util.go
+++ b/pkg/backup/util.go
@@ -86,3 +86,7 @@ func (bn backupNames) Less(i, j int) bool {
 func (bn backupNames) Swap(i, j int) {
 	bn[i], bn[j] = bn[j], bn[i]
 }
+
+func toMB(s int64) float64 {
+	return float64(s) / (1024 * 1024)
+}

--- a/pkg/spec/backup.go
+++ b/pkg/spec/backup.go
@@ -70,14 +70,17 @@ type BackupServiceStatus struct {
 
 	// Backups is the totoal number of existing backups
 	Backups int `json:"backups"`
+
+	// BackupSize is the total size of existing backups in MB.
+	BackupSize float64 `json:"backupSize"`
 }
 
 type BackupStatus struct {
 	// Creation time of the backup.
 	CreationTime time.Time `json:"creationTime"`
 
-	// Size is the size of the backup.
-	Size int64 `json:"size"`
+	// Size is the size of the backup in MB.
+	Size float64 `json:"size"`
 
 	// Version is the version of the backup cluster.
 	Version string `json:"version"`


### PR DESCRIPTION
Also change size from int64 to float64. It is not a breaking change since JSON does not differentiate about int and float (actually number is double type in JSON). 