### PR TITLE
spec: PodPolicy `resourceRequirements` field is renamed to `resources`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Changed
 
+- PodPolicy `resourceRequirements` field is renamed to `resources`
+
 ### Removed
 
 ### Fixed

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -122,9 +122,9 @@ type PodPolicy struct {
 	// the etcd members in the same cluster onto the same node.
 	AntiAffinity bool `json:"antiAffinity"`
 
-	// ResourceRequirements is the resource requirements for the etcd container.
+	// Resources is the resource requirements for the etcd container.
 	// This field cannot be updated once the cluster is created.
-	ResourceRequirements v1.ResourceRequirements `json:"resourceRequirements"`
+	Resources v1.ResourceRequirements `json:"resources"`
 }
 
 func (c *ClusterSpec) Validate() error {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -253,7 +253,7 @@ func NewEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 	}
 	container := containerWithLivenessProbe(etcdContainer(commands, cs.Version), etcdLivenessProbe())
 	if cs.Pod != nil {
-		container = containerWithRequirements(container, cs.Pod.ResourceRequirements)
+		container = containerWithRequirements(container, cs.Pod.Resources)
 	}
 	pod := &v1.Pod{
 		ObjectMeta: v1.ObjectMeta{

--- a/pkg/util/k8sutil/self_hosted.go
+++ b/pkg/util/k8sutil/self_hosted.go
@@ -73,7 +73,7 @@ func NewSelfHostedEtcdPod(name string, initialCluster []string, clusterName, sta
 
 	c := etcdContainer(commands, cs.Version)
 	if cs.Pod != nil {
-		c = containerWithRequirements(c, cs.Pod.ResourceRequirements)
+		c = containerWithRequirements(c, cs.Pod.Resources)
 	}
 	c.Env = []v1.EnvVar{envPodIP}
 	pod := &v1.Pod{


### PR DESCRIPTION
Make it more consistent with k8s naming. PromO also uses this naming.