### PR TITLE
test/e2e: add env to skip tests

### DIFF
--- a/test/e2e/cluster_status_test.go
+++ b/test/e2e/cluster_status_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestBackupStatus(t *testing.T) {
 	if os.Getenv(framework.EnvCloudProvider) == "aws" {
-		t.Skip("skipping...")
+		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
 	}
 
 	f := framework.Global

--- a/test/e2e/cluster_status_test.go
+++ b/test/e2e/cluster_status_test.go
@@ -16,6 +16,7 @@ package e2e
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -25,6 +26,10 @@ import (
 )
 
 func TestBackupStatus(t *testing.T) {
+	if os.Getenv(framework.EnvCloudProvider) == "aws" {
+		t.Skip("skipping...")
+	}
+
 	f := framework.Global
 
 	bp := newBackupPolicyPV()

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -30,6 +30,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const (
+	EnvCloudProvider = "E2E_CLOUD_PROVIDER"
+)
+
 var Global *Framework
 
 type Framework struct {

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestClusterRestore(t *testing.T) {
 	if os.Getenv(framework.EnvCloudProvider) == "aws" {
-		t.Skip("skipping test due to relying on PodIP reachability")
+		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
 	}
 
 	t.Run("restore cluster from backup", func(t *testing.T) {

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -40,7 +40,7 @@ func TestClusterRestore(t *testing.T) {
 
 func TestClusterRestoreS3(t *testing.T) {
 	if os.Getenv(framework.EnvCloudProvider) == "aws" {
-		t.Skip("skipping test due to relying on PodIP reachability")
+		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
 	}
 
 	if os.Getenv("AWS_TEST_ENABLED") != "true" {

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -28,6 +28,10 @@ import (
 )
 
 func TestClusterRestore(t *testing.T) {
+	if os.Getenv(framework.EnvCloudProvider) == "aws" {
+		t.Skip("skipping test due to relying on PodIP reachability")
+	}
+
 	t.Run("restore cluster from backup", func(t *testing.T) {
 		t.Run("restore from the same name cluster", testClusterRestoreSameName)
 		t.Run("restore from a different name cluster", testClusterRestoreDifferentName)
@@ -35,6 +39,10 @@ func TestClusterRestore(t *testing.T) {
 }
 
 func TestClusterRestoreS3(t *testing.T) {
+	if os.Getenv(framework.EnvCloudProvider) == "aws" {
+		t.Skip("skipping test due to relying on PodIP reachability")
+	}
+
 	if os.Getenv("AWS_TEST_ENABLED") != "true" {
 		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
 	}

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -38,7 +38,7 @@ func TestSelfHosted(t *testing.T) {
 
 func testCreateSelfHostedCluster(t *testing.T) {
 	if os.Getenv(framework.EnvCloudProvider) == "aws" {
-		t.Skip("skipping test due to relying on PodIP reachability")
+		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
 	}
 
 	f := framework.Global
@@ -62,7 +62,7 @@ func testCreateSelfHostedCluster(t *testing.T) {
 
 func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
 	if os.Getenv(framework.EnvCloudProvider) == "aws" {
-		t.Skip("skipping test due to relying on PodIP reachability")
+		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
 	}
 
 	dir, err := ioutil.TempDir("", "embed-etcd")

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -37,6 +37,10 @@ func TestSelfHosted(t *testing.T) {
 }
 
 func testCreateSelfHostedCluster(t *testing.T) {
+	if os.Getenv(framework.EnvCloudProvider) == "aws" {
+		t.Skip("skipping test due to relying on PodIP reachability")
+	}
+
 	f := framework.Global
 	c := newClusterSpec("test-etcd-", 3)
 	c = clusterWithSelfHosted(c, &spec.SelfHostedPolicy{})
@@ -57,6 +61,10 @@ func testCreateSelfHostedCluster(t *testing.T) {
 }
 
 func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
+	if os.Getenv(framework.EnvCloudProvider) == "aws" {
+		t.Skip("skipping test due to relying on PodIP reachability")
+	}
+
 	dir, err := ioutil.TempDir("", "embed-etcd")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Added an environment variable to skip 3 tests(ClusterRestore,SelfHosted and BackupStatus) that fail consistently on an AWS cluster. This is for ease of debugging on AWS.

/cc @hongchaodeng @xiang90 