### PR TITLE
e2e: skip test on aws

### DIFF
--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -87,6 +87,9 @@ func testDisasterRecovery2Members(t *testing.T) {
 // testDisasterRecoveryAll tests disaster recovery that
 // we should make a backup ahead and ooperator will recover cluster from it.
 func testDisasterRecoveryAll(t *testing.T) {
+	if os.Getenv(framework.EnvCloudProvider) == "aws" {
+		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
+	}
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -153,6 +156,9 @@ func testS3MajorityDown(t *testing.T) {
 }
 
 func testS3AllDown(t *testing.T) {
+	if os.Getenv(framework.EnvCloudProvider) == "aws" {
+		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
+	}
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}


### PR DESCRIPTION
These two tests are relying on pod IP reachability.
Will fix them later.