### PR TITLE
test: get rid of KUBERNETES_KUBECONFIG_PATH

### DIFF
--- a/client/cliente2e/test
+++ b/client/cliente2e/test
@@ -13,5 +13,5 @@ IMAGE=${E2E_IMAGE} ./client/cliente2e/build
 echo "test starts..."
 go test ./client/cliente2e \
   --e2e-image ${E2E_IMAGE} \
-  --kubeconfig ${KUBERNETES_KUBECONFIG_PATH} \
+  --kubeconfig ${KUBECONFIG} \
   --namespace ${TEST_NAMESPACE}

--- a/hack/test
+++ b/hack/test
@@ -45,7 +45,7 @@ function build_pass {
 
 function e2e_pass {
 	TEST_PKGS=`go list ./test/e2e/... | grep -v framework`
-	go test ${TEST_PKGS} -timeout 30m --race --kubeconfig $KUBERNETES_KUBECONFIG_PATH --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
+	go test ${TEST_PKGS} -timeout 30m --race --kubeconfig $KUBECONFIG --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
 }
 
 function unittest_pass {


### PR DESCRIPTION
That's jenkins specific variable.
We should use KUBECONFIG instead.