### PR TITLE
test_check: ignore _test

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -13,6 +13,7 @@ find_files() {
       \( \
         -wholename './_output' \
         -o -wholename '*/vendor/*' \
+        -o -wholename '*/_test/*' \
       \) -prune \
     \) -name '*.go'
 }


### PR DESCRIPTION
We put k8s under `_test/` .

[skip ci]