### PR TITLE
*: update default etcd version to 3.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Starting to serve on 127.0.0.1:8080
 ```
 
 Have following json file ready:
-(Note that the version field is changed from 3.0.16 to 3.1.0)
+(Note that the version field is changed from 3.0.16 to 3.1.2)
 
 ```
 $ cat body.json
@@ -368,7 +368,7 @@ $ cat body.json
   },
   "spec": {
     "size": 3,
-    "version": "3.1.0"
+    "version": "3.1.2"
   }
 }
 ```
@@ -380,11 +380,11 @@ $ curl -H 'Content-Type: application/json' -X PUT --data @body.json \
     http://127.0.0.1:8080/apis/etcd.coreos.com/v1beta1/namespaces/default/clusters/example-etcd-cluster
 ```
 
-Wait ~30 seconds. The container image version should be updated to v3.1.0:
+Wait ~30 seconds. The container image version should be updated to v3.1.2:
 
 ```
 $ kubectl get pod example-etcd-cluster-0000 -o yaml | grep "image:" | uniq
-    image: quay.io/coreos/etcd:v3.1.0
+    image: quay.io/coreos/etcd:v3.1.2
 ```
 
 Check the other two pods and you should see the same result.

--- a/doc/user/spec_examples.md
+++ b/doc/user/spec_examples.md
@@ -52,7 +52,7 @@ See [example](../../example/example-etcd-cluster-with-backup.yaml) .
 ```yaml
 spec:
   size: 3
-  version: "3.1.0"
+  version: "3.1.2"
   backup:
     backupIntervalInSecond: 300
     maxBackups: 5
@@ -72,7 +72,7 @@ metadata:
   name: "cluster-a"
 spec:
   size: 3
-  version: "3.1.0"
+  version: "3.1.2"
   backup:
     backupIntervalInSecond: 300
     maxBackups: 5
@@ -93,7 +93,7 @@ metadata:
   name: "cluster-a"
 spec:
   size: 3
-  version: "3.1.0"
+  version: "3.1.2"
   backup:
     backupIntervalInSecond: 300
     maxBackups: 5
@@ -114,7 +114,7 @@ metadata:
   name: "cluster-b"
 spec:
   size: 3
-  version: "3.1.0"
+  version: "3.1.2"
   backup:
     backupIntervalInSecond: 300
     maxBackups: 5

--- a/example/example-etcd-cluster-with-backup.yaml
+++ b/example/example-etcd-cluster-with-backup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "example-etcd-cluster-with-backup"
 spec:
   size: 3
-  version: "3.1.0"
+  version: "3.1.2"
   backup:
     # short snapshot interval for testing, do not use this in production!
     backupIntervalInSecond: 30

--- a/example/example-etcd-cluster.yaml
+++ b/example/example-etcd-cluster.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "3.1.0"
+  version: "3.1.2"

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	defaultVersion = "3.1.0"
+	defaultVersion = "3.1.2"
 
 	TPRKind        = "cluster"
 	TPRKindPlural  = "clusters"
@@ -75,10 +75,10 @@ type ClusterSpec struct {
 	// The etcd-operator will eventually make the etcd cluster version
 	// equal to the expected version.
 	//
-	// The version must follow the [semver]( http://semver.org) format, for example "3.1.0".
+	// The version must follow the [semver]( http://semver.org) format, for example "3.1.2".
 	// Only etcd released versions are supported: https://github.com/coreos/etcd/releases
 	//
-	// If version is not set, default is "3.1.0".
+	// If version is not set, default is "3.1.2".
 	Version string `json:"version"`
 
 	// Paused is to pause the control of the operator for the etcd cluster.

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -148,13 +148,13 @@ func testEtcdUpgrade(t *testing.T) {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 
-	testEtcd = etcdClusterWithVersion(testEtcd, "3.1.0")
+	testEtcd = etcdClusterWithVersion(testEtcd, "3.1.2")
 
 	if _, err := updateEtcdCluster(f, testEtcd); err != nil {
 		t.Fatalf("fail to update cluster version: %v", err)
 	}
 
-	err = waitSizeAndVersionReached(t, f, testEtcd.Metadata.Name, "3.1.0", 3, 60*time.Second)
+	err = waitSizeAndVersionReached(t, f, testEtcd.Metadata.Name, "3.1.2", 3, 60*time.Second)
 	if err != nil {
 		t.Fatalf("failed to wait new version etcd cluster: %v", err)
 	}


### PR DESCRIPTION
A raft issue is fixed in 3.1.2 . Should recommend users to use it.