### PR TITLE
ci: create role and binding if rbac present

### DIFF
--- a/doc/user/rbac.md
+++ b/doc/user/rbac.md
@@ -103,7 +103,7 @@ If you need use s3 backup, add these to above input:
   - secrets
   - configmaps
   verbs:
-  - read
+  - get
 ```
 
 ### Create Service Account

--- a/hack/ci/create_rbac_role
+++ b/hack/ci/create_rbac_role
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Create ClusterRole
+cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: etcd-operator
+rules:
+- apiGroups:
+  - etcd.coreos.com
+  resources:
+  - clusters
+  verbs:
+  - "*"
+- apiGroups:
+  - extensions
+  resources:
+  - thirdpartyresources
+  verbs:
+  - create
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  verbs:
+  - "*"
+- apiGroups:
+  - extensions
+  resources:
+  - replicasets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get
+EOF
+
+# Create ClusterRoleBinding in namespace
+cat <<EOF | kubectl create -f -
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: etcd-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: etcd-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: $TEST_NAMESPACE
+EOF
+
+# Check if ClusterRole and ClusterRoleBinding created
+kubectl --kubeconfig=$KUBECONFIG get clusterrole etcd-operator 1> /dev/null
+kubectl --kubeconfig=$KUBECONFIG get clusterrolebinding etcd-operator 1> /dev/null

--- a/hack/ci/rbac_utils.sh
+++ b/hack/ci/rbac_utils.sh
@@ -4,8 +4,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Create ClusterRole
-cat <<EOF | kubectl create -f -
+function rbac_cleanup {
+	kubectl delete clusterrolebinding etcd-operator
+	kubectl delete clusterrole etcd-operator
+}
+
+function rbac_setup() {
+    # Create ClusterRole
+    cat <<EOF | kubectl create -f -
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -53,8 +59,8 @@ rules:
   - get
 EOF
 
-# Create ClusterRoleBinding in namespace
-cat <<EOF | kubectl create -f -
+    # Create ClusterRoleBinding in namespace
+    cat <<EOF | kubectl create -f -
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
@@ -68,7 +74,4 @@ subjects:
   name: default
   namespace: $TEST_NAMESPACE
 EOF
-
-# Check if ClusterRole and ClusterRoleBinding created
-kubectl --kubeconfig=$KUBECONFIG get clusterrole etcd-operator 1> /dev/null
-kubectl --kubeconfig=$KUBECONFIG get clusterrolebinding etcd-operator 1> /dev/null
+}

--- a/hack/test
+++ b/hack/test
@@ -44,17 +44,14 @@ function build_pass {
 	IMAGE=$OPERATOR_IMAGE hack/build/operator/build
 }
 
-function rbac_cleanup {
-	kubectl delete clusterrolebinding etcd-operator
-	kubectl delete clusterrole etcd-operator
-}
-
 function e2e_pass {
+	# TODO: Move the scripts for rbac into test/e2e/utils.go
 	# Enable rbac if present
 	if kubectl --kubeconfig $KUBECONFIG get clusterrole 1> /dev/null ; then
+		source hack/ci/rbac_utils.sh
 		trap rbac_cleanup EXIT
 		# Create role and binding
-		if "hack/ci/create_rbac_role"; then
+		if rbac_setup ; then
 			echo "RBAC setup success! ==="
 		else
 			echo "RBAC setup fail! ==="

--- a/hack/test
+++ b/hack/test
@@ -44,7 +44,24 @@ function build_pass {
 	IMAGE=$OPERATOR_IMAGE hack/build/operator/build
 }
 
+function rbac_cleanup {
+	kubectl delete clusterrolebinding etcd-operator
+	kubectl delete clusterrole etcd-operator
+}
+
 function e2e_pass {
+	# Enable rbac if present
+	if kubectl --kubeconfig $KUBECONFIG get clusterrole 1> /dev/null ; then
+		trap rbac_cleanup EXIT
+		# Create role and binding
+		if "hack/ci/create_rbac_role"; then
+			echo "RBAC setup success! ==="
+		else
+			echo "RBAC setup fail! ==="
+			exit 1
+		fi
+	fi
+
 	TEST_PKGS=`go list ./test/e2e/... | grep -v framework`
 	go test ${TEST_PKGS} -timeout 30m --race --kubeconfig $KUBECONFIG --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
 }


### PR DESCRIPTION
Create a ClusterRole and ClusterRoleBinding if k8s supports rbac.
Also change the rbac documentation for the correct verb to use for permissions to the configmap and secrets.

#840 

/cc @xiang90 @hongchaodeng 