### PR TITLE
k8sutil: work around kubelet race not setting correct pod env

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/labels"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 )
 
@@ -78,7 +77,7 @@ func init() {
 	flag.Parse()
 
 	// Workaround for watching TPR resource.
-	restCfg, err := rest.InClusterConfig()
+	restCfg, err := k8sutil.InClusterConfig()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
close https://github.com/coreos/etcd-operator/issues/731

I have tested the DNS lookup code and it works.