### PR TITLE
README: change link for build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # etcd operator
-
+Kubernetes stable :
 [![Build Status](https://jenkins-etcd-public.prod.coreos.systems/buildStatus/icon?job=etcd-operator-master)](https://jenkins-etcd-public.prod.coreos.systems/job/etcd-operator-master/)
+
+Kubernetes master :
+[![Build Status](https://jenkins-etcd-public.prod.coreos.systems/buildStatus/icon?job=etcd-operator-master-k8s-master)](https://jenkins-etcd-public.prod.coreos.systems/job/etcd-operator-master-k8s-master/)
 
 ### Project status: beta
 


### PR DESCRIPTION
Change the build badge link to point to the new jenkins job which tests against upstream k8s master.
[skip ci]

/cc @hongchaodeng 