### PR TITLE
ci: add test selector flag in jenkins script

### DIFF
--- a/hack/ci/run
+++ b/hack/ci/run
@@ -34,11 +34,13 @@ GIT_VERSION=$(git rev-parse HEAD)
 export OPERATOR_IMAGE="gcr.io/coreos-k8s-scale-testing/etcd-operator:${GIT_VERSION}"
 export PARALLEL_TEST="true"
 export RUN_INTEGRATION_TEST="true"
+export E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-.*}
 
 echo "UNIQUE_BUILD_NAME: ${UNIQUE_BUILD_NAME}"
 echo "OPERATOR_IMAGE: ${OPERATOR_IMAGE}"
 echo "TEST_NAMESPACE: ${TEST_NAMESPACE}"
 echo "AWS_TEST_ENABLED: ${AWS_TEST_ENABLED}"
+echo "E2E_TEST_SELECTOR: ${E2E_TEST_SELECTOR}"
 
 gcloud docker -a # have docker command access to gcloud 
 

--- a/hack/test
+++ b/hack/test
@@ -60,7 +60,9 @@ function e2e_pass {
 	fi
 
 	TEST_PKGS=`go list ./test/e2e/... | grep -v framework`
-	go test ${TEST_PKGS} -timeout 30m --race --kubeconfig $KUBECONFIG --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
+	# Run all the tests by default
+	E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-.*}
+	go test ${TEST_PKGS} -run "$E2E_TEST_SELECTOR" -timeout 30m --race --kubeconfig $KUBECONFIG --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
 }
 
 function unit_pass {


### PR DESCRIPTION
Additional flag to selectively filter e2e tests for ease of testing on jenkins. The default behavior to run all e2e tests remains the same.

/cc @hongchaodeng @xiang90 