### PR TITLE
spec/ClusterStatus: track healthy pods

### DIFF
--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -193,6 +193,10 @@ type ClusterStatus struct {
 
 	// Size is the current size of the cluster
 	Size int `json:"size"`
+	// ReadyPods are the etcd pods that are ready to serve requests
+	ReadyPods []string `json:"readyPods"`
+	// UnreadyPods are the etcd pods not ready to serve requests
+	UnreadyPods []string `json:"unreadyPods"`
 	// CurrentVersion is the current cluster version
 	CurrentVersion string `json:"currentVersion"`
 	// TargetVersion is the version the cluster upgrading to.


### PR DESCRIPTION
Outline for keeping track of number of healthy pods etcd cluster.
My first thought are just to send HTTP GET requests to each running pod after the cluster is reconciled.

Is this the right place to do this?

/cc @hongchaodeng @xiang90 