### PR TITLE
operator: remove duplicate config creation

### DIFF
--- a/client/experimentalclient/client.go
+++ b/client/experimentalclient/client.go
@@ -62,7 +62,11 @@ type operator struct {
 }
 
 func NewOperator(namespace string) (Operator, error) {
-	tprclient, err := k8sutil.NewTPRClient()
+	config, err := k8sutil.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	tprclient, err := k8sutil.NewTPRClient(config)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -84,7 +84,7 @@ func init() {
 		panic(err)
 	}
 	controller.MasterHost = restCfg.Host
-	restcli, err := k8sutil.NewTPRClient()
+	restcli, err := k8sutil.NewTPRClient(restCfg)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -315,12 +315,7 @@ func InClusterConfig() (*rest.Config, error) {
 	return rest.InClusterConfig()
 }
 
-func NewTPRClient() (*rest.RESTClient, error) {
-	config, err := InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-
+func NewTPRClient(config *rest.Config) (*rest.RESTClient, error) {
 	config.GroupVersion = &unversioned.GroupVersion{
 		Group:   spec.TPRGroup,
 		Version: spec.TPRVersion,


### PR DESCRIPTION
This commit remove duplicate invocation
k8sutil.InClusterConfig() in operator main

Signed-off-by: grapebaba <281165273@qq.com>