### PR TITLE
cluster: change probe to linearizable

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -477,6 +477,7 @@ func (c *Cluster) pollPods() ([]*v1.Pod, []*v1.Pod, error) {
 	}
 
 	for _, pod := range running {
+		// TODO: Change to URL struct for TLS integration
 		url := fmt.Sprintf("http://%s:2379", pod.Status.PodIP)
 		healthy, err := etcdutil.CheckHealth(url)
 		if err != nil {

--- a/pkg/util/etcdutil/etcdutil.go
+++ b/pkg/util/etcdutil/etcdutil.go
@@ -85,7 +85,7 @@ func CheckHealth(url string) (bool, error) {
 		return false, fmt.Errorf("failed to create etcd client for %s: %v", url, err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
-	_, err = etcdcli.Get(ctx, "/", clientv3.WithSerializable())
+	_, err = etcdcli.Get(ctx, "/")
 	cancel()
 	etcdcli.Close()
 	if err != nil {


### PR DESCRIPTION
Change health probe to linearizable to test out tracking of ReadyMembers.

Do not merge yet.

#808 