### PR TITLE
spec/ClusterStatus: group ReadyMembers and UnreadyMembers together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Backup creation time is added in backup status.
 - Total size of backups time is added in backup service status.
-- Cluster members that are ready and unready to serve requests are tracked via the ClusterStatus fields `ReadyMembers` and `UnreadyMembers`
+- Cluster members that are ready and unready to serve requests are tracked via the ClusterStatus fields `Members.Ready` and `Members.Unready`
 
 ### Changed
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -273,8 +273,8 @@ func (c *Cluster) run(stopC <-chan struct{}) {
 				c.logger.Errorf("fail to poll pods: %v", err)
 				continue
 			}
-			c.status.ReadyMembers = k8sutil.GetPodNames(ready)
-			c.status.UnreadyMembers = k8sutil.GetPodNames(unready)
+			c.status.Members.Ready = k8sutil.GetPodNames(ready)
+			c.status.Members.Unready = k8sutil.GetPodNames(unready)
 
 			if err := c.updateTPRStatus(); err != nil {
 				c.logger.Warningf("failed to update TPR status: %v", err)

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -193,11 +193,8 @@ type ClusterStatus struct {
 
 	// Size is the current size of the cluster
 	Size int `json:"size"`
-	// ReadyMembers are the etcd members that are ready to serve requests
-	// The member names are the same as the etcd pod names
-	ReadyMembers []string `json:"readyMembers"`
-	// UnreadyPods are the etcd members not ready to serve requests
-	UnreadyMembers []string `json:"unreadyMembers"`
+	// Members are the etcd members in the cluster
+	Members MembersStatus `json:"members"`
 	// CurrentVersion is the current cluster version
 	CurrentVersion string `json:"currentVersion"`
 	// TargetVersion is the version the cluster upgrading to.
@@ -208,6 +205,14 @@ type ClusterStatus struct {
 	// BackupServiceStatus only exists when backup is enabled in the
 	// cluster spec.
 	BackupServiceStatus *BackupServiceStatus `json:"backupServiceStatus,omitempty"`
+}
+
+type MembersStatus struct {
+	// Ready are the etcd members that are ready to serve requests
+	// The member names are the same as the etcd pod names
+	Ready []string `json:"ready,omitempty"`
+	// Unready are the etcd members not ready to serve requests
+	Unready []string `json:"unready,omitempty"`
 }
 
 func (cs ClusterStatus) Copy() ClusterStatus {

--- a/test/e2e/cluster_status_test.go
+++ b/test/e2e/cluster_status_test.go
@@ -53,8 +53,8 @@ func TestReadyMembersStatus(t *testing.T) {
 			logfWithTimestamp(t, "failed to get updated cluster object: %v", err)
 			return false, nil
 		}
-		if len(currEtcd.Status.ReadyMembers) != size {
-			logfWithTimestamp(t, "size of ready members want = %d, get = %d ReadyMembers(%v) UnreadyMembers(%v). Will retry checking ReadyMembers", size, len(currEtcd.Status.ReadyMembers), currEtcd.Status.ReadyMembers, currEtcd.Status.UnreadyMembers)
+		if len(currEtcd.Status.Members.Ready) != size {
+			logfWithTimestamp(t, "size of ready members want = %d, get = %d ReadyMembers(%v) UnreadyMembers(%v). Will retry checking ReadyMembers", size, len(currEtcd.Status.Members.Ready), currEtcd.Status.Members.Ready, currEtcd.Status.Members.Unready)
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
Added another struct MembersStatus to group the ready and unready members together.

Fixes #878 

/cc @hongchaodeng @xiang90  