### PR TITLE
Dockerfile: run image as non-root user

### DIFF
--- a/hack/build/operator/Dockerfile
+++ b/hack/build/operator/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine:3.5
 
+RUN adduser -D etcd-operator
 RUN apk add --no-cache ca-certificates
 
 ADD _output/bin/etcd-operator /usr/local/bin
 ADD _output/bin/etcd-backup /usr/local/bin
+
+USER etcd-operator
 
 CMD ["/bin/sh", "-c", "/usr/local/bin/etcd-operator"]


### PR DESCRIPTION
The etcd-operator container image will run as a non-root user: etcd-operator.

Waiting to see if any tests break first so don't merge yet.

#806 