### PR TITLE
pod_util: remove Ports field

### DIFF
--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -33,21 +33,9 @@ func etcdContainer(commands, version string) v1.Container {
 	c := v1.Container{
 		// TODO: fix "sleep 5".
 		// Without waiting some time, there is highly probable flakes in network setup.
-		Command: []string{"/bin/sh", "-c", fmt.Sprintf("sleep 5; %s", commands)},
-		Name:    "etcd",
-		Image:   EtcdImageName(version),
-		Ports: []v1.ContainerPort{
-			{
-				Name:          "server",
-				ContainerPort: int32(2380),
-				Protocol:      v1.ProtocolTCP,
-			},
-			{
-				Name:          "client",
-				ContainerPort: int32(2379),
-				Protocol:      v1.ProtocolTCP,
-			},
-		},
+		Command:      []string{"/bin/sh", "-c", fmt.Sprintf("sleep 5; %s", commands)},
+		Name:         "etcd",
+		Image:        EtcdImageName(version),
 		VolumeMounts: etcdVolumeMounts(),
 	}
 


### PR DESCRIPTION
Reasons:
- Not really need this.
- It could cause scheduling failure on self hosted case where static
pod and “scheduled” pod tries to sit on same node. Work around here.