### PR TITLE
cluster: check healthy via serializable get()

### DIFF
--- a/pkg/util/etcdutil/etcdutil.go
+++ b/pkg/util/etcdutil/etcdutil.go
@@ -85,11 +85,11 @@ func CheckHealth(url string) (bool, error) {
 		return false, fmt.Errorf("failed to create etcd client for %s: %v", url, err)
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
-	_, err = etcdcli.Get(ctx, "/")
+	_, err = etcdcli.Get(ctx, "/", clientv3.WithSerializable())
 	cancel()
 	etcdcli.Close()
 	if err != nil {
-		return false, fmt.Errorf("etcd health probing failed for %s: %v ", url, err)
+		return false, fmt.Errorf("etcd health probing failed for %s: %v", url, err)
 	}
 	return true, nil
 }


### PR DESCRIPTION
fix https://github.com/coreos/etcd-operator/issues/890

depends on https://github.com/coreos/etcd-operator/pull/889