### PR TITLE
cluster: fix looping of reconcile skip due to unready members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- [GH-900] Fix looping of reconcile skip due to unready members
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
Verified it fixed https://github.com/coreos/etcd-operator/issues/900

Previously we were skipping reconcile if there are unready members.
However, this is unpredictable — member could be transition from ready
back to unready. Our initial reason for skipping is actually for
pending state, a stage that we think a pod would be running later
because of slow image pulling. We should only skip reconcile if pods
are pending. This is more deterministic.

Moved update members status right before update TPR status. This is not
gonna show pending pods as unready and might be slower to show ready
members.