### PR TITLE
k8sutil: GetPodNames() return nil if slice is empty

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -60,6 +60,9 @@ func SetEtcdVersion(pod *v1.Pod, version string) {
 }
 
 func GetPodNames(pods []*v1.Pod) []string {
+	if len(pods) == 0 {
+		return nil
+	}
 	res := []string{}
 	for _, p := range pods {
 		res = append(res, p.Name)


### PR DESCRIPTION
Externally, ready/unready member slice relies on this.
We want it to be nil to be consistent.
But if pods parameter is nil, it also makes more sense to return nil.