### PR TITLE
spec: change time type to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@
 ### Changed
 
 - TLSSpec json tag changed as `omitempty`
+- Time related fields in spec, i.e. TransitionTime and CreationTime, is changed to type `string`.
+  This should be backward compatible and no effect on operator upgrade.
 
 ### Removed
 
 ### Fixed
+
+- [GH-910] Operator keeps updating status even if there is no change.
 
 ### Deprecated
 

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -212,7 +212,7 @@ func (b *Backup) writeSnap(m *etcdutil.Member, rev int64) error {
 	}
 
 	bs := backupapi.BackupStatus{
-		CreationTime:     time.Now(),
+		CreationTime:     time.Now().Format(time.RFC3339),
 		Size:             toMB(n),
 		Version:          resp.Version,
 		TimeTookInSecond: int(time.Since(start).Seconds() + 1),

--- a/pkg/backup/backupapi/types.go
+++ b/pkg/backup/backupapi/types.go
@@ -14,8 +14,6 @@
 
 package backupapi
 
-import "time"
-
 type ServiceStatus struct {
 	// RecentBackup is status of the most recent backup created by
 	// the backup service
@@ -30,7 +28,7 @@ type ServiceStatus struct {
 
 type BackupStatus struct {
 	// Creation time of the backup.
-	CreationTime time.Time `json:"creationTime"`
+	CreationTime string `json:"creationTime"`
 
 	// Size is the size of the backup in MB.
 	Size float64 `json:"size"`

--- a/pkg/spec/backup.go
+++ b/pkg/spec/backup.go
@@ -14,8 +14,6 @@
 
 package spec
 
-import "time"
-
 type BackupStorageType string
 
 const (
@@ -76,7 +74,7 @@ type BackupServiceStatus struct {
 
 type BackupStatus struct {
 	// Creation time of the backup.
-	CreationTime time.Time `json:"creationTime"`
+	CreationTime string `json:"creationTime"`
 
 	// Size is the size of the backup in MB.
 	Size float64 `json:"size"`

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -165,7 +165,7 @@ type ClusterCondition struct {
 
 	Reason string `json:"reason"`
 
-	TransitionTime time.Time `json:"transitionTime"`
+	TransitionTime string `json:"transitionTime"`
 }
 
 type ClusterConditionType string
@@ -267,7 +267,7 @@ func (cs *ClusterStatus) AppendScalingUpCondition(from, to int) {
 	c := ClusterCondition{
 		Type:           ClusterConditionScalingUp,
 		Reason:         scalingReason(from, to),
-		TransitionTime: time.Now(),
+		TransitionTime: time.Now().Format(time.RFC3339),
 	}
 	cs.appendCondition(c)
 }
@@ -276,7 +276,7 @@ func (cs *ClusterStatus) AppendScalingDownCondition(from, to int) {
 	c := ClusterCondition{
 		Type:           ClusterConditionScalingDown,
 		Reason:         scalingReason(from, to),
-		TransitionTime: time.Now(),
+		TransitionTime: time.Now().Format(time.RFC3339),
 	}
 	cs.appendCondition(c)
 }
@@ -284,7 +284,7 @@ func (cs *ClusterStatus) AppendScalingDownCondition(from, to int) {
 func (cs *ClusterStatus) AppendRecoveringCondition() {
 	c := ClusterCondition{
 		Type:           ClusterConditionRecovering,
-		TransitionTime: time.Now(),
+		TransitionTime: time.Now().Format(time.RFC3339),
 	}
 	cs.appendCondition(c)
 }
@@ -295,7 +295,7 @@ func (cs *ClusterStatus) AppendUpgradingCondition(to string, member string) {
 	c := ClusterCondition{
 		Type:           ClusterConditionUpgrading,
 		Reason:         reason,
-		TransitionTime: time.Now(),
+		TransitionTime: time.Now().Format(time.RFC3339),
 	}
 	cs.appendCondition(c)
 }
@@ -306,7 +306,7 @@ func (cs *ClusterStatus) AppendRemovingDeadMember(name string) {
 	c := ClusterCondition{
 		Type:           ClusterConditionRemovingDeadMember,
 		Reason:         reason,
-		TransitionTime: time.Now(),
+		TransitionTime: time.Now().Format(time.RFC3339),
 	}
 	cs.appendCondition(c)
 }
@@ -314,7 +314,7 @@ func (cs *ClusterStatus) AppendRemovingDeadMember(name string) {
 func (cs *ClusterStatus) SetReadyCondition() {
 	c := ClusterCondition{
 		Type:           ClusterConditionReady,
-		TransitionTime: time.Now(),
+		TransitionTime: time.Now().Format(time.RFC3339),
 	}
 
 	if len(cs.Conditions) == 0 {


### PR DESCRIPTION
fix https://github.com/coreos/etcd-operator/issues/910

There is a problem when using DeepEqual() to compare ClusterStatus
structs — time.Time isn’t comparable. We change it to string. This is
backward compatible and should be no effect on upgrade