### PR TITLE
backup: add "none" storage type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Added
 
+- Add "none" PV provisioner option. If operator flag "pv-provisioner" is set to "none",
+  operator won’t create any storage class and users couldn’t make use of operator’s PV backup feature.
+
 ### Changed
 
 - TLSSpec json tag changed as `omitempty`

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/chaos"
 	"github.com/coreos/etcd-operator/pkg/controller"
 	"github.com/coreos/etcd-operator/pkg/garbagecollection"
+	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil/election"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil/election/resourcelock"
@@ -66,7 +67,7 @@ var (
 func init() {
 	flag.BoolVar(&analyticsEnabled, "analytics", true, "Send analytical event (Cluster Created/Deleted etc.) to Google Analytics")
 
-	flag.StringVar(&pvProvisioner, "pv-provisioner", "kubernetes.io/gce-pd", "persistent volume provisioner type")
+	flag.StringVar(&pvProvisioner, "pv-provisioner", constants.PVProvisionerGCEPD, "persistent volume provisioner type")
 	flag.StringVar(&awsSecret, "backup-aws-secret", "",
 		"The name of the kube secret object that stores the AWS credential file. The file name must be 'credentials'.")
 	flag.StringVar(&awsConfig, "backup-aws-config", "",

--- a/pkg/cluster/backup_manager_test.go
+++ b/pkg/cluster/backup_manager_test.go
@@ -1,0 +1,61 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"testing"
+
+	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/coreos/etcd-operator/pkg/spec"
+	"github.com/coreos/etcd-operator/pkg/util/constants"
+)
+
+func TestNewBackupManagerWithNonePVProvisioner(t *testing.T) {
+	cfg := Config{PVProvisioner: constants.PVProvisionerNone}
+	cl := &spec.Cluster{
+		Metadata: v1.ObjectMeta{Name: "testing"},
+		Spec: spec.ClusterSpec{
+			Backup: &spec.BackupPolicy{
+				StorageType: spec.BackupStorageTypePersistentVolume,
+				StorageSource: spec.StorageSource{
+					PV: &spec.PVSource{VolumeSizeInMB: 512},
+				},
+				MaxBackups: 1,
+			},
+		},
+	}
+	_, err := newBackupManager(cfg, cl, nil)
+	if err != errNoPVForBackup {
+		t.Errorf("expect err=%v, get=%v", errNoPVForBackup, err)
+	}
+}
+
+func TestNewBackupManagerWithoutS3Config(t *testing.T) {
+	cfg := Config{}
+	cl := &spec.Cluster{
+		Metadata: v1.ObjectMeta{Name: "testing"},
+		Spec: spec.ClusterSpec{
+			Backup: &spec.BackupPolicy{
+				StorageType: spec.BackupStorageTypeS3,
+				MaxBackups:  1,
+			},
+		},
+	}
+	_, err := newBackupManager(cfg, cl, nil)
+	if err != errNoS3ConfigForBackup {
+		t.Errorf("expect err=%v, get=%v", errNoS3ConfigForBackup, err)
+	}
+}

--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -24,4 +24,8 @@ const (
 	DefaultBackupPodHTTPPort = 19999
 
 	BackupMountDir = "/var/etcd-backup"
+
+	PVProvisionerGCEPD  = "kubernetes.io/gce-pd"
+	PVProvisionerAWSEBS = "kubernetes.io/aws-ebs"
+	PVProvisionerNone   = "none"
 )


### PR DESCRIPTION
If “pv-provisioner” is set to “none”, then operator won’t create any
storage class and users couldn’t make use of PV backup feature.

Also fix that if s3 config isn’t set but spec asks for “S3” storage
type, we will reject it immediately.

fix https://github.com/coreos/etcd-operator/issues/921