### PR TITLE
controller: fix logic for deleting failed cluster

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -159,7 +159,12 @@ func (c *Controller) handleClusterEvent(event *Event) {
 	clus := event.Object
 
 	if clus.Status.IsFailed() {
-		c.logger.Infof("ignore failed cluster (%s). Please delete its TPR", clus.Metadata.Name)
+		if event.Type == kwatch.Deleted {
+			delete(c.clusters, clus.Metadata.Name)
+			delete(c.clusterRVs, clus.Metadata.Name)
+		} else {
+			c.logger.Infof("ignore failed cluster (%s). Please delete its TPR", clus.Metadata.Name)
+		}
 		return
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/watch"
+
+	"github.com/coreos/etcd-operator/pkg/cluster"
+	"github.com/coreos/etcd-operator/pkg/spec"
+)
+
+func TestHandleClusterEventUpdateFailedCluster(t *testing.T) {
+	c := New(Config{})
+
+	clus := &spec.Cluster{
+		Metadata: v1.ObjectMeta{
+			Name: "test",
+		},
+		Status: spec.ClusterStatus{
+			Phase: spec.ClusterPhaseFailed,
+		},
+	}
+	e := &Event{
+		Type:   watch.Modified,
+		Object: clus,
+	}
+	err := c.handleClusterEvent(e)
+	prefix := "ignore failed cluster"
+	if !strings.HasPrefix(err.Error(), prefix) {
+		t.Errorf("expect err='%s...', get=%v", prefix, err)
+	}
+}
+
+func TestHandleClusterEventDeleteFailedCluster(t *testing.T) {
+	c := New(Config{})
+	name := "tests"
+	clus := &spec.Cluster{
+		Metadata: v1.ObjectMeta{
+			Name: name,
+		},
+		Status: spec.ClusterStatus{
+			Phase: spec.ClusterPhaseFailed,
+		},
+	}
+	e := &Event{
+		Type:   watch.Deleted,
+		Object: clus,
+	}
+
+	c.clusters[name] = &cluster.Cluster{}
+	c.clusterRVs[name] = "123"
+
+	if err := c.handleClusterEvent(e); err != nil {
+		t.Fatal(err)
+	}
+
+	if c.clusters[name] != nil || c.clusterRVs[name] != "" {
+		t.Errorf("failed cluster not cleaned up after delete event, cluster struct: %v, RV: %s", c.clusters[name], c.clusterRVs[name])
+	}
+}

--- a/test/e2e/cluster_status_test.go
+++ b/test/e2e/cluster_status_test.go
@@ -16,17 +16,12 @@ package e2e
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
-	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
-
-	"k8s.io/client-go/pkg/api/unversioned"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
 func TestReadyMembersStatus(t *testing.T) {
@@ -114,53 +109,4 @@ func TestBackupStatus(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-}
-
-func TestUpdateClusterAfterItFailed(t *testing.T) {
-	f := framework.Global
-
-	cl := &spec.Cluster{
-		TypeMeta: unversioned.TypeMeta{
-			Kind:       strings.Title(spec.TPRKind),
-			APIVersion: spec.TPRGroup + "/" + spec.TPRVersion,
-		},
-		Metadata: v1.ObjectMeta{
-			GenerateName: "test-etcd-",
-		},
-		Spec: spec.ClusterSpec{
-			Size: 1,
-		},
-		Status: spec.ClusterStatus{
-			Phase: spec.ClusterPhaseFailed,
-		},
-	}
-	testEtcd, err := createCluster(t, f, cl)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err := deleteEtcdCluster(t, f, testEtcd); err != nil {
-			t.Fatal(err)
-		}
-	}()
-	testEtcd.Spec.Size = 3
-	if _, err := updateEtcdCluster(f, testEtcd); err != nil {
-		t.Fatal(err)
-	}
-	// make sure operator does not panic after a reasonable amount of time
-	time.Sleep(3 * time.Second)
-	if err := verifyOperatorRunning(f); err != nil {
-		t.Error(err)
-	}
-}
-
-func verifyOperatorRunning(f *framework.Framework) error {
-	pod, err := f.KubeClient.CoreV1().Pods(f.Namespace).Get("etcd-operator")
-	if err != nil {
-		return err
-	}
-	if ph := pod.Status.Phase; ph != v1.PodRunning {
-		return fmt.Errorf("operator pod isn't running: phase (%s)", ph)
-	}
-	return nil
 }


### PR DESCRIPTION
If cluster was failed, it would show in cluster status. User would then
delete it. But there are two problems: 1. we didn’t cleanup resources;
2. we have a logging which is confusing — “ignore failed cluster …”