### PR TITLE
docs: more explanations for enabling S3 backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The etcd operator manages etcd clusters deployed to [Kubernetes][k8s-home] and a
 - [Backup and restore a cluster](#disaster-recovery)
 - [Rolling upgrade](#upgrade-an-etcd-cluster)
 
-There are [more spec examples](./doc/user/spec_examples.md).
+There are [more spec examples](./doc/user/spec_examples.md) on setting up clusters with backup, restore, and other configurations.
 
 Read [Best Practices](./doc/best_practices.md) for more information on how to better use etcd operator.
 
@@ -247,7 +247,7 @@ NAME                 TYPE
 etcd-backup-gce-pd   kubernetes.io/gce-pd
 ```
 
-This is used to request the persistent volume to store the backup data. See [other backup options](doc/user/backup_options.md).
+This is used to request the persistent volume to store the backup data. See [other backup options](doc/user/backup_config.md).
 
 To enable backup, create an etcd cluster with [backup enabled spec](example/example-etcd-cluster-with-backup.yaml).
 

--- a/doc/user/backup_config.md
+++ b/doc/user/backup_config.md
@@ -20,12 +20,13 @@ This is essentially saving backups on an instance of AWS EBS.
 
 ## S3 on AWS
 
-Saving backups to S3 is also supported. The following flags need to be passed to operator:
+Saving backups to S3 is also supported. See the [S3 backup deployment](../../example/deployment-s3-backup.yaml.template) template on how to configure the operator to enable S3 backups. The following flags need to be passed to operator:
 - `backup-aws-secret`: The name of the kube secret object that stores the AWS credential file. The file name must be 'credentials'.
 Profile must be "default".
 - `backup-aws-config`: The name of the kube configmap object that stores the AWS config file. The file name must be 'config'.
-For example, create configmap as `kubectl create configmap aws --from-file=$AWS_DIR/config`, and then set flag `--backup-aws-config=aws`.
 - `backup-s3-bucket`: The name of the S3 bucket to store backups in.
+
+Both the secret and configmap objects must be created in the same namespace that the etcd-operator is running in.
 
 For example, let's say we have aws credentials:
 ```
@@ -37,7 +38,7 @@ aws_secret_access_key = XXX
 
 We create a secret "aws":
 ```
-$ kubectl create secret generic aws --from-file=$AWS_DIR/credentials
+$ kubectl -n <namespace-name> create secret generic aws --from-file=$AWS_DIR/credentials
 ```
 
 We have aws config:
@@ -49,7 +50,7 @@ region = us-west-1
 
 We create a configmap "aws":
 ```
-$ kubectl create configmap aws --from-file=$AWS_DIR/config
+$ kubectl -n <namespace-name> create configmap aws --from-file=$AWS_DIR/config
 ```
 
 What we have:
@@ -61,4 +62,4 @@ We will start etcd operator with the following flags:
 ```
 $ ./etcd-operator ... --backup-aws-secret=aws --backup-aws-config=aws --backup-s3-bucket=etcd_backups
 ```
-Then we could start using S3 storage for backups. See [spec examples](spec_examples.md) .
+Then we could start using S3 storage for backups. See [spec examples](spec_examples.md#three-members-cluster-with-s3-backup) on how to configure a cluster that uses an S3 bucket as its storage type.

--- a/example/deployment-s3-backup.yaml.template
+++ b/example/deployment-s3-backup.yaml.template
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etcd-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: etcd-operator
+    spec:
+      containers:
+      - name: etcd-operator
+        image: quay.io/coreos/etcd-operator:v0.2.4
+        # Assuming the configmap and secret are both named 'aws'
+        # Set the name of the S3 bucket that will store the backups
+        command: ["/bin/sh", "-ec", "/usr/local/bin/etcd-operator --backup-aws-secret=aws --backup-aws-config=aws --backup-s3-bucket=<s3-bucket-name>"]
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name


### PR DESCRIPTION
[skip ci]

Some further clarifications and a broken link fix in the docs explaining how to enable S3 backups.
Added `example/deployment-s3-backup.yaml.template` to show the flags that need to be passed to the operator pod.

/cc @xiang90 @hongchaodeng 