### PR TITLE
*: use pod A record as fqdn for better grouping

### DIFF
--- a/pkg/util/etcdutil/member.go
+++ b/pkg/util/etcdutil/member.go
@@ -39,7 +39,7 @@ type Member struct {
 }
 
 func (m *Member) fqdn() string {
-	return fmt.Sprintf("%s.%s.svc.cluster.local", m.Name, m.Namespace)
+	return fmt.Sprintf("%s.%s.%s.pod.cluster.local", m.Name, clusterNameFromMemberName(m.Name), m.Namespace)
 }
 
 func (m *Member) ClientAddr() string {
@@ -167,4 +167,12 @@ func MemberNameFromPeerURL(pu string) (string, error) {
 
 func CreateMemberName(clusterName string, member int) string {
 	return fmt.Sprintf("%s-%04d", clusterName, member)
+}
+
+func clusterNameFromMemberName(mn string) string {
+	i := strings.LastIndex(mn, "-")
+	if i == -1 {
+		return mn
+	}
+	return mn[:i]
 }

--- a/pkg/util/etcdutil/member.go
+++ b/pkg/util/etcdutil/member.go
@@ -39,7 +39,7 @@ type Member struct {
 }
 
 func (m *Member) fqdn() string {
-	return fmt.Sprintf("%s.%s.%s.pod.cluster.local", m.Name, clusterNameFromMemberName(m.Name), m.Namespace)
+	return fmt.Sprintf("%s.%s.%s.svc.cluster.local", m.Name, clusterNameFromMemberName(m.Name), m.Namespace)
 }
 
 func (m *Member) ClientAddr() string {
@@ -172,7 +172,7 @@ func CreateMemberName(clusterName string, member int) string {
 func clusterNameFromMemberName(mn string) string {
 	i := strings.LastIndex(mn, "-")
 	if i == -1 {
-		return mn
+		panic(fmt.Sprintf("unexpected member name: %s", mn))
 	}
 	return mn[:i]
 }

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -266,6 +266,11 @@ func NewEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 			Volumes: []v1.Volume{
 				{Name: "etcd-data", VolumeSource: v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}},
 			},
+			// DNS A record: [m.Name].[clusterName].Namespace.pod.cluster.local.
+			// For example, etcd-0000 in default namesapce will have DNS name
+			// `etcd-0000.etcd.default.pod.cluster.local`.
+			Hostname:  m.Name,
+			Subdomain: clusterName,
 		},
 	}
 


### PR DESCRIPTION
With cluster name as subdomain grouping, we can do TLS
SAN wildcard more accurately.

/cc @colhom @hongchaodeng 