### PR TITLE
op_guide: highlight rbac setup

### DIFF
--- a/doc/user/op_guide.md
+++ b/doc/user/op_guide.md
@@ -2,6 +2,8 @@
 
 ## Install etcd operator
 
+Before you create the etcd-operator make sure you setup the necessary [rbac rules](./rbac.md) if your Kubernetes version is 1.6 or higher.
+
 Create deployment:
 
 ```bash


### PR DESCRIPTION
We need to highlight the rbac setup part just before creating the operator since it's easy to skim past the RBAC docs link in the overview.
A few users have already faced this problem and with rbac being default in k8s 1.6 this will become more common.

[skip ci]

/cc @hongchaodeng @xiang90 