### PR TITLE
TLS: update docs (client communication)

### DIFF
--- a/pkg/spec/cluster_tls.go
+++ b/pkg/spec/cluster_tls.go
@@ -23,7 +23,10 @@ type TLSPolicy struct {
 
 type StaticTLS struct {
 	// Member contains secrets containing TLS certs used by each etcd member pod.
-	Member MemberSecret `json:"member"`
+	Member *MemberSecret `json:"member"`
+	// OperatorSecret is the secret containing TLS certs used by operator to
+	// talk securely to this cluster.
+	OperatorSecret string `json:"operatorSecret"`
 }
 
 type MemberSecret struct {

--- a/pkg/util/etcdutil/etcdutil.go
+++ b/pkg/util/etcdutil/etcdutil.go
@@ -23,9 +23,9 @@ import (
 	"golang.org/x/net/context"
 )
 
-func ListMembers(endpoints []string) (*clientv3.MemberListResponse, error) {
+func ListMembers(clientURLs []string) (*clientv3.MemberListResponse, error) {
 	cfg := clientv3.Config{
-		Endpoints:   endpoints,
+		Endpoints:   clientURLs,
 		DialTimeout: constants.DefaultDialTimeout,
 	}
 	etcdcli, err := clientv3.New(cfg)

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -37,7 +37,7 @@ func TestPeerTLS(t *testing.T) {
 	c.Metadata.Name = clusterName
 	c.Spec.TLS = &spec.TLSPolicy{
 		Static: &spec.StaticTLS{
-			Member: spec.MemberSecret{
+			Member: &spec.MemberSecret{
 				PeerSecret: secretName,
 			},
 		},


### PR DESCRIPTION
Update the user docs to reflect operator's client key/cert and
etcd server's client key/cert.

Meanwhile, change the staticTLS fields to be pointer so that we preserve
the possibility of more options.