### PR TITLE
e2e: kill the last pod in recovery test

### DIFF
--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -64,7 +64,8 @@ func testOneMemberRecovery(t *testing.T) {
 	}
 	fmt.Println("reached to 3 members cluster")
 
-	if err := killMembers(f, names[0]); err != nil {
+	// The last pod could have not come up serving yet. If we are not killing the last pod, we should wait.
+	if err := killMembers(f, names[2]); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {


### PR DESCRIPTION
The last pod could have not come up yet.
A simple solution is to kill the last pod.

fix https://github.com/coreos/etcd-operator/issues/975