### PR TITLE
hack/test: add unused and gosimple checks

### DIFF
--- a/hack/ci/run
+++ b/hack/ci/run
@@ -14,6 +14,7 @@ mkdir -p $GOPATH
 cd $GOPATH
 export GOPATH=`pwd`
 echo "GOPATH: ${GOPATH}"
+export PATH=$GOPATH/bin:$PATH
 
 mkdir -p $GOPATH/src/github.com/coreos
 ln -s "${origpwd}" $GOPATH/src/github.com/coreos/etcd-operator

--- a/hack/test
+++ b/hack/test
@@ -29,7 +29,6 @@ function fmt_pass {
 		fi
 	done
 
-
 	echo "Checking govet..."
 	for file in $allfiles; do
 		checkRes=$(go vet $file)
@@ -38,6 +37,30 @@ function fmt_pass {
 			exit 255
 		fi
 	done
+
+	go get honnef.co/go/tools/cmd/gosimple || true
+	if which gosimple >/dev/null; then
+		echo "Checking gosimple..."
+		checkRes=$(gosimple $(go list ./client/... ./cmd/... ./pkg/... ./test/e2e/...)) || true
+			if [ -n "${checkRes}" ]; then
+				echo -e "gosimple checking failed:\n${checkRes}"
+				exit 255
+			fi
+	else
+		echo "Skipping gosimple: failed to install"
+	fi
+
+	go get honnef.co/go/tools/cmd/unused || true
+	if which unused >/dev/null; then
+		echo "Checking unused..."
+		checkRes=$(unused $(go list ./client/... ./cmd/... ./pkg/... ./test/e2e/...)) || true
+		if [ -n "${checkRes}" ]; then
+				echo -e "unused checking failed:\n${checkRes}"
+				exit 255
+		fi
+	else
+		echo "Skipping unused: failed to install"
+	fi
 }
 
 function build_pass {

--- a/pkg/backup/s3/s3.go
+++ b/pkg/backup/s3/s3.go
@@ -70,11 +70,7 @@ func (s *S3) Put(key string, rs io.ReadSeeker) error {
 		Body:   rs,
 	})
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (s *S3) Get(key string) (io.ReadCloser, error) {
@@ -95,11 +91,7 @@ func (s *S3) Delete(key string) error {
 		Key:    aws.String(path.Join(v1, s.prefix, key)),
 	})
 
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (s *S3) List() ([]string, error) {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -44,14 +44,12 @@ import (
 )
 
 const (
-	etcdVolumeMountDir         = "/var/etcd"
-	dataDir                    = etcdVolumeMountDir + "/data"
-	backupFile                 = "/var/etcd/latest.backup"
-	etcdVersionAnnotationKey   = "etcd.version"
-	annotationPrometheusScrape = "prometheus.io/scrape"
-	annotationPrometheusPort   = "prometheus.io/port"
-	peerTLSDir                 = "/etc/etcd-operator/member/peer-tls"
-	peerTLSVolume              = "member-peer-tls"
+	etcdVolumeMountDir       = "/var/etcd"
+	dataDir                  = etcdVolumeMountDir + "/data"
+	backupFile               = "/var/etcd/latest.backup"
+	etcdVersionAnnotationKey = "etcd.version"
+	peerTLSDir               = "/etc/etcd-operator/member/peer-tls"
+	peerTLSVolume            = "member-peer-tls"
 )
 
 func GetEtcdVersion(pod *v1.Pod) string {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -135,11 +135,7 @@ func (f *Framework) SetupEtcdOperator() error {
 	logrus.Infof("etcd operator pod is running on node (%s)", p.Spec.NodeName)
 
 	err = k8sutil.WaitEtcdTPRReady(f.KubeClient.Core().RESTClient(), 5*time.Second, 60*time.Second, f.Namespace)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 func (f *Framework) DeleteEtcdOperatorCompletely() error {


### PR DESCRIPTION
Added checks for `unused` and `gosimple`.
Fixes #876 

Also corrected changes pointed out by the above checks:
```
Checking unused...
unused checking failed:
pkg/cluster/cluster.go:85:2: field backupDir is unused (U1000)
pkg/cluster/cluster.go:390:19: func (*Cluster).deleteClientServiceLB is unused (U1000)
pkg/util/k8sutil/k8sutil.go:51:2: const annotationPrometheusScrape is unused (U1000)
pkg/util/k8sutil/k8sutil.go:52:2: const annotationPrometheusPort is unused (U1000)
Checking gosimple...
gosimple checking failed:
pkg/backup/s3/s3.go:73:2: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013)
pkg/backup/s3/s3.go:98:2: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013)
pkg/cluster/cluster.go:417:2: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013)
test/e2e/framework/framework.go:138:2: 'if err != nil { return err }; return nil' can be simplified to 'return err' (S1013)
```
Waiting for tests to pass.