### PR TITLE
e2e: safe update TPR instead of unconditional update

### DIFF
--- a/pkg/util/k8sutil/tpr_util.go
+++ b/pkg/util/k8sutil/tpr_util.go
@@ -83,13 +83,6 @@ func UpdateClusterTPRObject(restcli rest.Interface, ns string, c *spec.Cluster) 
 	return updateClusterTPRObject(restcli, ns, c)
 }
 
-// UpdateClusterTPRObjectUnconditionally updates the given TPR object.
-// This should only be used in tests.
-func UpdateClusterTPRObjectUnconditionally(restcli rest.Interface, ns string, c *spec.Cluster) (*spec.Cluster, error) {
-	c.Metadata.ResourceVersion = ""
-	return updateClusterTPRObject(restcli, ns, c)
-}
-
 func updateClusterTPRObject(restcli rest.Interface, ns string, c *spec.Cluster) (*spec.Cluster, error) {
 	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters/%s", spec.TPRGroup, spec.TPRVersion, ns, c.Metadata.Name)
 	b, err := restcli.Put().RequestURI(uri).Body(c).DoRaw()

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
@@ -82,6 +83,11 @@ func testStopOperator(t *testing.T, kill bool) {
 	}
 
 	if !kill {
+		testEtcd, err = k8sutil.GetClusterTPRObject(f.KubeClient.CoreV1().RESTClient(), f.Namespace, testEtcd.Metadata.Name)
+		if err != nil {
+			t.Fatalf("failed to get cluster TPR object:%v", err)
+		}
+
 		testEtcd.Spec.Paused = true
 		if testEtcd, err = updateEtcdCluster(f, testEtcd); err != nil {
 			t.Fatalf("failed to pause control: %v", err)
@@ -107,6 +113,11 @@ func testStopOperator(t *testing.T, kill bool) {
 	}
 
 	if !kill {
+		testEtcd, err = k8sutil.GetClusterTPRObject(f.KubeClient.CoreV1().RESTClient(), f.Namespace, testEtcd.Metadata.Name)
+		if err != nil {
+			t.Fatalf("failed to get cluster TPR object:%v", err)
+		}
+
 		testEtcd.Spec.Paused = false
 		if _, err = updateEtcdCluster(f, testEtcd); err != nil {
 			t.Fatalf("failed to resume control: %v", err)
@@ -143,6 +154,11 @@ func testEtcdUpgrade(t *testing.T) {
 	err = waitSizeAndVersionReached(t, f, testEtcd.Metadata.Name, "3.0.16", 3, 60*time.Second)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
+	}
+
+	testEtcd, err = k8sutil.GetClusterTPRObject(f.KubeClient.CoreV1().RESTClient(), f.Namespace, testEtcd.Metadata.Name)
+	if err != nil {
+		t.Fatalf("failed to get cluster TPR object:%v", err)
 	}
 
 	testEtcd = etcdClusterWithVersion(testEtcd, "3.1.4")

--- a/test/e2e/resize_test.go
+++ b/test/e2e/resize_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
@@ -51,6 +52,11 @@ func testResizeCluster3to5(t *testing.T) {
 	}
 	fmt.Println("reached to 3 members cluster")
 
+	testEtcd, err = k8sutil.GetClusterTPRObject(f.KubeClient.CoreV1().RESTClient(), f.Namespace, testEtcd.Metadata.Name)
+	if err != nil {
+		t.Fatalf("failed to get cluster TPR object:%v", err)
+	}
+
 	testEtcd.Spec.Size = 5
 	if _, err := updateEtcdCluster(f, testEtcd); err != nil {
 		t.Fatal(err)
@@ -81,6 +87,11 @@ func testResizeCluster5to3(t *testing.T) {
 		t.Fatalf("failed to create 5 members etcd cluster: %v", err)
 	}
 	fmt.Println("reached to 5 members cluster")
+
+	testEtcd, err = k8sutil.GetClusterTPRObject(f.KubeClient.CoreV1().RESTClient(), f.Namespace, testEtcd.Metadata.Name)
+	if err != nil {
+		t.Fatalf("failed to get cluster TPR object:%v", err)
+	}
 
 	testEtcd.Spec.Size = 3
 	if _, err := updateEtcdCluster(f, testEtcd); err != nil {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -233,7 +233,7 @@ func createCluster(t *testing.T, f *framework.Framework, cl *spec.Cluster) (*spe
 }
 
 func updateEtcdCluster(f *framework.Framework, c *spec.Cluster) (*spec.Cluster, error) {
-	return k8sutil.UpdateClusterTPRObjectUnconditionally(f.KubeClient.CoreV1().RESTClient(), f.Namespace, c)
+	return k8sutil.UpdateClusterTPRObject(f.KubeClient.CoreV1().RESTClient(), f.Namespace, c)
 }
 
 func deleteEtcdCluster(t *testing.T, f *framework.Framework, c *spec.Cluster) error {


### PR DESCRIPTION
Unconditional update will overwrite TPR and we should not use it.