### PR TITLE
	hack/test: add upgrade test

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -89,6 +89,13 @@ function e2e_pass {
 	go test "./test/e2e/" -run "$E2E_TEST_SELECTOR" -timeout 30m --race --kubeconfig $KUBECONFIG --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
 }
 
+function upgrade_pass {
+	go test ./test/e2e/upgradetest/ --kubeconfig=$KUBECONFIG --kube-ns=$TEST_NAMESPACE \
+		--old-image=$UPGRADE_FROM \
+		--new-image=$UPGRADE_TO
+
+}
+
 function unit_pass {
 	# coverage.txt is the combined coverage report consumed by codecov
 	echo "mode: atomic" > coverage.txt

--- a/test/e2e/upgradetest/README.md
+++ b/test/e2e/upgradetest/README.md
@@ -4,5 +4,5 @@
 
 From operator root dir, run:
 ```
-$ go run ./test/e2e/upgradetest/ --kubeconfig=... --kube-ns=... --old-image=... --new-image=...
+$ go test ./test/e2e/upgradetest/ --kubeconfig=... --kube-ns=... --old-image=... --new-image=...
 ```


### PR DESCRIPTION
I have set up a **NIGHTLY** jenkins job: https://jenkins-etcd.prod.coreos.systems/view/operator/job/etcd-operator-upgrade/

It will do upgrade test trying to upgrade from latest release to tip version of etcd operator.