### PR TITLE
upgradetest: fix compile

### DIFF
--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -103,7 +103,7 @@ func createCluster() (*spec.Cluster, error) {
 }
 
 func updateEtcdCluster(cl *spec.Cluster) (*spec.Cluster, error) {
-	return k8sutil.UpdateClusterTPRObjectUnconditionally(testF.KubeCli.CoreV1().RESTClient(), testF.KubeNS, cl)
+	return k8sutil.UpdateClusterTPRObject(testF.KubeCli.CoreV1().RESTClient(), testF.KubeNS, cl)
 }
 
 func deleteCluster() error {


### PR DESCRIPTION
This is broken by https://github.com/coreos/etcd-operator/pull/1023