### PR TITLE
tpr_util,e2e/util: AtomicUpdateClusterTPR to retry safe update

### DIFF
--- a/test/e2e/e2eutil/tpr_util.go
+++ b/test/e2e/e2eutil/tpr_util.go
@@ -1,0 +1,12 @@
+package e2eutil
+
+import (
+	"github.com/coreos/etcd-operator/pkg/spec"
+	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+func UpdateEtcdCluster(kubeClient kubernetes.Interface, cl *spec.Cluster, maxRetries int, updateFunc k8sutil.ClusterTPRUpdateFunc) (*spec.Cluster, error) {
+	return k8sutil.AtomicUpdateClusterTPRObject(kubeClient.CoreV1().RESTClient(), cl.Metadata.Name, cl.Metadata.Namespace, maxRetries, updateFunc)
+}

--- a/test/e2e/resize_test.go
+++ b/test/e2e/resize_test.go
@@ -20,7 +20,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
+	"github.com/coreos/etcd-operator/pkg/spec"
+	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
@@ -52,13 +53,10 @@ func testResizeCluster3to5(t *testing.T) {
 	}
 	fmt.Println("reached to 3 members cluster")
 
-	testEtcd, err = k8sutil.GetClusterTPRObject(f.KubeClient.CoreV1().RESTClient(), f.Namespace, testEtcd.Metadata.Name)
-	if err != nil {
-		t.Fatalf("failed to get cluster TPR object:%v", err)
+	updateFunc := func(cl *spec.Cluster) {
+		cl.Spec.Size = 5
 	}
-
-	testEtcd.Spec.Size = 5
-	if _, err := updateEtcdCluster(f, testEtcd); err != nil {
+	if _, err := e2eutil.UpdateEtcdCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -88,13 +86,10 @@ func testResizeCluster5to3(t *testing.T) {
 	}
 	fmt.Println("reached to 5 members cluster")
 
-	testEtcd, err = k8sutil.GetClusterTPRObject(f.KubeClient.CoreV1().RESTClient(), f.Namespace, testEtcd.Metadata.Name)
-	if err != nil {
-		t.Fatalf("failed to get cluster TPR object:%v", err)
+	updateFunc := func(cl *spec.Cluster) {
+		cl.Spec.Size = 3
 	}
-
-	testEtcd.Spec.Size = 3
-	if _, err := updateEtcdCluster(f, testEtcd); err != nil {
+	if _, err := e2eutil.UpdateEtcdCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
+	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
@@ -66,9 +67,11 @@ func TestResize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testClus.Spec.Size = 5
-	_, err = updateEtcdCluster(testClus)
-	if err != nil {
+
+	updateFunc := func(cl *spec.Cluster) {
+		cl.Spec.Size = 5
+	}
+	if _, err := e2eutil.UpdateEtcdCluster(testF.KubeCli, testClus, 10, updateFunc); err != nil {
 		t.Fatal(err)
 	}
 	_, err = waitUntilSizeReached(testClus.Metadata.Name, 5, 60*time.Second)
@@ -100,10 +103,6 @@ func createCluster() (*spec.Cluster, error) {
 		return nil, err
 	}
 	return res, nil
-}
-
-func updateEtcdCluster(cl *spec.Cluster) (*spec.Cluster, error) {
-	return k8sutil.UpdateClusterTPRObject(testF.KubeCli.CoreV1().RESTClient(), testF.KubeNS, cl)
 }
 
 func deleteCluster() error {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -232,10 +232,6 @@ func createCluster(t *testing.T, f *framework.Framework, cl *spec.Cluster) (*spe
 	return res, nil
 }
 
-func updateEtcdCluster(f *framework.Framework, c *spec.Cluster) (*spec.Cluster, error) {
-	return k8sutil.UpdateClusterTPRObject(f.KubeClient.CoreV1().RESTClient(), f.Namespace, c)
-}
-
 func deleteEtcdCluster(t *testing.T, f *framework.Framework, c *spec.Cluster) error {
 	podList, err := f.KubeClient.CoreV1().Pods(f.Namespace).List(k8sutil.ClusterListOpt(c.Metadata.Name))
 	if err != nil {


### PR DESCRIPTION
`AtomicUpdateClusterTPR` avoids overwriting the cluster TPR by fetching the latest cluster TPR and applying an update function to modify it before attempting to update the cluster TPR object.
 
This could fail if our fetched TPR becomes outdated before we can modify and update it. 
So the whole process is retried with exponential backoff for `Step` number of times until the update is successful, else we return an error.

Also changed is `updateEtcdCluster` in `e2e/util.go` which now accepts an update function in order to use `AtomicUpdateClusterTPR`.

@hongchaodeng I have not modified upgrade_test.go to use `AtomicUpdateClusterTPR` though it should be a similar change once it starts using `e2e/util.go`
