### PR TITLE
e2e/util.go: refactor CreateCluster() into e2e/e2eutil for common use

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -41,7 +41,7 @@ func testCreateCluster(t *testing.T) {
 		t.Parallel()
 	}
 	f := framework.Global
-	testEtcd, err := createCluster(t, f, newClusterSpec("test-etcd-", 3))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", 3))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func testPauseControl(t *testing.T) {
 
 func testStopOperator(t *testing.T, kill bool) {
 	f := framework.Global
-	testEtcd, err := createCluster(t, f, newClusterSpec("test-etcd-", 3))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", 3))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func testEtcdUpgrade(t *testing.T) {
 	f := framework.Global
 	origEtcd := newClusterSpec("test-etcd-", 3)
 	origEtcd = etcdClusterWithVersion(origEtcd, "3.0.16")
-	testEtcd, err := createCluster(t, f, origEtcd)
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, origEtcd)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/cluster_status_test.go
+++ b/test/e2e/cluster_status_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
+	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
@@ -38,7 +39,7 @@ func testReadyMembersStatus(t *testing.T) {
 	}
 	f := framework.Global
 	size := 1
-	testEtcd, err := createCluster(t, f, newClusterSpec("test-etcd-", size))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", size))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +79,7 @@ func testBackupStatus(t *testing.T) {
 
 	bp := newBackupPolicyPV()
 	bp.CleanupBackupsOnClusterDelete = true
-	testEtcd, err := createCluster(t, f, etcdClusterWithBackup(newClusterSpec("test-etcd-", 1), bp))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, etcdClusterWithBackup(newClusterSpec("test-etcd-", 1), bp))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/e2eutil/tpr_util.go
+++ b/test/e2e/e2eutil/tpr_util.go
@@ -1,12 +1,35 @@
 package e2eutil
 
 import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 
 	"k8s.io/client-go/kubernetes"
 )
 
+func CreateCluster(t *testing.T, kubeClient kubernetes.Interface, namespace string, cl *spec.Cluster) (*spec.Cluster, error) {
+	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters", spec.TPRGroup, spec.TPRVersion, namespace)
+	b, err := kubeClient.CoreV1().RESTClient().Post().Body(cl).RequestURI(uri).DoRaw()
+	if err != nil {
+		return nil, err
+	}
+	res := &spec.Cluster{}
+	if err := json.Unmarshal(b, res); err != nil {
+		return nil, err
+	}
+	logfWithTimestamp(t, "created etcd cluster: %v", res.Metadata.Name)
+	return res, nil
+}
+
 func UpdateEtcdCluster(kubeClient kubernetes.Interface, cl *spec.Cluster, maxRetries int, updateFunc k8sutil.ClusterTPRUpdateFunc) (*spec.Cluster, error) {
 	return k8sutil.AtomicUpdateClusterTPRObject(kubeClient.CoreV1().RESTClient(), cl.Metadata.Name, cl.Metadata.Namespace, maxRetries, updateFunc)
+}
+
+func logfWithTimestamp(t *testing.T, format string, args ...interface{}) {
+	t.Log(time.Now(), fmt.Sprintf(format, args...))
 }

--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd-operator/pkg/spec"
+	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
@@ -48,7 +49,7 @@ func testOneMemberRecovery(t *testing.T) {
 	}
 
 	f := framework.Global
-	testEtcd, err := createCluster(t, f, newClusterSpec("test-etcd-", 3))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", 3))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -103,7 +104,7 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, numToKill int, backupPol
 
 	backupPolicy.CleanupBackupsOnClusterDelete = true
 	origEtcd := newClusterSpec("test-etcd-", 3)
-	testEtcd, err := createCluster(t, f, etcdClusterWithBackup(origEtcd, backupPolicy))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, etcdClusterWithBackup(origEtcd, backupPolicy))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/resize_test.go
+++ b/test/e2e/resize_test.go
@@ -37,7 +37,7 @@ func testResizeCluster3to5(t *testing.T) {
 		t.Parallel()
 	}
 	f := framework.Global
-	testEtcd, err := createCluster(t, f, newClusterSpec("test-etcd-", 3))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", 3))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func testResizeCluster5to3(t *testing.T) {
 		t.Parallel()
 	}
 	f := framework.Global
-	testEtcd, err := createCluster(t, f, newClusterSpec("test-etcd-", 5))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", 5))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/constants"
+	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 
 	"golang.org/x/net/context"
@@ -76,7 +77,7 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 	f := framework.Global
 
 	origEtcd := newClusterSpec("test-etcd-", 3)
-	testEtcd, err := createCluster(t, f, etcdClusterWithBackup(origEtcd, backupPolicy))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, etcdClusterWithBackup(origEtcd, backupPolicy))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,7 +125,7 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 	})
 
 	backupPolicy.CleanupBackupsOnClusterDelete = true
-	testEtcd, err = createCluster(t, f, etcdClusterWithBackup(origEtcd, backupPolicy))
+	testEtcd, err = e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, etcdClusterWithBackup(origEtcd, backupPolicy))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
+	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 
 	"github.com/coreos/etcd/embed"
@@ -50,7 +51,7 @@ func testCreateSelfHostedCluster(t *testing.T) {
 	f := framework.Global
 	c := newClusterSpec("test-etcd-", 3)
 	c = clusterWithSelfHosted(c, &spec.SelfHostedPolicy{})
-	testEtcd, err := createCluster(t, f, c)
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, c)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -115,7 +116,7 @@ func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
 	c = clusterWithSelfHosted(c, &spec.SelfHostedPolicy{
 		BootMemberClientEndpoint: embedCfg.ACUrls[0].String(),
 	})
-	testEtcd, err := createCluster(t, f, c)
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -44,7 +44,7 @@ func TestPeerTLS(t *testing.T) {
 			},
 		},
 	}
-	c, err = createCluster(t, f, c)
+	c, err = e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -15,7 +15,6 @@
 package upgradetest
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -49,7 +48,7 @@ func TestResize(t *testing.T) {
 		}
 		time.Sleep(10 * time.Second)
 	}()
-	testClus, err := createCluster()
+	testClus, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, newClusterSpec())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,8 +79,8 @@ func TestResize(t *testing.T) {
 	}
 }
 
-func createCluster() (*spec.Cluster, error) {
-	cl := &spec.Cluster{
+func newClusterSpec() *spec.Cluster {
+	return &spec.Cluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       strings.Title(spec.TPRKind),
 			APIVersion: spec.TPRGroup + "/" + spec.TPRVersion,
@@ -93,16 +92,6 @@ func createCluster() (*spec.Cluster, error) {
 			Size: 3,
 		},
 	}
-	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters", spec.TPRGroup, spec.TPRVersion, testF.KubeNS)
-	b, err := testF.KubeCli.CoreV1().RESTClient().Post().Body(cl).RequestURI(uri).DoRaw()
-	if err != nil {
-		return nil, err
-	}
-	res := &spec.Cluster{}
-	if err := json.Unmarshal(b, res); err != nil {
-		return nil, err
-	}
-	return res, nil
 }
 
 func deleteCluster() error {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -17,7 +17,6 @@ package e2e
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
@@ -216,20 +215,6 @@ func etcdClusterWithVersion(cl *spec.Cluster, version string) *spec.Cluster {
 func clusterWithSelfHosted(cl *spec.Cluster, sh *spec.SelfHostedPolicy) *spec.Cluster {
 	cl.Spec.SelfHosted = sh
 	return cl
-}
-
-func createCluster(t *testing.T, f *framework.Framework, cl *spec.Cluster) (*spec.Cluster, error) {
-	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters", spec.TPRGroup, spec.TPRVersion, f.Namespace)
-	b, err := f.KubeClient.CoreV1().RESTClient().Post().Body(cl).RequestURI(uri).DoRaw()
-	if err != nil {
-		return nil, err
-	}
-	res := &spec.Cluster{}
-	if err := json.Unmarshal(b, res); err != nil {
-		return nil, err
-	}
-	logfWithTimestamp(t, "created etcd cluster: %v", res.Metadata.Name)
-	return res, nil
 }
 
 func deleteEtcdCluster(t *testing.T, f *framework.Framework, c *spec.Cluster) error {


### PR DESCRIPTION
Refactored the `CreateCluster()` function and moved it to `e2eutil/tpr_util.go` since it's a common function.

upgrade_test.go is also changed to use the `CreateCluster()` func.

/cc @hongchaodeng 