### PR TITLE
backup: use Deployment to manage sidecar instead od ReplicaSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased 0.2.6]
 
+### Upgrade Notice
+
+- Once operator is upgraded, all backup-enabled cluster will go through an upgrade process that
+  deletes backup sidecar's ReplicaSet and creates new Deployment for sidecar.
+  If upgrading failed for any reason, cluster TPR's `status.phase` will be FAILED.
+  Recreate of the cluster TPR is needed on failure case.
+
 ### Added
 
 - PodPolicy provides `EtcdEnv` option to add custom env to the etcd process.
@@ -9,7 +16,7 @@
 
 - Self-hosted etcd pod's anti-affinity label selector is changed to select `{"app": "etcd"}`.
   That is, no two etcd pods should sit on the same node, even if they belongs to different clusters.
-
+- Using Deployment to manage backup sidecar instead of ReplicaSet.
 - S3 backup path is changed to `${BUCKET_NAME}/v1/${NAMESPACE}/${CLUSTER_NAME}/`.
 
 ### Removed

--- a/doc/user/rbac.md
+++ b/doc/user/rbac.md
@@ -86,9 +86,9 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-  - extensions
+  - apps
   resources:
-  - replicasets
+  - deployments
   verbs:
   - "*"
 EOF

--- a/hack/ci/rbac_utils.sh
+++ b/hack/ci/rbac_utils.sh
@@ -43,9 +43,9 @@ rules:
   verbs:
   - "*"
 - apiGroups:
-  - extensions
+  - apps
   resources:
-  - replicasets
+  - deployments
   verbs:
   - "*"
 - apiGroups:

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -157,6 +157,12 @@ func (c *Cluster) setup() error {
 		if err != nil {
 			return err
 		}
+		if !shouldCreateCluster {
+			err := c.bm.upgradeIfNeeded()
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	if shouldCreateCluster {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/coreos/etcd-operator/pkg/backup/backupapi"
 	"github.com/coreos/etcd-operator/pkg/spec"
-	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
 
@@ -114,14 +113,6 @@ func EtcdImageName(version string) string {
 func PodWithNodeSelector(p *v1.Pod, ns map[string]string) *v1.Pod {
 	p.Spec.NodeSelector = ns
 	return p
-}
-
-func BackupServiceAddr(clusterName string) string {
-	return fmt.Sprintf("%s:%d", BackupServiceName(clusterName), constants.DefaultBackupPodHTTPPort)
-}
-
-func BackupServiceName(clusterName string) string {
-	return fmt.Sprintf("%s-backup-sidecar", clusterName)
 }
 
 func CreateClientService(kubecli kubernetes.Interface, clusterName, ns string, owner metav1.OwnerReference) error {
@@ -342,11 +333,11 @@ func IsKubernetesResourceNotFoundError(err error) bool {
 // We are using internal api types for cluster related.
 func ClusterListOpt(clusterName string) metav1.ListOptions {
 	return metav1.ListOptions{
-		LabelSelector: labels.SelectorFromSet(newLablesForCluster(clusterName)).String(),
+		LabelSelector: labels.SelectorFromSet(LabelsForCluster(clusterName)).String(),
 	}
 }
 
-func newLablesForCluster(clusterName string) map[string]string {
+func LabelsForCluster(clusterName string) map[string]string {
 	return map[string]string{
 		"etcd_cluster": clusterName,
 		"app":          "etcd",

--- a/test/e2e/upgradetest/framework/framework.go
+++ b/test/e2e/upgradetest/framework/framework.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	appsv1beta1 "k8s.io/client-go/pkg/apis/apps/v1beta1"
 	"k8s.io/client-go/tools/clientcmd"
@@ -109,7 +108,7 @@ func (f *Framework) UpgradeOperator() error {
 	if err != nil {
 		return err
 	}
-	cd := cloneDeployment(d)
+	cd := k8sutil.CloneDeployment(d)
 	cd.Spec.Template.Spec.Containers[0].Image = image
 	patchData, err := k8sutil.CreatePatch(d, cd, appsv1beta1.Deployment{})
 	if err != nil {
@@ -117,12 +116,4 @@ func (f *Framework) UpgradeOperator() error {
 	}
 	_, err = f.KubeCli.AppsV1beta1().Deployments(f.KubeNS).Patch(d.Name, types.StrategicMergePatchType, patchData)
 	return err
-}
-
-func cloneDeployment(d *appsv1beta1.Deployment) *appsv1beta1.Deployment {
-	cd, err := api.Scheme.DeepCopy(d)
-	if err != nil {
-		panic("cannot deep copy pod")
-	}
-	return cd.(*appsv1beta1.Deployment)
 }


### PR DESCRIPTION
ref https://github.com/coreos/etcd-operator/issues/1014

This PR changes backup sidecar to use Deployment, and upgrade backup sidecar automatically if operator is upgraded.

It also handles backward compatibility:
```
Once operator is upgraded, all backup-enabled cluster will go through
an upgrade process that deletes backup sidecar's ReplicaSet and creates
new Deployment for sidecar. If upgrading failed for any reason, cluster
TPR's `status.phase` will be FAILED. Recreate of the cluster TPR is
needed on failure case.
```

I have manually test upgrade. We need upgrade test for it later before next release.