### PR TITLE
e2e/util.go: Move etcd spec related methods into e2eutil for common use

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -41,13 +41,13 @@ func testCreateCluster(t *testing.T) {
 		t.Parallel()
 	}
 	f := framework.Global
-	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", 3))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.NewCluster("test-etcd-", 3))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	defer func() {
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -68,12 +68,12 @@ func testPauseControl(t *testing.T) {
 
 func testStopOperator(t *testing.T, kill bool) {
 	f := framework.Global
-	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", 3))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.NewCluster("test-etcd-", 3))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -87,7 +87,7 @@ func testStopOperator(t *testing.T, kill bool) {
 		updateFunc := func(cl *spec.Cluster) {
 			cl.Spec.Paused = true
 		}
-		if testEtcd, err = e2eutil.UpdateEtcdCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
+		if testEtcd, err = e2eutil.UpdateCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
 			t.Fatalf("failed to pause control: %v", err)
 		}
 
@@ -114,7 +114,7 @@ func testStopOperator(t *testing.T, kill bool) {
 		updateFunc := func(cl *spec.Cluster) {
 			cl.Spec.Paused = false
 		}
-		if _, err = e2eutil.UpdateEtcdCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
+		if _, err = e2eutil.UpdateCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
 			t.Fatalf("failed to resume control: %v", err)
 		}
 	} else {
@@ -133,15 +133,15 @@ func testEtcdUpgrade(t *testing.T) {
 		t.Parallel()
 	}
 	f := framework.Global
-	origEtcd := newClusterSpec("test-etcd-", 3)
-	origEtcd = etcdClusterWithVersion(origEtcd, "3.0.16")
+	origEtcd := e2eutil.NewCluster("test-etcd-", 3)
+	origEtcd = e2eutil.ClusterWithVersion(origEtcd, "3.0.16")
 	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, origEtcd)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	defer func() {
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -152,9 +152,9 @@ func testEtcdUpgrade(t *testing.T) {
 	}
 
 	updateFunc := func(cl *spec.Cluster) {
-		cl = etcdClusterWithVersion(cl, "3.1.4")
+		cl = e2eutil.ClusterWithVersion(cl, "3.1.4")
 	}
-	if _, err := e2eutil.UpdateEtcdCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
+	if _, err := e2eutil.UpdateCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
 		t.Fatalf("fail to update cluster version: %v", err)
 	}
 

--- a/test/e2e/cluster_status_test.go
+++ b/test/e2e/cluster_status_test.go
@@ -40,13 +40,13 @@ func testReadyMembersStatus(t *testing.T) {
 	}
 	f := framework.Global
 	size := 1
-	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", size))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.NewCluster("test-etcd-", size))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	defer func() {
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -78,9 +78,9 @@ func testBackupStatus(t *testing.T) {
 	}
 	f := framework.Global
 
-	bp := newBackupPolicyPV()
+	bp := e2eutil.NewPVBackupPolicy()
 	bp.CleanupBackupsOnClusterDelete = true
-	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, etcdClusterWithBackup(newClusterSpec("test-etcd-", 1), bp))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.ClusterWithBackup(e2eutil.NewCluster("test-etcd-", 1), bp))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func testBackupStatus(t *testing.T) {
 			}
 		}
 
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, storageCheckerOptions); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, storageCheckerOptions); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -1,0 +1,82 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2eutil
+
+import (
+	"strings"
+
+	"github.com/coreos/etcd-operator/pkg/spec"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewCluster(genName string, size int) *spec.Cluster {
+	return &spec.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       strings.Title(spec.TPRKind),
+			APIVersion: spec.TPRGroup + "/" + spec.TPRVersion,
+		},
+		Metadata: metav1.ObjectMeta{
+			GenerateName: genName,
+		},
+		Spec: spec.ClusterSpec{
+			Size: size,
+		},
+	}
+}
+
+func NewS3BackupPolicy() *spec.BackupPolicy {
+	return &spec.BackupPolicy{
+		BackupIntervalInSecond: 60 * 60,
+		MaxBackups:             5,
+		StorageType:            spec.BackupStorageTypeS3,
+		StorageSource: spec.StorageSource{
+			S3: &spec.S3Source{},
+		},
+	}
+}
+
+func NewPVBackupPolicy() *spec.BackupPolicy {
+	return &spec.BackupPolicy{
+		BackupIntervalInSecond: 60 * 60,
+		MaxBackups:             5,
+		StorageType:            spec.BackupStorageTypePersistentVolume,
+		StorageSource: spec.StorageSource{
+			PV: &spec.PVSource{
+				VolumeSizeInMB: 512,
+			},
+		},
+	}
+}
+
+func ClusterWithBackup(cl *spec.Cluster, backupPolicy *spec.BackupPolicy) *spec.Cluster {
+	cl.Spec.Backup = backupPolicy
+	return cl
+}
+
+func ClusterWithRestore(cl *spec.Cluster, restorePolicy *spec.RestorePolicy) *spec.Cluster {
+	cl.Spec.Restore = restorePolicy
+	return cl
+}
+
+func ClusterWithVersion(cl *spec.Cluster, version string) *spec.Cluster {
+	cl.Spec.Version = version
+	return cl
+}
+
+func ClusterWithSelfHosted(cl *spec.Cluster, sh *spec.SelfHostedPolicy) *spec.Cluster {
+	cl.Spec.SelfHosted = sh
+	return cl
+}

--- a/test/e2e/e2eutil/tpr_util.go
+++ b/test/e2e/e2eutil/tpr_util.go
@@ -46,11 +46,11 @@ func CreateCluster(t *testing.T, kubeClient kubernetes.Interface, namespace stri
 	return res, nil
 }
 
-func UpdateEtcdCluster(kubeClient kubernetes.Interface, cl *spec.Cluster, maxRetries int, updateFunc k8sutil.ClusterTPRUpdateFunc) (*spec.Cluster, error) {
+func UpdateCluster(kubeClient kubernetes.Interface, cl *spec.Cluster, maxRetries int, updateFunc k8sutil.ClusterTPRUpdateFunc) (*spec.Cluster, error) {
 	return k8sutil.AtomicUpdateClusterTPRObject(kubeClient.CoreV1().RESTClient(), cl.Metadata.Name, cl.Metadata.Namespace, maxRetries, updateFunc)
 }
 
-func DeleteEtcdCluster(t *testing.T, kubeClient kubernetes.Interface, cl *spec.Cluster, storageCheckerOptions *StorageCheckerOptions) error {
+func DeleteCluster(t *testing.T, kubeClient kubernetes.Interface, cl *spec.Cluster, storageCheckerOptions *StorageCheckerOptions) error {
 	uri := fmt.Sprintf("/apis/%s/%s/namespaces/%s/clusters/%s", spec.TPRGroup, spec.TPRVersion, cl.Metadata.Namespace, cl.Metadata.Name)
 	if _, err := kubeClient.CoreV1().RESTClient().Delete().RequestURI(uri).DoRaw(); err != nil {
 		return err

--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -49,12 +49,12 @@ func testOneMemberRecovery(t *testing.T) {
 	}
 
 	f := framework.Global
-	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", 3))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.NewCluster("test-etcd-", 3))
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -96,15 +96,15 @@ func testDisasterRecoveryAll(t *testing.T) {
 }
 
 func testDisasterRecovery(t *testing.T, numToKill int) {
-	testDisasterRecoveryWithBackupPolicy(t, numToKill, newBackupPolicyPV())
+	testDisasterRecoveryWithBackupPolicy(t, numToKill, e2eutil.NewPVBackupPolicy())
 }
 
 func testDisasterRecoveryWithBackupPolicy(t *testing.T, numToKill int, backupPolicy *spec.BackupPolicy) {
 	f := framework.Global
 
 	backupPolicy.CleanupBackupsOnClusterDelete = true
-	origEtcd := newClusterSpec("test-etcd-", 3)
-	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, etcdClusterWithBackup(origEtcd, backupPolicy))
+	origEtcd := e2eutil.NewCluster("test-etcd-", 3)
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.ClusterWithBackup(origEtcd, backupPolicy))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, numToKill int, backupPol
 			}
 		}
 
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, storageCheckerOptions); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, storageCheckerOptions); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -162,7 +162,7 @@ func testS3MajorityDown(t *testing.T) {
 		t.Parallel()
 	}
 
-	testDisasterRecoveryWithBackupPolicy(t, 2, newBackupPolicyS3())
+	testDisasterRecoveryWithBackupPolicy(t, 2, e2eutil.NewS3BackupPolicy())
 }
 
 func testS3AllDown(t *testing.T) {
@@ -173,5 +173,5 @@ func testS3AllDown(t *testing.T) {
 		t.Parallel()
 	}
 
-	testDisasterRecoveryWithBackupPolicy(t, 3, newBackupPolicyS3())
+	testDisasterRecoveryWithBackupPolicy(t, 3, e2eutil.NewS3BackupPolicy())
 }

--- a/test/e2e/resize_test.go
+++ b/test/e2e/resize_test.go
@@ -37,13 +37,13 @@ func testResizeCluster3to5(t *testing.T) {
 		t.Parallel()
 	}
 	f := framework.Global
-	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", 3))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.NewCluster("test-etcd-", 3))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	defer func() {
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -56,7 +56,7 @@ func testResizeCluster3to5(t *testing.T) {
 	updateFunc := func(cl *spec.Cluster) {
 		cl.Spec.Size = 5
 	}
-	if _, err := e2eutil.UpdateEtcdCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
+	if _, err := e2eutil.UpdateCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
 		t.Fatal(err)
 	}
 
@@ -70,13 +70,13 @@ func testResizeCluster5to3(t *testing.T) {
 		t.Parallel()
 	}
 	f := framework.Global
-	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, newClusterSpec("test-etcd-", 5))
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.NewCluster("test-etcd-", 5))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	defer func() {
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -89,7 +89,7 @@ func testResizeCluster5to3(t *testing.T) {
 	updateFunc := func(cl *spec.Cluster) {
 		cl.Spec.Size = 3
 	}
-	if _, err := e2eutil.UpdateEtcdCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
+	if _, err := e2eutil.UpdateCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
 		t.Fatal(err)
 	}
 

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -70,14 +70,14 @@ func testClusterRestoreDifferentName(t *testing.T) {
 }
 
 func testClusterRestore(t *testing.T, needDataClone bool) {
-	testClusterRestoreWithBackupPolicy(t, needDataClone, newBackupPolicyPV())
+	testClusterRestoreWithBackupPolicy(t, needDataClone, e2eutil.NewPVBackupPolicy())
 }
 
 func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backupPolicy *spec.BackupPolicy) {
 	f := framework.Global
 
-	origEtcd := newClusterSpec("test-etcd-", 3)
-	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, etcdClusterWithBackup(origEtcd, backupPolicy))
+	origEtcd := e2eutil.NewCluster("test-etcd-", 3)
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.ClusterWithBackup(origEtcd, backupPolicy))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,7 +113,7 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 			S3Bucket: f.S3Bucket,
 		}
 	}
-	if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, storageCheckerOptions); err != nil {
+	if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, storageCheckerOptions); err != nil {
 		t.Fatal(err)
 	}
 	// waits a bit to make sure resources are finally deleted on APIServer.
@@ -130,13 +130,13 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 	}
 	waitRestoreTimeout := calculateRestoreWaitTime(needDataClone)
 
-	origEtcd = etcdClusterWithRestore(origEtcd, &spec.RestorePolicy{
+	origEtcd = e2eutil.ClusterWithRestore(origEtcd, &spec.RestorePolicy{
 		BackupClusterName: testEtcd.Metadata.Name,
 		StorageType:       backupPolicy.StorageType,
 	})
 
 	backupPolicy.CleanupBackupsOnClusterDelete = true
-	testEtcd, err = e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, etcdClusterWithBackup(origEtcd, backupPolicy))
+	testEtcd, err = e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.ClusterWithBackup(origEtcd, backupPolicy))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 				S3Bucket: f.S3Bucket,
 			}
 		}
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, storageCheckerOptions); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, storageCheckerOptions); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -216,7 +216,7 @@ func testClusterRestoreS3SameName(t *testing.T) {
 		t.Parallel()
 	}
 
-	testClusterRestoreWithBackupPolicy(t, false, newBackupPolicyS3())
+	testClusterRestoreWithBackupPolicy(t, false, e2eutil.NewS3BackupPolicy())
 }
 
 func testClusterRestoreS3DifferentName(t *testing.T) {
@@ -224,5 +224,5 @@ func testClusterRestoreS3DifferentName(t *testing.T) {
 		t.Parallel()
 	}
 
-	testClusterRestoreWithBackupPolicy(t, true, newBackupPolicyS3())
+	testClusterRestoreWithBackupPolicy(t, true, e2eutil.NewS3BackupPolicy())
 }

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -49,15 +49,15 @@ func testCreateSelfHostedCluster(t *testing.T) {
 	}
 
 	f := framework.Global
-	c := newClusterSpec("test-etcd-", 3)
-	c = clusterWithSelfHosted(c, &spec.SelfHostedPolicy{})
+	c := e2eutil.NewCluster("test-etcd-", 3)
+	c = e2eutil.ClusterWithSelfHosted(c, &spec.SelfHostedPolicy{})
 	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, c)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	defer func() {
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}()
@@ -112,8 +112,8 @@ func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
 
 	f := framework.Global
 
-	c := newClusterSpec("test-etcd-", 3)
-	c = clusterWithSelfHosted(c, &spec.SelfHostedPolicy{
+	c := e2eutil.NewCluster("test-etcd-", 3)
+	c = e2eutil.ClusterWithSelfHosted(c, &spec.SelfHostedPolicy{
 		BootMemberClientEndpoint: embedCfg.ACUrls[0].String(),
 	})
 	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, c)
@@ -122,7 +122,7 @@ func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
 	}
 
 	defer func() {
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd, &e2eutil.StorageCheckerOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -35,7 +35,7 @@ func TestPeerTLS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := newClusterSpec("", 3)
+	c := e2eutil.NewCluster("", 3)
 	c.Metadata.Name = clusterName
 	c.Spec.TLS = &spec.TLSPolicy{
 		Static: &spec.StaticTLS{
@@ -50,7 +50,7 @@ func TestPeerTLS(t *testing.T) {
 	}
 
 	defer func() {
-		if err := e2eutil.DeleteEtcdCluster(t, f.KubeClient, c, &e2eutil.StorageCheckerOptions{}); err != nil {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, c, &e2eutil.StorageCheckerOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -18,12 +18,10 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/coreos/etcd-operator/client/experimentalclient"
-	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
@@ -153,65 +151,6 @@ func killMembers(f *framework.Framework, names ...string) error {
 		}
 	}
 	return nil
-}
-
-func newClusterSpec(genName string, size int) *spec.Cluster {
-	return &spec.Cluster{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       strings.Title(spec.TPRKind),
-			APIVersion: spec.TPRGroup + "/" + spec.TPRVersion,
-		},
-		Metadata: metav1.ObjectMeta{
-			GenerateName: genName,
-		},
-		Spec: spec.ClusterSpec{
-			Size: size,
-		},
-	}
-}
-
-func etcdClusterWithBackup(cl *spec.Cluster, backupPolicy *spec.BackupPolicy) *spec.Cluster {
-	cl.Spec.Backup = backupPolicy
-	return cl
-}
-
-func newBackupPolicyS3() *spec.BackupPolicy {
-	return &spec.BackupPolicy{
-		BackupIntervalInSecond: 60 * 60,
-		MaxBackups:             5,
-		StorageType:            spec.BackupStorageTypeS3,
-		StorageSource: spec.StorageSource{
-			S3: &spec.S3Source{},
-		},
-	}
-}
-
-func newBackupPolicyPV() *spec.BackupPolicy {
-	return &spec.BackupPolicy{
-		BackupIntervalInSecond: 60 * 60,
-		MaxBackups:             5,
-		StorageType:            spec.BackupStorageTypePersistentVolume,
-		StorageSource: spec.StorageSource{
-			PV: &spec.PVSource{
-				VolumeSizeInMB: 512,
-			},
-		},
-	}
-}
-
-func etcdClusterWithRestore(cl *spec.Cluster, restorePolicy *spec.RestorePolicy) *spec.Cluster {
-	cl.Spec.Restore = restorePolicy
-	return cl
-}
-
-func etcdClusterWithVersion(cl *spec.Cluster, version string) *spec.Cluster {
-	cl.Spec.Version = version
-	return cl
-}
-
-func clusterWithSelfHosted(cl *spec.Cluster, sh *spec.SelfHostedPolicy) *spec.Cluster {
-	cl.Spec.SelfHosted = sh
-	return cl
 }
 
 func logfWithTimestamp(t *testing.T, format string, args ...interface{}) {


### PR DESCRIPTION
Cluster spec methods grouped in `e2eutil` but mostly unchanged.