### PR TITLE
e2e/util.go: Move waitUntilSize functions to e2eutil for common use

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -52,7 +52,7 @@ func testCreateCluster(t *testing.T) {
 		}
 	}()
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 }
@@ -78,7 +78,7 @@ func testStopOperator(t *testing.T, kill bool) {
 		}
 	}()
 
-	names, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second)
+	names, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
@@ -103,10 +103,10 @@ func testStopOperator(t *testing.T, kill bool) {
 	if err := killMembers(f, names[0]); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 2, 10*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 2, 10*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to wait for killed member to die: %v", err)
 	}
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 10*time.Second); err == nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 10*time.Second, testEtcd); err == nil {
 		t.Fatalf("cluster should not be recovered: control is paused")
 	}
 
@@ -114,7 +114,7 @@ func testStopOperator(t *testing.T, kill bool) {
 		updateFunc := func(cl *spec.Cluster) {
 			cl.Spec.Paused = false
 		}
-		if _, err = e2eutil.UpdateCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
+		if testEtcd, err = e2eutil.UpdateCluster(f.KubeClient, testEtcd, 10, updateFunc); err != nil {
 			t.Fatalf("failed to resume control: %v", err)
 		}
 	} else {
@@ -123,7 +123,7 @@ func testStopOperator(t *testing.T, kill bool) {
 		}
 	}
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
 	}
 }
@@ -146,7 +146,7 @@ func testEtcdUpgrade(t *testing.T) {
 		}
 	}()
 
-	err = waitSizeAndVersionReached(t, f, testEtcd.Metadata.Name, "3.0.16", 3, 60*time.Second)
+	err = e2eutil.WaitSizeAndVersionReached(t, f.KubeClient, "3.0.16", 3, 60*time.Second, testEtcd)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
@@ -158,7 +158,7 @@ func testEtcdUpgrade(t *testing.T) {
 		t.Fatalf("fail to update cluster version: %v", err)
 	}
 
-	err = waitSizeAndVersionReached(t, f, testEtcd.Metadata.Name, "3.1.4", 3, 60*time.Second)
+	err = e2eutil.WaitSizeAndVersionReached(t, f.KubeClient, "3.1.4", 3, 60*time.Second, testEtcd)
 	if err != nil {
 		t.Fatalf("failed to wait new version etcd cluster: %v", err)
 	}

--- a/test/e2e/e2eutil/tpr_util.go
+++ b/test/e2e/e2eutil/tpr_util.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
@@ -42,7 +41,7 @@ func CreateCluster(t *testing.T, kubeClient kubernetes.Interface, namespace stri
 	if err := json.Unmarshal(b, res); err != nil {
 		return nil, err
 	}
-	logfWithTimestamp(t, "created etcd cluster: %v", res.Metadata.Name)
+	LogfWithTimestamp(t, "created etcd cluster: %v", res.Metadata.Name)
 	return res, nil
 }
 
@@ -65,8 +64,4 @@ func DeleteCluster(t *testing.T, kubeClient kubernetes.Interface, cl *spec.Clust
 		}
 	}
 	return nil
-}
-
-func logfWithTimestamp(t *testing.T, format string, args ...interface{}) {
-	t.Log(time.Now(), fmt.Sprintf(format, args...))
 }

--- a/test/e2e/e2eutil/util.go
+++ b/test/e2e/e2eutil/util.go
@@ -20,131 +20,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/etcd-operator/pkg/spec"
-	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
-	"github.com/coreos/etcd-operator/pkg/util/retryutil"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
 )
-
-func waitResourcesDeleted(t *testing.T, kubeClient kubernetes.Interface, cl *spec.Cluster) error {
-	err := retryutil.Retry(5*time.Second, 5, func() (done bool, err error) {
-		list, err := kubeClient.CoreV1().Pods(cl.Metadata.Namespace).List(k8sutil.ClusterListOpt(cl.Metadata.Name))
-		if err != nil {
-			return false, err
-		}
-		if len(list.Items) > 0 {
-			p := list.Items[0]
-			logfWithTimestamp(t, "waiting pod (%s) to be deleted.", p.Name)
-
-			buf := bytes.NewBuffer(nil)
-			buf.WriteString("init container status:\n")
-			printContainerStatus(buf, p.Status.InitContainerStatuses)
-			buf.WriteString("container status:\n")
-			printContainerStatus(buf, p.Status.ContainerStatuses)
-			t.Logf("pod (%s) status.phase is (%s): %v", p.Name, p.Status.Phase, buf.String())
-
-			return false, nil
-		}
-		return true, nil
-	})
-	if err != nil {
-		return fmt.Errorf("fail to wait pods deleted: %v", err)
-	}
-
-	err = retryutil.Retry(5*time.Second, 5, func() (done bool, err error) {
-		list, err := kubeClient.CoreV1().Services(cl.Metadata.Namespace).List(k8sutil.ClusterListOpt(cl.Metadata.Name))
-		if err != nil {
-			return false, err
-		}
-		if len(list.Items) > 0 {
-			logfWithTimestamp(t, "waiting service (%s) to be deleted", list.Items[0].Name)
-			return false, nil
-		}
-		return true, nil
-	})
-	if err != nil {
-		return fmt.Errorf("fail to wait services deleted: %v", err)
-	}
-	return nil
-}
-
-func waitBackupDeleted(kubeClient kubernetes.Interface, cl *spec.Cluster, storageCheckerOptions *StorageCheckerOptions) error {
-	err := retryutil.Retry(5*time.Second, 5, func() (bool, error) {
-		_, err := kubeClient.AppsV1beta1().Deployments(cl.Metadata.Namespace).Get(k8sutil.BackupSidecarName(cl.Metadata.Name), metav1.GetOptions{})
-		if err == nil {
-			return false, nil
-		}
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return false, err
-	})
-	if err != nil {
-		return fmt.Errorf("failed to wait backup Deployment deleted: %v", err)
-	}
-	err = retryutil.Retry(5*time.Second, 2, func() (done bool, err error) {
-		ls := labels.SelectorFromSet(map[string]string{
-			"app":          k8sutil.BackupPodSelectorAppField,
-			"etcd_cluster": cl.Metadata.Name,
-		}).String()
-		pl, err := kubeClient.CoreV1().Pods(cl.Metadata.Namespace).List(metav1.ListOptions{
-			LabelSelector: ls,
-		})
-		if err != nil {
-			return false, err
-		}
-		if len(pl.Items) == 0 {
-			return true, nil
-		}
-		if pl.Items[0].DeletionTimestamp != nil {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to wait backup pod terminated: %v", err)
-	}
-	// The rest is to track backup storage, e.g. PV or S3 "dir" deleted.
-	// If CleanupBackupsOnClusterDelete=false, we don't delete them and thus don't check them.
-	if !cl.Spec.Backup.CleanupBackupsOnClusterDelete {
-		return nil
-	}
-	err = retryutil.Retry(5*time.Second, 5, func() (done bool, err error) {
-		switch cl.Spec.Backup.StorageType {
-		case spec.BackupStorageTypePersistentVolume, spec.BackupStorageTypeDefault:
-			pl, err := kubeClient.CoreV1().PersistentVolumeClaims(cl.Metadata.Namespace).List(k8sutil.ClusterListOpt(cl.Metadata.Name))
-			if err != nil {
-				return false, err
-			}
-			if len(pl.Items) > 0 {
-				return false, nil
-			}
-		case spec.BackupStorageTypeS3:
-			resp, err := storageCheckerOptions.S3Cli.ListObjects(&s3.ListObjectsInput{
-				Bucket: aws.String(storageCheckerOptions.S3Bucket),
-				Prefix: aws.String(cl.Metadata.Name + "/"),
-			})
-			if err != nil {
-				return false, err
-			}
-			if len(resp.Contents) > 0 {
-				return false, nil
-			}
-		}
-		return true, nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to wait storage (%s) to be deleted: %v", cl.Spec.Backup.StorageType, err)
-	}
-	return nil
-}
 
 func printContainerStatus(buf *bytes.Buffer, ss []v1.ContainerStatus) {
 	for _, s := range ss {
@@ -155,4 +32,8 @@ func printContainerStatus(buf *bytes.Buffer, ss []v1.ContainerStatus) {
 			buf.WriteString(fmt.Sprintf("%s: Terminated: message (%s) reason (%s)\n", s.Name, s.State.Terminated.Message, s.State.Terminated.Reason))
 		}
 	}
+}
+
+func LogfWithTimestamp(t *testing.T, format string, args ...interface{}) {
+	t.Log(time.Now(), fmt.Sprintf(format, args...))
 }

--- a/test/e2e/e2eutil/wait_util.go
+++ b/test/e2e/e2eutil/wait_util.go
@@ -1,0 +1,200 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2eutil
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd-operator/pkg/spec"
+	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
+	"github.com/coreos/etcd-operator/pkg/util/retryutil"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+type acceptFunc func(*v1.Pod) bool
+
+func WaitUntilSizeReached(t *testing.T, kubeClient kubernetes.Interface, size int, timeout time.Duration, cl *spec.Cluster) ([]string, error) {
+	return waitSizeReachedWithAccept(t, kubeClient, size, timeout, cl)
+}
+
+func WaitSizeAndVersionReached(t *testing.T, kubeClient kubernetes.Interface, version string, size int, timeout time.Duration, cl *spec.Cluster) error {
+	_, err := waitSizeReachedWithAccept(t, kubeClient, size, timeout, cl, func(pod *v1.Pod) bool {
+		return k8sutil.GetEtcdVersion(pod) == version
+	})
+	return err
+}
+
+func waitSizeReachedWithAccept(t *testing.T, kubeClient kubernetes.Interface, size int, timeout time.Duration, cl *spec.Cluster, accepts ...acceptFunc) ([]string, error) {
+	var names []string
+	err := retryutil.Retry(10*time.Second, int(timeout/(10*time.Second)), func() (done bool, err error) {
+		podList, err := kubeClient.Core().Pods(cl.Metadata.Namespace).List(k8sutil.ClusterListOpt(cl.Metadata.Name))
+		if err != nil {
+			return false, err
+		}
+		names = nil
+		var nodeNames []string
+		for i := range podList.Items {
+			pod := &podList.Items[i]
+			if pod.Status.Phase != v1.PodRunning {
+				continue
+			}
+			accepted := true
+			for _, acceptPod := range accepts {
+				if !acceptPod(pod) {
+					accepted = false
+					break
+				}
+			}
+			if !accepted {
+				continue
+			}
+			names = append(names, pod.Name)
+			nodeNames = append(nodeNames, pod.Spec.NodeName)
+		}
+		LogfWithTimestamp(t, "waiting size (%d), etcd pods: names (%v), nodes (%v)", size, names, nodeNames)
+		// TODO: Change this to check for ready members and not just cluster pods
+		if len(names) != size {
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return names, nil
+}
+
+func waitResourcesDeleted(t *testing.T, kubeClient kubernetes.Interface, cl *spec.Cluster) error {
+	err := retryutil.Retry(5*time.Second, 5, func() (done bool, err error) {
+		list, err := kubeClient.CoreV1().Pods(cl.Metadata.Namespace).List(k8sutil.ClusterListOpt(cl.Metadata.Name))
+		if err != nil {
+			return false, err
+		}
+		if len(list.Items) > 0 {
+			p := list.Items[0]
+			LogfWithTimestamp(t, "waiting pod (%s) to be deleted.", p.Name)
+
+			buf := bytes.NewBuffer(nil)
+			buf.WriteString("init container status:\n")
+			printContainerStatus(buf, p.Status.InitContainerStatuses)
+			buf.WriteString("container status:\n")
+			printContainerStatus(buf, p.Status.ContainerStatuses)
+			t.Logf("pod (%s) status.phase is (%s): %v", p.Name, p.Status.Phase, buf.String())
+
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("fail to wait pods deleted: %v", err)
+	}
+
+	err = retryutil.Retry(5*time.Second, 5, func() (done bool, err error) {
+		list, err := kubeClient.CoreV1().Services(cl.Metadata.Namespace).List(k8sutil.ClusterListOpt(cl.Metadata.Name))
+		if err != nil {
+			return false, err
+		}
+		if len(list.Items) > 0 {
+			LogfWithTimestamp(t, "waiting service (%s) to be deleted", list.Items[0].Name)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("fail to wait services deleted: %v", err)
+	}
+	return nil
+}
+
+func waitBackupDeleted(kubeClient kubernetes.Interface, cl *spec.Cluster, storageCheckerOptions *StorageCheckerOptions) error {
+	err := retryutil.Retry(5*time.Second, 5, func() (bool, error) {
+		_, err := kubeClient.AppsV1beta1().Deployments(cl.Metadata.Namespace).Get(k8sutil.BackupSidecarName(cl.Metadata.Name), metav1.GetOptions{})
+		if err == nil {
+			return false, nil
+		}
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait backup Deployment deleted: %v", err)
+	}
+	err = retryutil.Retry(5*time.Second, 2, func() (done bool, err error) {
+		ls := labels.SelectorFromSet(map[string]string{
+			"app":          k8sutil.BackupPodSelectorAppField,
+			"etcd_cluster": cl.Metadata.Name,
+		}).String()
+		pl, err := kubeClient.CoreV1().Pods(cl.Metadata.Namespace).List(metav1.ListOptions{
+			LabelSelector: ls,
+		})
+		if err != nil {
+			return false, err
+		}
+		if len(pl.Items) == 0 {
+			return true, nil
+		}
+		if pl.Items[0].DeletionTimestamp != nil {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait backup pod terminated: %v", err)
+	}
+	// The rest is to track backup storage, e.g. PV or S3 "dir" deleted.
+	// If CleanupBackupsOnClusterDelete=false, we don't delete them and thus don't check them.
+	if !cl.Spec.Backup.CleanupBackupsOnClusterDelete {
+		return nil
+	}
+	err = retryutil.Retry(5*time.Second, 5, func() (done bool, err error) {
+		switch cl.Spec.Backup.StorageType {
+		case spec.BackupStorageTypePersistentVolume, spec.BackupStorageTypeDefault:
+			pl, err := kubeClient.CoreV1().PersistentVolumeClaims(cl.Metadata.Namespace).List(k8sutil.ClusterListOpt(cl.Metadata.Name))
+			if err != nil {
+				return false, err
+			}
+			if len(pl.Items) > 0 {
+				return false, nil
+			}
+		case spec.BackupStorageTypeS3:
+			resp, err := storageCheckerOptions.S3Cli.ListObjects(&s3.ListObjectsInput{
+				Bucket: aws.String(storageCheckerOptions.S3Bucket),
+				Prefix: aws.String(cl.Metadata.Name + "/"),
+			})
+			if err != nil {
+				return false, err
+			}
+			if len(resp.Contents) > 0 {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait storage (%s) to be deleted: %v", cl.Spec.Backup.StorageType, err)
+	}
+	return nil
+}

--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -59,7 +59,7 @@ func testOneMemberRecovery(t *testing.T) {
 		}
 	}()
 
-	names, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second)
+	names, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
@@ -69,7 +69,7 @@ func testOneMemberRecovery(t *testing.T) {
 	if err := killMembers(f, names[2]); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
 	}
 }
@@ -125,7 +125,7 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, numToKill int, backupPol
 		}
 	}()
 
-	names, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second)
+	names, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
@@ -146,12 +146,12 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, numToKill int, backupPol
 		time.Sleep(10 * time.Second)
 	}
 	toKill := names[:numToKill]
-	logfWithTimestamp(t, "killing pods: %v", toKill)
+	e2eutil.LogfWithTimestamp(t, "killing pods: %v", toKill)
 	// TODO: race: members could be recovered between being deleted one by one.
 	if err := killMembers(f, toKill...); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 120*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 120*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
 	}
 	// TODO: add checking of data in etcd

--- a/test/e2e/resize_test.go
+++ b/test/e2e/resize_test.go
@@ -48,7 +48,7 @@ func testResizeCluster3to5(t *testing.T) {
 		}
 	}()
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 	fmt.Println("reached to 3 members cluster")
@@ -60,7 +60,7 @@ func testResizeCluster3to5(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 5, 60*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 5, 60*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to resize to 5 members etcd cluster: %v", err)
 	}
 }
@@ -81,7 +81,7 @@ func testResizeCluster5to3(t *testing.T) {
 		}
 	}()
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 5, 90*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 5, 90*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to create 5 members etcd cluster: %v", err)
 	}
 	fmt.Println("reached to 5 members cluster")
@@ -93,7 +93,7 @@ func testResizeCluster5to3(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
 	}
 }

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -82,7 +82,7 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 		t.Fatal(err)
 	}
 
-	names, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 60*time.Second)
+	names, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
@@ -156,7 +156,7 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 		}
 	}()
 
-	names, err = waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, waitRestoreTimeout)
+	names, err = e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, waitRestoreTimeout, testEtcd)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}

--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -62,7 +62,7 @@ func testCreateSelfHostedCluster(t *testing.T) {
 		}
 	}()
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 240*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 240*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to create 3 members self-hosted etcd cluster: %v", err)
 	}
 }
@@ -127,7 +127,7 @@ func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
 		}
 	}()
 
-	if _, err := waitUntilSizeReached(t, f, testEtcd.Metadata.Name, 3, 120*time.Second); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 120*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 }

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -55,7 +55,7 @@ func TestPeerTLS(t *testing.T) {
 		}
 	}()
 
-	members, err := waitUntilSizeReached(t, f, c.Metadata.Name, 3, 60*time.Second)
+	members, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, c)
 	if err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}


### PR DESCRIPTION
Moved `waitUntilSizeReached` functions with the other `waitUntilSomething` functions in `e2eutil/wait_util.go`.
Other common functions like `LogfWithTimestamp` have been moved to `e2eutil/util.go`