### PR TITLE
e2e: test should always pull latest image

### DIFF
--- a/client/cliente2e/client_test.go
+++ b/client/cliente2e/client_test.go
@@ -40,9 +40,10 @@ func TestClient(t *testing.T) {
 		Spec: v1.PodSpec{
 			RestartPolicy: v1.RestartPolicyNever,
 			Containers: []v1.Container{{
-				Name:    name,
-				Image:   e2eImage,
-				Command: []string{"cliente2e"},
+				Name:            name,
+				Image:           e2eImage,
+				ImagePullPolicy: v1.PullAlways,
+				Command:         []string{"cliente2e"},
 				Env: []v1.EnvVar{{
 					Name:      "MY_POD_NAMESPACE",
 					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -109,9 +109,10 @@ func (f *Framework) SetupEtcdOperator() error {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:    "etcd-operator",
-					Image:   f.opImage,
-					Command: cmd,
+					Name:            "etcd-operator",
+					Image:           f.opImage,
+					ImagePullPolicy: v1.PullAlways,
+					Command:         cmd,
 					Env: []v1.EnvVar{
 						{
 							Name:      "MY_POD_NAMESPACE",

--- a/test/e2e/upgradetest/framework/framework.go
+++ b/test/e2e/upgradetest/framework/framework.go
@@ -73,9 +73,10 @@ func (f *Framework) CreateOperator() error {
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
-						Name:    "etcd-operator",
-						Image:   image,
-						Command: cmd,
+						Name:            "etcd-operator",
+						Image:           image,
+						ImagePullPolicy: v1.PullAlways,
+						Command:         cmd,
 						Env: []v1.EnvVar{
 							{
 								Name:      "MY_POD_NAMESPACE",


### PR DESCRIPTION
We might not use versioned image in test, e.g. nightly build dev image.