### PR TITLE
e2e/upgradetest: 1 member recovery test

### DIFF
--- a/test/e2e/e2eutil/util.go
+++ b/test/e2e/e2eutil/util.go
@@ -27,9 +27,9 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
-func KillMembers(kubecli kubernetes.Interface, ns string, names ...string) error {
+func KillMembers(kubecli kubernetes.Interface, namespace string, names ...string) error {
 	for _, name := range names {
-		err := kubecli.CoreV1().Pods(ns).Delete(name, metav1.NewDeleteOptions(0))
+		err := kubecli.CoreV1().Pods(namespace).Delete(name, metav1.NewDeleteOptions(0))
 		if err != nil && !k8sutil.IsKubernetesResourceNotFoundError(err) {
 			return err
 		}


### PR DESCRIPTION
- Added an `e2e/upgrade` test for the newer operator to successfully heal the cluster back to size after a single member failure.
- Moved `KillMembers()` from `e2e/util.go` to `e2e/e2eutil/util.go` to make it common between `e2e` and `e2e/upgradetest` tests.
- Changed the deployment delete grace period to zero, and wait for deployment pods to be deleted, so that the deployment from the previous test is gone before it conflicts with the next test's creation.