### PR TITLE
e2eutil: add WaitPodsDeleted util families

### DIFF
--- a/pkg/util/retryutil/retry_util.go
+++ b/pkg/util/retryutil/retry_util.go
@@ -13,6 +13,11 @@ func (e *RetryError) Error() string {
 	return fmt.Sprintf("still failing after %d retries", e.n)
 }
 
+func IsRetryFailure(err error) bool {
+	_, ok := err.(*RetryError)
+	return ok
+}
+
 type ConditionFunc func() (bool, error)
 
 // Retry retries f every interval until after maxRetries.


### PR DESCRIPTION
We will also need to use this util in upgrade test for:
- wait old version etcd operator deleted
- wait old version backup sidecar deleted