### PR TITLE
upgradetest: Add test to restore from backup of old cluster

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -90,10 +90,11 @@ function e2e_pass {
 }
 
 function upgrade_pass {
-	go test ./test/e2e/upgradetest/ --kubeconfig=$KUBECONFIG --kube-ns=$TEST_NAMESPACE \
+	# Run all the tests by default
+	UPGRADE_TEST_SELECTOR=${UPGRADE_TEST_SELECTOR:-.*}
+	go test ./test/e2e/upgradetest/ -run "$UPGRADE_TEST_SELECTOR" -timeout 30m --kubeconfig=$KUBECONFIG --kube-ns=$TEST_NAMESPACE \
 		--old-image=$UPGRADE_FROM \
 		--new-image=$UPGRADE_TO
-
 }
 
 function unit_pass {

--- a/test/e2e/e2eutil/etcd_util.go
+++ b/test/e2e/e2eutil/etcd_util.go
@@ -1,0 +1,74 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2eutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/coreos/etcd-operator/pkg/util/constants"
+	"github.com/coreos/etcd/clientv3"
+)
+
+const (
+	etcdKeyFoo = "foo"
+	etcdValBar = "bar"
+)
+
+func PutDataToEtcd(url string) error {
+	etcdcli, err := createEtcdClient(url)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
+	_, err = etcdcli.Put(ctx, etcdKeyFoo, etcdValBar)
+	cancel()
+	etcdcli.Close()
+	return err
+}
+
+func CheckEtcdData(t *testing.T, url string) {
+	etcdcli, err := createEtcdClient(url)
+	if err != nil {
+		t.Fatalf("failed to create etcd client:%v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
+	resp, err := etcdcli.Get(ctx, etcdKeyFoo)
+	cancel()
+	etcdcli.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Kvs) != 1 {
+		t.Errorf("want only 1 key result, get %d", len(resp.Kvs))
+	} else {
+		val := string(resp.Kvs[0].Value)
+		if val != etcdValBar {
+			t.Errorf("value want = '%s', get = '%s'", etcdValBar, val)
+		}
+	}
+}
+
+func createEtcdClient(addr string) (*clientv3.Client, error) {
+	cfg := clientv3.Config{
+		Endpoints:   []string{addr},
+		DialTimeout: constants.DefaultDialTimeout,
+	}
+	c, err := clientv3.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}

--- a/test/e2e/e2eutil/wait_util.go
+++ b/test/e2e/e2eutil/wait_util.go
@@ -36,6 +36,15 @@ import (
 type acceptFunc func(*v1.Pod) bool
 type filterFunc func(*v1.Pod) bool
 
+func CalculateRestoreWaitTime(needDataClone bool) time.Duration {
+	waitTime := 240 * time.Second
+	if needDataClone {
+		// Take additional time to clone the data.
+		waitTime += 60 * time.Second
+	}
+	return waitTime
+}
+
 func WaitUntilSizeReached(t *testing.T, kubeClient kubernetes.Interface, size int, timeout time.Duration, cl *spec.Cluster) ([]string, error) {
 	return waitSizeReachedWithAccept(t, kubeClient, size, timeout, cl)
 }

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -66,9 +66,9 @@ func TestPeerTLS(t *testing.T) {
 	}
 	// TODO: get rid of pod IP assumption.
 	clientURL := fmt.Sprintf("http://%s:2379", pod.Status.PodIP)
-	err = putDataToEtcd(clientURL)
+	err = e2eutil.PutDataToEtcd(clientURL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	checkEtcdData(t, clientURL)
+	e2eutil.CheckEtcdData(t, clientURL)
 }

--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -15,6 +15,7 @@
 package upgradetest
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -41,7 +42,7 @@ func TestResize(t *testing.T) {
 		t.Fatalf("failed to see cluster TPR get created in time: %v", err)
 	}
 
-	testClus, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, e2eutil.NewCluster("upgrade-test-", 3))
+	testClus, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, e2eutil.NewCluster("upgrade-test-resize-", 3))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,7 +92,7 @@ func TestHealOneMemberForOldCluster(t *testing.T) {
 		t.Fatalf("failed to see cluster TPR get created in time: %v", err)
 	}
 
-	testEtcd, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, e2eutil.NewCluster("upgrade-test-", 3))
+	testEtcd, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, e2eutil.NewCluster("upgrade-test-heal-", 3))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,6 +117,122 @@ func TestHealOneMemberForOldCluster(t *testing.T) {
 	if _, err := e2eutil.WaitUntilSizeReached(t, testF.KubeCli, 3, 60*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to heal one member: %v", err)
 	}
+}
+
+// TestRestoreFromBackup tests that new operator could recover a new cluster from a backup of the old cluster.
+func TestRestoreFromBackup(t *testing.T) {
+	t.Run("Restore from PV backup of old cluster", func(t *testing.T) {
+		testRestoreWithBackupPolicy(t, e2eutil.NewPVBackupPolicy())
+	})
+	t.Run("Restore from S3 backup of old cluster", func(t *testing.T) {
+		testRestoreWithBackupPolicy(t, e2eutil.NewS3BackupPolicy())
+	})
+}
+
+func testRestoreWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy) {
+	// create operator
+	err := testF.CreateOperator()
+	if err != nil {
+		t.Fatalf("failed to create operator:%v", err)
+	}
+	defer func() {
+		err := testF.DeleteOperator()
+		if err != nil {
+			t.Fatalf("failed to delete operator:%v", err)
+		}
+	}()
+	err = k8sutil.WaitEtcdTPRReady(testF.KubeCli.CoreV1().RESTClient(), 3*time.Second, 30*time.Second, testF.KubeNS)
+	if err != nil {
+		t.Fatalf("failed to see cluster TPR get created in time: %v", err)
+	}
+
+	// create cluster
+	bp.BackupIntervalInSecond = 60 * 60 * 24 // long enough that no backup was made automatically
+	bp.CleanupBackupsOnClusterDelete = false
+	origClus := e2eutil.NewCluster("upgrade-test-restore-", 3)
+	origClus = e2eutil.ClusterWithBackup(origClus, bp)
+	testClus, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, origClus)
+	if err != nil {
+		t.Fatalf("failed to create cluster:%v", err)
+	}
+	names, err := e2eutil.WaitUntilSizeReached(t, testF.KubeCli, 3, 60*time.Second, testClus)
+	if err != nil {
+		t.Fatalf("failed to reach desired cluster size:%v", err)
+	}
+	err = e2eutil.WaitBackupPodUp(t, testF.KubeCli, testF.KubeNS, testClus.Metadata.Name, 60*time.Second)
+	if err != nil {
+		t.Fatalf("failed to create backup pod: %v", err)
+	}
+
+	// write data to etcd and make a backup
+	pod, err := testF.KubeCli.CoreV1().Pods(testF.KubeNS).Get(names[0], metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get backup pod:%v", err)
+	}
+	err = e2eutil.PutDataToEtcd(fmt.Sprintf("http://%s:2379", pod.Status.PodIP))
+	if err != nil {
+		t.Fatalf("failed to put data to etcd:%v", err)
+	}
+	err = e2eutil.MakeBackup(testF.KubeCli, testClus.Metadata.Namespace, testClus.Metadata.Name)
+	if err != nil {
+		t.Fatalf("failed to make backup:%v", err)
+	}
+
+	// remove old cluster
+	checker := e2eutil.StorageCheckerOptions{
+		S3Cli:    testF.S3Cli,
+		S3Bucket: testF.S3Bucket,
+	}
+	err = e2eutil.DeleteClusterAndBackup(t, testF.KubeCli, testClus, checker)
+	if err != nil {
+		t.Fatalf("failed to delete cluster and its backup:%v", err)
+	}
+
+	err = testF.UpgradeOperator()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// create new cluster to restore from backup
+	// Restore the etcd cluster of the same name:
+	// - use the name already generated. We don't need to regenerate again.
+	// - set BackupClusterName to the same name in RestorePolicy.
+	// Then operator will use the existing backup in the same storage and
+	// restore cluster with the same data.
+	origClus.Metadata.GenerateName = ""
+	origClus.Metadata.Name = testClus.Metadata.Name
+
+	origClus = e2eutil.ClusterWithRestore(origClus, &spec.RestorePolicy{
+		BackupClusterName: origClus.Metadata.Name,
+		StorageType:       bp.StorageType,
+	})
+	origClus.Spec.Backup.CleanupBackupsOnClusterDelete = true
+	testClus, err = e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, origClus)
+	if err != nil {
+		t.Fatalf("failed to create cluster:%v", err)
+	}
+	defer func() {
+		checker := e2eutil.StorageCheckerOptions{
+			S3Cli:    testF.S3Cli,
+			S3Bucket: testF.S3Bucket,
+		}
+		err := e2eutil.DeleteClusterAndBackup(t, testF.KubeCli, testClus, checker)
+		if err != nil {
+			t.Fatalf("failed to delete cluster and its backup:%v", err)
+		}
+	}()
+
+	names, err = e2eutil.WaitUntilSizeReached(t, testF.KubeCli, 3, 240*time.Second, testClus)
+	if err != nil {
+		t.Fatalf("failed to reach desired cluster size: %v", err)
+	}
+
+	// ensure the data from the previous cluster is present
+	pod, err = testF.KubeCli.CoreV1().Pods(testF.KubeNS).Get(names[0], metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get backup pod:%v", err)
+	}
+	e2eutil.CheckEtcdData(t, fmt.Sprintf("http://%s:2379", pod.Status.PodIP))
 }
 
 // TestBackupForOldCluster tests that new backup sidecar could make backup from old cluster.
@@ -146,7 +263,7 @@ func testBackupForOldClusterWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy
 
 	bp.BackupIntervalInSecond = 60 * 60 * 24 // long enough that no backup was made automatically
 	bp.CleanupBackupsOnClusterDelete = true
-	cl := e2eutil.NewCluster("upgrade-test-", 3)
+	cl := e2eutil.NewCluster("upgrade-test-backup-", 3)
 	cl = e2eutil.ClusterWithBackup(cl, bp)
 	testClus, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, cl)
 	if err != nil {

--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -14,28 +14,7 @@
 
 package e2e
 
-import (
-	"github.com/coreos/etcd-operator/pkg/util/constants"
-
-	"github.com/coreos/etcd/clientv3"
-)
-
 const (
 	envParallelTest     = "PARALLEL_TEST"
 	envParallelTestTrue = "true"
-
-	etcdKeyFoo = "foo"
-	etcdValBar = "bar"
 )
-
-func createEtcdClient(addr string) (*clientv3.Client, error) {
-	cfg := clientv3.Config{
-		Endpoints:   []string{addr},
-		DialTimeout: constants.DefaultDialTimeout,
-	}
-	c, err := clientv3.New(cfg)
-	if err != nil {
-		return nil, err
-	}
-	return c, nil
-}


### PR DESCRIPTION
- Added `TestRestoreFromBackup ` to test if the upgraded operator can restore a cluster from the backup of an older cluster.
- Moved utils for reading and writing data to the etcd cluster into `e2eutil/etcd_util.go`.
- Added a test selector in `upgrade_pass` to make it easy to selectively run tests. And a timeout of 30m since all upgrade tests take at least 10 minutes currently.
- Made the `genName` passed to `CreateCluster()` unique for each upgrade test for ease of manual testing. 