### PR TITLE
cluster: add basic metrics

### DIFF
--- a/pkg/cluster/metrics.go
+++ b/pkg/cluster/metrics.go
@@ -1,0 +1,29 @@
+package cluster
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var reconcileHistogram = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+	Namespace: "etcd_operator",
+	Subsystem: "cluster",
+	Name:      "reconcile_duration",
+	Help:      "Reconcile duration histogram in second",
+	Buckets:   prometheus.ExponentialBuckets(0.1, 2, 10),
+},
+	[]string{"ClusterName"},
+)
+
+var reconcileFailed = prometheus.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "etcd_operator",
+	Subsystem: "cluster",
+	Name:      "reconcile_failed",
+	Help:      "Total number of failed reconcilations",
+},
+	[]string{"Reason"},
+)
+
+func init() {
+	prometheus.MustRegister(reconcileHistogram)
+	prometheus.MustRegister(reconcileFailed)
+}


### PR DESCRIPTION
fix https://github.com/coreos/etcd-operator/issues/737.

we do not really have ALL the metrics we want. but adding metrics around reconcile is probably good enough to start with.