### PR TITLE
*: drop compatability for non-namespaced s3 backup paths

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -81,12 +81,6 @@ func New(kclient kubernetes.Interface, clusterName, ns string, sp spec.ClusterSp
 			return nil, err
 		}
 
-		// for backward compatibility.
-		err = s3cli.CopyPrefix(clusterName)
-		if err != nil {
-			return nil, err
-		}
-
 		be = &s3Backend{
 			dir: tmpDir,
 			S3:  s3cli,

--- a/pkg/cluster/backupstorage/s3.go
+++ b/pkg/cluster/backupstorage/s3.go
@@ -42,12 +42,6 @@ func (s *s3) Create() error {
 }
 
 func (s *s3) Clone(from string) error {
-	// for backward compatibility.
-	err := s.s3cli.CopyPrefix(from)
-	if err != nil {
-		return err
-	}
-
 	prefix := s.namespace + "/" + from
 	return s.s3cli.CopyPrefix(prefix)
 }


### PR DESCRIPTION
Removed `CopyPrefix(clusterName)` so the backup manager will no longer be backwards compatible with non-namespaced s3 backups created by operators <= v0.2.5