### PR TITLE
doc: update instructions for per cluster S3 backup configurations

### DIFF
--- a/doc/user/spec_examples.md
+++ b/doc/user/spec_examples.md
@@ -58,6 +58,20 @@ spec:
     storageType: "S3"
 ```
 
+### S3 backup and cluster specific S3 configuration
+
+```yaml
+spec:
+  size: 3
+  backup:
+    backupIntervalInSecond: 1800
+    maxBackups: 5
+    storageType: "S3"
+    s3:
+      s3Bucket: <S3-bucket-name>
+      awsSecret: <aws-secret-name>
+```
+
 ### Three members cluster that restores from previous PV backup
 
 If a cluster `cluster-a` was created with backup, but deleted or failed later on,


### PR DESCRIPTION
[skip ci]
Updated the sections in backup_config.md `S3 on AWS` to explain how to setup operator and cluster level S3 backup configurations.

The link in `Cluster level configuration` to the section `S3 backup and cluster specific S3 configuration` will start working once the PR is merged and spec_examples.md is updated.