### PR TITLE
e2eutil/wait_util: wait until etcd member is ready

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -82,10 +82,10 @@ func TestPauseControl(t *testing.T) {
 	if err := e2eutil.KillMembers(f.KubeClient, f.Namespace, names[0]); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 2, 10*time.Second, testEtcd); err != nil {
+	if _, err := e2eutil.WaitUntilPodSizeReached(t, f.KubeClient, 2, 10*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to wait for killed member to die: %v", err)
 	}
-	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 10*time.Second, testEtcd); err == nil {
+	if _, err := e2eutil.WaitUntilPodSizeReached(t, f.KubeClient, 3, 10*time.Second, testEtcd); err == nil {
 		t.Fatalf("cluster should not be recovered: control is paused")
 	}
 

--- a/test/e2e/e2eslow/disruptive_test.go
+++ b/test/e2e/e2eslow/disruptive_test.go
@@ -47,10 +47,10 @@ func TestRestartOperator(t *testing.T) {
 	if err := e2eutil.KillMembers(f.KubeClient, f.Namespace, names[0]); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 2, 10*time.Second, testEtcd); err != nil {
+	if _, err := e2eutil.WaitUntilPodSizeReached(t, f.KubeClient, 2, 10*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to wait for killed member to die: %v", err)
 	}
-	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 10*time.Second, testEtcd); err == nil {
+	if _, err := e2eutil.WaitUntilPodSizeReached(t, f.KubeClient, 3, 10*time.Second, testEtcd); err == nil {
 		t.Fatalf("cluster should not be recovered: operator is deleted")
 	}
 


### PR DESCRIPTION
`waitSizeReachedWithAccept()` now waits until the cluster TPR shows the desired number of ready members.

`WaitUntilPodSizeReached` is needed for the tests `TestPauseControl` and `TestRestartOperator` to directly check the number of pods, since the TPR won't be updated while the operator is paused/deleted. 

fixes #1060 