### PR TITLE
selfHosted: fix backup unable to talk to etcd pods 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- [GH-1108] selfHosted: fix backup unable to talk to etcd pods
+
 ### Deprecated
 
 ### Security


### PR DESCRIPTION
Currently Backup Sidecar is not able to talk to etcd pods because
it is using the FQDN which isn't supported in self hosted yet.
For self-hosted case, we are going to use PodIP.

fix https://github.com/coreos/etcd-operator/issues/1107