### PR TITLE
e2e: refactor NewXXBackupPolicy() to include cleanup option

### DIFF
--- a/test/e2e/cluster_status_test.go
+++ b/test/e2e/cluster_status_test.go
@@ -78,8 +78,7 @@ func testBackupStatus(t *testing.T) {
 	}
 	f := framework.Global
 
-	bp := e2eutil.NewPVBackupPolicy()
-	bp.CleanupBackupsOnClusterDelete = true
+	bp := e2eutil.NewPVBackupPolicy(true)
 	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.ClusterWithBackup(e2eutil.NewCluster("test-etcd-", 1), bp))
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -38,7 +38,7 @@ func NewCluster(genName string, size int) *spec.Cluster {
 	}
 }
 
-func NewS3BackupPolicy() *spec.BackupPolicy {
+func NewS3BackupPolicy(cleanup bool) *spec.BackupPolicy {
 	return &spec.BackupPolicy{
 		BackupIntervalInSecond: 60 * 60,
 		MaxBackups:             5,
@@ -49,18 +49,20 @@ func NewS3BackupPolicy() *spec.BackupPolicy {
 				AWSSecret: os.Getenv("TEST_AWS_SECRET"),
 			},
 		},
+		CleanupBackupsOnClusterDelete: cleanup,
 	}
 }
 
-func NewOperatorS3BackupPolicy() *spec.BackupPolicy {
+func NewOperatorS3BackupPolicy(cleanup bool) *spec.BackupPolicy {
 	return &spec.BackupPolicy{
-		BackupIntervalInSecond: 60 * 60,
-		MaxBackups:             5,
-		StorageType:            spec.BackupStorageTypeS3,
+		BackupIntervalInSecond:        60 * 60,
+		MaxBackups:                    5,
+		StorageType:                   spec.BackupStorageTypeS3,
+		CleanupBackupsOnClusterDelete: cleanup,
 	}
 }
 
-func NewPVBackupPolicy() *spec.BackupPolicy {
+func NewPVBackupPolicy(cleanup bool) *spec.BackupPolicy {
 	return &spec.BackupPolicy{
 		BackupIntervalInSecond: 60 * 60,
 		MaxBackups:             5,
@@ -70,6 +72,7 @@ func NewPVBackupPolicy() *spec.BackupPolicy {
 				VolumeSizeInMB: 512,
 			},
 		},
+		CleanupBackupsOnClusterDelete: cleanup,
 	}
 }
 

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -73,7 +73,7 @@ func testClusterRestoreDifferentName(t *testing.T) {
 }
 
 func testClusterRestore(t *testing.T, needDataClone bool) {
-	testClusterRestoreWithBackupPolicy(t, needDataClone, e2eutil.NewPVBackupPolicy())
+	testClusterRestoreWithBackupPolicy(t, needDataClone, e2eutil.NewPVBackupPolicy(false))
 }
 
 func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backupPolicy *spec.BackupPolicy) {
@@ -182,9 +182,9 @@ func testClusterRestoreS3SameName(t *testing.T, perCluster bool) {
 
 	var bp *spec.BackupPolicy
 	if perCluster {
-		bp = e2eutil.NewS3BackupPolicy()
+		bp = e2eutil.NewS3BackupPolicy(false)
 	} else {
-		bp = e2eutil.NewOperatorS3BackupPolicy()
+		bp = e2eutil.NewOperatorS3BackupPolicy(false)
 	}
 
 	testClusterRestoreWithBackupPolicy(t, false, bp)
@@ -197,9 +197,9 @@ func testClusterRestoreS3DifferentName(t *testing.T, perCluster bool) {
 
 	var bp *spec.BackupPolicy
 	if perCluster {
-		bp = e2eutil.NewS3BackupPolicy()
+		bp = e2eutil.NewS3BackupPolicy(false)
 	} else {
-		bp = e2eutil.NewOperatorS3BackupPolicy()
+		bp = e2eutil.NewOperatorS3BackupPolicy(false)
 	}
 
 	testClusterRestoreWithBackupPolicy(t, true, bp)

--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -122,14 +122,14 @@ func TestHealOneMemberForOldCluster(t *testing.T) {
 // TestRestoreFromBackup tests that new operator could recover a new cluster from a backup of the old cluster.
 func TestRestoreFromBackup(t *testing.T) {
 	t.Run("Restore from PV backup of old cluster", func(t *testing.T) {
-		testRestoreWithBackupPolicy(t, e2eutil.NewPVBackupPolicy())
+		testRestoreWithBackupPolicy(t, e2eutil.NewPVBackupPolicy(false))
 	})
 	t.Run("Restore from S3 backup of old cluster", func(t *testing.T) {
 		t.Run("per cluster s3 policy", func(t *testing.T) {
-			testRestoreWithBackupPolicy(t, e2eutil.NewS3BackupPolicy())
+			testRestoreWithBackupPolicy(t, e2eutil.NewS3BackupPolicy(false))
 		})
 		t.Run("operator wide s3 policy", func(t *testing.T) {
-			testRestoreWithBackupPolicy(t, e2eutil.NewOperatorS3BackupPolicy())
+			testRestoreWithBackupPolicy(t, e2eutil.NewOperatorS3BackupPolicy(false))
 		})
 	})
 }
@@ -151,7 +151,6 @@ func testRestoreWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy) {
 		t.Fatalf("failed to see cluster TPR get created in time: %v", err)
 	}
 
-	bp.CleanupBackupsOnClusterDelete = false
 	origClus := e2eutil.NewCluster("upgrade-test-restore-", 3)
 	origClus = e2eutil.ClusterWithBackup(origClus, bp)
 	testClus, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, origClus)
@@ -241,14 +240,14 @@ func testRestoreWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy) {
 // TestBackupForOldCluster tests that new backup sidecar could make backup from old cluster.
 func TestBackupForOldCluster(t *testing.T) {
 	t.Run("PV backup for old cluster", func(t *testing.T) {
-		testBackupForOldClusterWithBackupPolicy(t, e2eutil.NewPVBackupPolicy())
+		testBackupForOldClusterWithBackupPolicy(t, e2eutil.NewPVBackupPolicy(true))
 	})
 	t.Run("S3 backup for old cluster", func(t *testing.T) {
 		t.Run("per cluster s3 policy", func(t *testing.T) {
-			testBackupForOldClusterWithBackupPolicy(t, e2eutil.NewS3BackupPolicy())
+			testBackupForOldClusterWithBackupPolicy(t, e2eutil.NewS3BackupPolicy(true))
 		})
 		t.Run("operator wide s3 policy", func(t *testing.T) {
-			testBackupForOldClusterWithBackupPolicy(t, e2eutil.NewOperatorS3BackupPolicy())
+			testBackupForOldClusterWithBackupPolicy(t, e2eutil.NewOperatorS3BackupPolicy(true))
 		})
 	})
 }
@@ -271,7 +270,6 @@ func testBackupForOldClusterWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy
 
 	// Make interval long so no backup is made by the sidecar since we want to make only one backup during the whole test
 	bp.BackupIntervalInSecond = 60 * 60 * 24
-	bp.CleanupBackupsOnClusterDelete = true
 	cl := e2eutil.NewCluster("upgrade-test-backup-", 3)
 	cl = e2eutil.ClusterWithBackup(cl, bp)
 	testClus, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, cl)
@@ -324,14 +322,14 @@ func testBackupForOldClusterWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy
 // TestDisasterRecovery tests if the new operator could do disaster recovery from backup of the old cluster.
 func TestDisasterRecovery(t *testing.T) {
 	t.Run("Recover from PV backup", func(t *testing.T) {
-		testDisasterRecoveryWithBackupPolicy(t, e2eutil.NewPVBackupPolicy())
+		testDisasterRecoveryWithBackupPolicy(t, e2eutil.NewPVBackupPolicy(true))
 	})
 	t.Run("Recover from S3 backup", func(t *testing.T) {
 		t.Run("per cluster s3 policy", func(t *testing.T) {
-			testDisasterRecoveryWithBackupPolicy(t, e2eutil.NewS3BackupPolicy())
+			testDisasterRecoveryWithBackupPolicy(t, e2eutil.NewS3BackupPolicy(true))
 		})
 		t.Run("operator wide s3 policy", func(t *testing.T) {
-			testDisasterRecoveryWithBackupPolicy(t, e2eutil.NewOperatorS3BackupPolicy())
+			testDisasterRecoveryWithBackupPolicy(t, e2eutil.NewOperatorS3BackupPolicy(true))
 		})
 	})
 }
@@ -352,7 +350,6 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy) {
 		t.Fatalf("failed to see cluster TPR get created in time: %v", err)
 	}
 
-	bp.CleanupBackupsOnClusterDelete = true
 	testClus := e2eutil.NewCluster("upgrade-test-recovery-", 3)
 	testClus = e2eutil.ClusterWithBackup(testClus, bp)
 	testClus, err = e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, testClus)


### PR DESCRIPTION
There is a lot of `CleanupBackupsOnClusterDelete` scattered around. They can be simplified if we initiate them in NewXXBackupPolicy()