### PR TITLE
doc: correct diagrams; replace tabs with sapces.

### DIFF
--- a/doc/design/cluster_status.md
+++ b/doc/design/cluster_status.md
@@ -6,15 +6,15 @@ A common way to do this in the Kuberentes world is through status field, like po
 
 ```go
 type EtcdCluster struct {
-	unversioned.TypeMeta `json:",inline"`
-	api.ObjectMeta       `json:"metadata,omitempty"`
-	Spec                 ClusterSpec `json:"spec"`
-	Status               ClusterStatus `json:"status"`   
+    unversioned.TypeMeta `json:",inline"`
+    api.ObjectMeta       `json:"metadata,omitempty"`
+    Spec                 ClusterSpec `json:"spec"`
+    Status               ClusterStatus `json:"status"`   
 }
 
 Type ClusterStatus struct {
-	Paused bool `json:"paused"`
-	...
+    Paused bool `json:"paused"`
+    ...
 }
 ```
 

--- a/doc/design/cluster_tls.md
+++ b/doc/design/cluster_tls.md
@@ -17,73 +17,75 @@ Here is the overview for etcd-operator TLS flow, which should set us up well for
 
 ### Trust delegation diagram:
 
+```
     -----------------
     | external PKI  |  (something that can sign the operator's CSRs)
     -----------------
-		  |	 |
-	      |  | /|\ CERT
-		  |  |  |   |
-	      |  |  |   |
-		  |  | CSR \|/
-	      |  |
-		  |	 |
-		  |  |
-		  |  |---> [ operator client-interface CA ]
-		  |         |
-		  |			|                    --------------> [ etcd-cluster-A client-interface CLIENT CERT ]
-		  |			|                    |
-		  |			|             DIRECT | SIGN
-		  |			|		             |
-		  |			|-------->  [ etcd-cluster-A client-interface CERTIFICATE AUTHORITY ]
-	 	  |			|                    |
-		  |		 D	|                    |  etcd-cluster-A-0000
-       	  |		 I	|                    |-------------> [ client-interface SERVER CERT ]
-		  |		 R	|           /|\ CERT |
-	      |		 E	|            |   |   |  etcd-cluster-A-0001
-		  |		 C	|           CSR \|/  |-------------> [ client-interface SERVER CERT ]
-		  |		 T	|                    |
-		  |		 	|                    |  etcd-cluster-A-0002
-		  |		 S	|                    |-------------> [ client-interface SERVER CERT ]
-		  |		 I	|                    |
-		  |		 G	|                    |  cluster-A-backup-sidecar
-		  |		 N	|                    |-------------> [ client-interface CLIENT CERT ]
-		  |			|
-		  |			|
-		  |			|
-		  |			|                    --------------> [ etcd-cluster-B client-interface CLIENT CERT ]
-		  |			|                    |
-		  |			|             DIRECT | SIGN
-		  |			|		             |
-		  |			|-------->  [ etcd-cluster-B client-interface CERTIFICATE AUTHORITY ]
-     /|\  | CERT	|					 |
-	  |   |	 |		|					 |  etcd-cluster-B-0000
-	  |	  |	 |		|					 |------> ...
-	 CSR  | \|/ 	|
-		  |			| ...
+          |     |
+          |  | /|\ CERT
+          |  |  |   |
+          |  |  |   |
+          |  | CSR \|/
+          |  |
+          |  |
+          |  |
+          |  |---> [ operator client-interface CA ]
+          |         |
+          |            |                    --------------> [ etcd-cluster-A client-interface CLIENT CERT ]
+          |            |                    |
+          |            |             DIRECT | SIGN
+          |            |                     |
+          |            |-------->  [ etcd-cluster-A client-interface CERTIFICATE AUTHORITY ]
+          |            |                    |
+          |         D  |                    |  etcd-cluster-A-0000
+          |         I  |                    |-------------> [ client-interface SERVER CERT ]
+          |         R  |           /|\ CERT |
+          |         E  |            |   |   |  etcd-cluster-A-0001
+          |         C  |           CSR \|/  |-------------> [ client-interface SERVER CERT ]
+          |         T  |                    |
+          |            |                    |  etcd-cluster-A-0002
+          |         S  |                    |-------------> [ client-interface SERVER CERT ]
+          |         I  |                    |
+          |         G  |                    |  cluster-A-backup-sidecar
+          |         N  |                    |-------------> [ client-interface CLIENT CERT ]
+          |            |                    |
+          |            |                    |
+          |            |                    |
+          |            |                    --------------> [ etcd-cluster-B client-interface CLIENT CERT ]
+          |            |                    |
+          |            |             DIRECT | SIGN
+          |            |                    |
+          |            |                    |-------->  [ etcd-cluster-B client-interface CERTIFICATE AUTHORITY ]
+     /|\  | CERT       |                    |
+      |   |  |         |                    |  etcd-cluster-B-0000
+      |      |         |                    |------> ...
+     CSR  | \|/        |
+          |            | ...
           |
-		  |
-		  |------> [ operator peer-interface CA ]
-					|
-					|
-					|-------->  [ etcd-cluster-A peer interface CERTIFICATE AUTHORITY ]
-					|                    |
-				 D	|                    |  etcd-cluster-A-0000
-				 I	|                    |-------------> [ peer-interface SERVER CERT ]
-				 R	|           /|\ CERT |
-				 E	|            |   |   |  etcd-cluster-A-0001
-				 C	|           CSR \|/  |-------------> [ peer-interface SERVER CERT ]
-				 T	|                    |
-				 	|                    |  etcd-cluster-A-0002
-				 S	|                    |-------------> [ peer-interface SERVER CERT ]
-				 I	|
-				 G	|
-				 N	|
-					|-------->  [ etcd-cluster-B peer interface CERTIFICATE AUTHORITY ]
-					|					 |
-					|					 |  etcd-cluster-B-0000
-					|					 |------> ...
-					|
-					| ...
+          |
+          |------> [ operator peer-interface CA ]
+                    |
+                    |
+                    |-------->  [ etcd-cluster-A peer interface CERTIFICATE AUTHORITY ]
+                    |                    |
+                 D  |                    |  etcd-cluster-A-0000
+                 I  |                    |-------------> [ peer-interface SERVER CERT ]
+                 R  |           /|\ CERT |
+                 E  |            |   |   |  etcd-cluster-A-0001
+                 C  |           CSR \|/  |-------------> [ peer-interface SERVER CERT ]
+                 T  |                    |
+                    |                    |  etcd-cluster-A-0002
+                 S  |                    |-------------> [ peer-interface SERVER CERT ]
+                 I  |
+                 G  |
+                 N  |
+                    |-------->  [ etcd-cluster-B peer interface CERTIFICATE AUTHORITY ]
+                    |                     |
+                    |                     |  etcd-cluster-B-0000
+                    |                     |------> ...
+                    |
+                    | ...
+```
 
 
 
@@ -116,25 +118,29 @@ Here is the overview for etcd-operator TLS flow, which should set us up well for
 
 #### Direct Sign (intra-component)
 
+```
            [ signer ]
                |
-	           |
-	    DIRECT | SIGN
-	           |
-	           |
+               |
+        DIRECT | SIGN
+               |
+               |
                -----> [ signee ]
+```
 
 In the case that the _signer_ and _signee_ are within the same component, we have the _signer's_ private key material immediately available to produce a signed certificate for the _signee_. No need for CSR exchange.
 
 #### CSR/Cert exchange (inter-component)
 
+```
            [ signer ]
                |
-	 /|\ CERT  |
-	  |   |    |
-	  |   |    |
-	 CSR \|/   |
+     /|\ CERT  |
+      |   |    |
+      |   |    |
+     CSR \|/   |
                -----> [ signee ]
+```
 
 
 This is a symbol for a _signee_ submitting a CSR to a _signer_, and recieving back a signed certificate back.

--- a/doc/user/backup_service.md
+++ b/doc/user/backup_service.md
@@ -22,17 +22,17 @@ JSON format of the backup status when backup is successful.
 
 ``` go
 type BackupStatus struct {
-	// Creation time of the backup.
-	CreationTime string `json:"creationTime"`
+    // Creation time of the backup.
+    CreationTime string `json:"creationTime"`
 
-	// Size is the size of the backup in MB.
-	Size float64 `json:"size"`
+    // Size is the size of the backup in MB.
+    Size float64 `json:"size"`
 
-	// Version is the version of the backup cluster.
-	Version string `json:"version"`
+    // Version is the version of the backup cluster.
+    Version string `json:"version"`
 
-	// TimeTookInSecond is the total time took to create the backup.
-	TimeTookInSecond int `json:"timeTookInSecond"`
+    // TimeTookInSecond is the total time took to create the backup.
+    TimeTookInSecond int `json:"timeTookInSecond"`
 }
 ```
 


### PR DESCRIPTION
~[The cluster_tls page](https://coreos.com/operators/etcd/docs/latest/design/cluster_tls.html#trust-delegation-diagram) has a diagram which includes mixed spaces and tabs, making it look mangled. This fixes that malformatting.~

~cc @colhom  to make sure the diagram is correct.~

UDPATE: Actually we're deleting that doc instead. @hongchaodeng does this look good to you? I can remove that other commit.

[skip ci]