### PR TITLE
e2e: add missing AWS_TEST_ENABLED check

### DIFF
--- a/test/e2e/self_hosted_test.go
+++ b/test/e2e/self_hosted_test.go
@@ -132,6 +132,10 @@ func testCreateSelfHostedClusterWithBootMember(t *testing.T) {
 }
 
 func testSelfHostedClusterWithBackup(t *testing.T) {
+	if os.Getenv("AWS_TEST_ENABLED") != "true" {
+		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
+	}
+
 	f := framework.Global
 
 	cl := e2eutil.NewCluster("test-cluster-", 3)


### PR DESCRIPTION
Seems like somehow we didn’t set AWS_TEST_ENABLED=true in master jenkins job..

Fixed in jenkins. Also adding the check here.