### PR TITLE
remove aboslute path references in docs.

### DIFF
--- a/doc/user/upgrade/incompatible_upgrade.md
+++ b/doc/user/upgrade/incompatible_upgrade.md
@@ -4,7 +4,7 @@ For the case when the desired operator version is not compatible with an existin
 This is a more general way to upgrade the operator when an in-place update is not possible.
 
 
-First make a backup of the current cluster. See the [backup service](/doc/user/backup_service.md) doc to see how to do this from inside the kubernetes cluster.
+First make a backup of the current cluster. See the [backup service](../backup_service.md) doc to see how to do this from inside the kubernetes cluster.
 
 Next delete the current cluster and operator. Make sure that the `cleanupBackupsOnClusterDelete` field was not set to `true` for the cluster configuration since that would clean the backup upon deleting the cluster.
 ```bash

--- a/doc/user/upgrade/upgrade_guide.md
+++ b/doc/user/upgrade/upgrade_guide.md
@@ -1,9 +1,9 @@
 # Upgrade Guide
 
-This document shows how to safely upgrade the operator to a desired version while preserving the cluster's state and data whenever possible. It is assumed that the preexisting cluster is configured to create and store backups to persistent storage. See the [backup config guide](/doc/user/backup_config.md) for details.
+This document shows how to safely upgrade the operator to a desired version while preserving the cluster's state and data whenever possible. It is assumed that the preexisting cluster is configured to create and store backups to persistent storage. See the [backup config guide](../backup_config.md) for details.
 
 ### Backup safety precaution:
-First create a backup of your current cluster before starting the upgrade process. See the [backup service guide](/doc/user/backup_service.md) on how to create a backup.
+First create a backup of your current cluster before starting the upgrade process. See the [backup service guide](../backup_service.md) on how to create a backup.
 
 In the case of an upgrade failure you can restore your cluster to the previous state from the previous backup. See the [spec examples](https://github.com/coreos/etcd-operator/blob/master/doc/user/spec_examples.md#three-members-cluster-that-restores-from-previous-pv-backup) on how to do that.
 
@@ -20,7 +20,7 @@ $ kubectl edit deployment/etcd-operator
 ```
 
 ### Incompatible upgrade
-In the case of an incompatible upgrade, the process requires restoring a new cluster from backup. See the [incompatible upgrade guide](/doc/user/upgrade/incompatible_upgrade.md) for more information.
+In the case of an incompatible upgrade, the process requires restoring a new cluster from backup. See the [incompatible upgrade guide](incompatible_upgrade.md) for more information.
 
 
 ## v0.2.x to v0.3.x


### PR DESCRIPTION
The downstream documentation on coreos.com does not like absolute URLs.
This is the upstream patch to remove those absolute paths.