### PR TITLE
k8sutil: apply anti-affinity to etcd pods only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Anti-affinity only applies to etcd pods. Backup pod could still colocate with any etcd pod.
+
 ### Removed
 
 - Update default etcd version to 3.1.8

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -90,6 +90,7 @@ func PodWithAntiAffinity(pod *v1.Pod, clusterName string) *v1.Pod {
 	// set pod anti-affinity with the pods that belongs to the same etcd cluster
 	ls := &metav1.LabelSelector{MatchLabels: map[string]string{
 		"etcd_cluster": clusterName,
+		"app":          "etcd",
 	}}
 	return podWithAntiAffinity(pod, ls)
 }


### PR DESCRIPTION
Expected behavior (TB implemented):

|                                                  |  sidecar with anti-affinity | sidecar without anti-affinity |
|------------------------------|--------------------------|-----------------------------|
| etcd pod with anti-affinity      | cannot colocate               | can colocate                           |
| etcd pod without anti-affinity | can colocate                    | can colocate                           |

Current status:
- for self-hosted, etcd pods and backup sidecar can colocate regardlessly,
- for normal cluster, etcd pods and backup sidecar cannot colocate if anti-affinity is set on PodPolicy.