### PR TITLE
cluster: delete backup manager's deployment, service and storage on spec change

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -373,7 +373,8 @@ func (c *Cluster) updateBackupPolicy(ob, nb *spec.BackupPolicy) error {
 		}
 		return c.bm.setup()
 	case ob != nil && nb == nil:
-		// TODO: delete backup sidecar
+		c.bm.deleteBackupSidecar()
+		c.bm = nil
 	case ob != nil && nb != nil:
 		return c.bm.updateSidecar(c.cluster)
 	default:

--- a/pkg/garbagecollection/gc.go
+++ b/pkg/garbagecollection/gc.go
@@ -146,13 +146,7 @@ func (gc *GC) collectDeployment(option metav1.ListOptions, runningSet map[types.
 			continue
 		}
 		if !runningSet[d.OwnerReferences[0].UID] {
-			err = gc.kubecli.AppsV1beta1().Deployments(gc.ns).Delete(d.GetName(), &metav1.DeleteOptions{
-				GracePeriodSeconds: func(t int64) *int64 { return &t }(0),
-				PropagationPolicy: func() *metav1.DeletionPropagation {
-					foreground := metav1.DeletePropagationForeground
-					return &foreground
-				}(),
-			})
+			err = gc.kubecli.AppsV1beta1().Deployments(gc.ns).Delete(d.GetName(), k8sutil.CascadeDeleteOptions(0))
 			if err != nil {
 				if !k8sutil.IsKubernetesResourceNotFoundError(err) {
 					return err

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -389,6 +389,16 @@ func PatchDeployment(kubecli kubernetes.Interface, namespace, name string, updat
 	return err
 }
 
+func CascadeDeleteOptions(gracePeriodSeconds int64) *metav1.DeleteOptions {
+	return &metav1.DeleteOptions{
+		GracePeriodSeconds: func(t int64) *int64 { return &t }(gracePeriodSeconds),
+		PropagationPolicy: func() *metav1.DeletionPropagation {
+			foreground := metav1.DeletePropagationForeground
+			return &foreground
+		}(),
+	}
+}
+
 // mergeLables merges l2 into l1. Conflicting label will be skipped.
 func mergeLabels(l1, l2 map[string]string) {
 	for k, v := range l2 {

--- a/test/e2e/e2eutil/tpr_util.go
+++ b/test/e2e/e2eutil/tpr_util.go
@@ -62,7 +62,7 @@ func DeleteClusterAndBackup(t *testing.T, kubecli kubernetes.Interface, cl *spec
 	if err != nil {
 		return err
 	}
-	err = waitBackupDeleted(kubecli, cl, checkerOpt)
+	err = WaitBackupDeleted(kubecli, cl, checkerOpt)
 	if err != nil {
 		return fmt.Errorf("fail to wait backup deleted: %v", err)
 	}

--- a/test/e2e/e2eutil/wait_util.go
+++ b/test/e2e/e2eutil/wait_util.go
@@ -131,7 +131,7 @@ func waitResourcesDeleted(t *testing.T, kubeClient kubernetes.Interface, cl *spe
 	return nil
 }
 
-func waitBackupDeleted(kubeClient kubernetes.Interface, cl *spec.Cluster, storageCheckerOptions StorageCheckerOptions) error {
+func WaitBackupDeleted(kubeClient kubernetes.Interface, cl *spec.Cluster, storageCheckerOptions StorageCheckerOptions) error {
 	err := retryutil.Retry(5*time.Second, 5, func() (bool, error) {
 		_, err := kubeClient.AppsV1beta1().Deployments(cl.Metadata.Namespace).Get(k8sutil.BackupSidecarName(cl.Metadata.Name), metav1.GetOptions{})
 		if err == nil {

--- a/test/e2e/upgradetest/framework/framework.go
+++ b/test/e2e/upgradetest/framework/framework.go
@@ -108,11 +108,7 @@ func (f *Framework) CreateOperator() error {
 }
 
 func (f *Framework) DeleteOperator() error {
-	foreground := metav1.DeletePropagationForeground
-	err := f.KubeCli.AppsV1beta1().Deployments(f.KubeNS).Delete("etcd-operator", &metav1.DeleteOptions{
-		GracePeriodSeconds: func(t int64) *int64 { return &t }(0),
-		PropagationPolicy:  &foreground,
-	})
+	err := f.KubeCli.AppsV1beta1().Deployments(f.KubeNS).Delete("etcd-operator", k8sutil.CascadeDeleteOptions(0))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If the backup policy becomes nil in the new spec then the backup sidecar deployment, backup service and storage(if `CleanupBackupsOnClusterDelete` is set) should get deleted.

Should there be anything in the changelog for this?