### PR TITLE
spec: add support for host networking

### DIFF
--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -150,6 +150,9 @@ type PodPolicy struct {
 	// bootstrap the cluster (for example `--initial-cluster` flag).
 	// This field cannot be updated.
 	EtcdEnv []v1.EnvVar `json:"etcdEnv,omitempty"`
+
+	// HostNetwork determines if the etcd will run in host network mode.
+	HostNetwork bool `json:"hostNetwork,omitempty"`
 }
 
 func (c *ClusterSpec) Validate() error {

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -149,6 +149,10 @@ func applyPodPolicyToPodTemplateSpec(clusterName string, pod *v1.PodTemplateSpec
 	if len(policy.Tolerations) != 0 {
 		pod.Spec.Tolerations = policy.Tolerations
 	}
+	if policy.HostNetwork {
+		pod.Spec.HostNetwork = true
+		pod.Spec.DNSPolicy = v1.DNSClusterFirstWithHostNet
+	}
 
 	mergeLabels(pod.Labels, policy.Labels)
 }


### PR DESCRIPTION
We have a usage where we need to deploy metric collection agent(collectd) as daemonset on all nodes running etcd(one pod per node). The problem is the agent needs a stable way to talk to the etcd instance on the same node. By running both etcd and collectd under host networking mode, the metric agent can simply talk to `localhost:2379` to collect the metric.