### PR TITLE
*: parallelize e2e tests dramatically

### DIFF
--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -24,15 +24,7 @@ import (
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
-func TestBasic(t *testing.T) {
-	t.Run("basic test", func(t *testing.T) {
-		t.Run("create cluster", testCreateCluster)
-		t.Run("upgrade cluster", testEtcdUpgrade)
-		t.Run("pause control", testPauseControl)
-	})
-}
-
-func testCreateCluster(t *testing.T) {
+func TestCreateCluster(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -53,9 +45,9 @@ func testCreateCluster(t *testing.T) {
 	}
 }
 
-// testPauseControl tests the user can pause the operator from controlling
+// TestPauseControl tests the user can pause the operator from controlling
 // an etcd cluster.
-func testPauseControl(t *testing.T) {
+func TestPauseControl(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -109,7 +101,7 @@ func testPauseControl(t *testing.T) {
 	}
 }
 
-func testEtcdUpgrade(t *testing.T) {
+func TestEtcdUpgrade(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}

--- a/test/e2e/cluster_status_test.go
+++ b/test/e2e/cluster_status_test.go
@@ -27,14 +27,7 @@ import (
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
-func TestClusterStatus(t *testing.T) {
-	t.Run("cluster status test", func(t *testing.T) {
-		t.Run("ready member status", testReadyMembersStatus)
-		t.Run("backup status", testBackupStatus)
-	})
-}
-
-func testReadyMembersStatus(t *testing.T) {
+func TestReadyMembersStatus(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -72,7 +65,7 @@ func testReadyMembersStatus(t *testing.T) {
 	}
 }
 
-func testBackupStatus(t *testing.T) {
+func TestBackupStatus(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}

--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -26,32 +26,23 @@ import (
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
-func TestFailureRecovery(t *testing.T) {
-	t.Run("failure recovery", func(t *testing.T) {
-		t.Run("1 member (minority) down", testOneMemberRecovery)
-		t.Run("2 members (majority) down", testDisasterRecovery2Members)
-		t.Run("3 members (all) down", testDisasterRecoveryAll)
-	})
+func TestPerClusterS3MajDown(t *testing.T) {
+	testS3MajorityDown(t, true)
 }
 
-func TestS3Backup(t *testing.T) {
-	if os.Getenv("AWS_TEST_ENABLED") != "true" {
-		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
-	}
-	t.Run("2 members (majority) down", func(t *testing.T) {
-		t.Run("per cluster s3 policy", func(t *testing.T) { testS3MajorityDown(t, true) })
-		t.Run("operator wide s3 policy", func(t *testing.T) { testS3MajorityDown(t, false) })
-	})
-	t.Run("3 members (all) down", func(t *testing.T) {
-		t.Run("per cluster s3 policy", func(t *testing.T) { testS3AllDown(t, true) })
-		t.Run("operator wide s3 policy", func(t *testing.T) { testS3AllDown(t, false) })
-	})
-	t.Run("dynamically add backup policy", testDynamicAddBackupPolicy)
-	t.Run("dynamically remove backup policy", testDynamicRemoveBackupPolicy)
-
+func TestOperWideS3MajDown(t *testing.T) {
+	testS3MajorityDown(t, true)
 }
 
-func testOneMemberRecovery(t *testing.T) {
+func TestPerClusterS3AllDown(t *testing.T) {
+	testS3AllDown(t, true)
+}
+
+func TestOperWideS3AllDown(t *testing.T) {
+	testS3AllDown(t, false)
+}
+
+func TestOneMemberRecovery(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -83,9 +74,9 @@ func testOneMemberRecovery(t *testing.T) {
 	}
 }
 
-// testDisasterRecovery2Members tests disaster recovery that
+// TestDisasterRecoveryMaj tests disaster recovery that
 // ooperator will make a backup from the left one pod.
-func testDisasterRecovery2Members(t *testing.T) {
+func TestDisasterRecoveryMaj(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -94,7 +85,7 @@ func testDisasterRecovery2Members(t *testing.T) {
 
 // testDisasterRecoveryAll tests disaster recovery that
 // we should make a backup ahead and ooperator will recover cluster from it.
-func testDisasterRecoveryAll(t *testing.T) {
+func TestDisasterRecoveryAll(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -171,6 +162,9 @@ func testDisasterRecoveryWithCluster(t *testing.T, numToKill int, cl *spec.Clust
 }
 
 func testS3MajorityDown(t *testing.T, perCluster bool) {
+	if os.Getenv("AWS_TEST_ENABLED") != "true" {
+		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
+	}
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -186,6 +180,9 @@ func testS3MajorityDown(t *testing.T, perCluster bool) {
 }
 
 func testS3AllDown(t *testing.T, perCluster bool) {
+	if os.Getenv("AWS_TEST_ENABLED") != "true" {
+		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
+	}
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -200,7 +197,10 @@ func testS3AllDown(t *testing.T, perCluster bool) {
 	testDisasterRecoveryWithBackupPolicy(t, 3, bp)
 }
 
-func testDynamicAddBackupPolicy(t *testing.T) {
+func TestDynamicAddBackupPolicy(t *testing.T) {
+	if os.Getenv("AWS_TEST_ENABLED") != "true" {
+		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
+	}
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -236,7 +236,10 @@ func testDynamicAddBackupPolicy(t *testing.T) {
 	}
 }
 
-func testDynamicRemoveBackupPolicy(t *testing.T) {
+func TestDynamicRemoveBackupPolicy(t *testing.T) {
+	if os.Getenv("AWS_TEST_ENABLED") != "true" {
+		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
+	}
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}

--- a/test/e2e/resize_test.go
+++ b/test/e2e/resize_test.go
@@ -25,14 +25,7 @@ import (
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
-func TestResize(t *testing.T) {
-	t.Run("resize etcd cluster", func(t *testing.T) {
-		t.Run("resize 3->5", testResizeCluster3to5)
-		t.Run("resize 5->3", testResizeCluster5to3)
-	})
-}
-
-func testResizeCluster3to5(t *testing.T) {
+func TestResizeCluster3to5(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -65,7 +58,7 @@ func testResizeCluster3to5(t *testing.T) {
 	}
 }
 
-func testResizeCluster5to3(t *testing.T) {
+func TestResizeCluster5to3(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -27,40 +27,39 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestClusterRestore(t *testing.T) {
-	t.Run("restore cluster from backup", func(t *testing.T) {
-		t.Run("restore from the same name cluster", testClusterRestoreSameName)
-		t.Run("restore from a different name cluster", testClusterRestoreDifferentName)
-	})
-}
-
-func TestClusterRestoreS3(t *testing.T) {
+func TestPerClusS3RestoreSameName(t *testing.T) {
 	if os.Getenv("AWS_TEST_ENABLED") != "true" {
 		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
 	}
-
-	t.Run("restore from the same name cluster", func(t *testing.T) {
-		t.Run("per cluster s3 policy", func(t *testing.T) { testClusterRestoreS3SameName(t, true) })
-		t.Run("operator wide s3 policy", func(t *testing.T) { testClusterRestoreS3SameName(t, false) })
-	})
-
-	t.Run("restore from a different name cluster", func(t *testing.T) {
-		t.Run("per cluster s3 policy", func(t *testing.T) { testClusterRestoreS3DifferentName(t, true) })
-		t.Run("operator wide s3 policy", func(t *testing.T) { testClusterRestoreS3DifferentName(t, false) })
-	})
+	testClusterRestoreS3SameName(t, true)
 }
 
-func testClusterRestoreSameName(t *testing.T) {
-	if os.Getenv(envParallelTest) == envParallelTestTrue {
-		t.Parallel()
+func TestOperWideS3RestoreSameName(t *testing.T) {
+	if os.Getenv("AWS_TEST_ENABLED") != "true" {
+		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
 	}
+	testClusterRestoreS3SameName(t, false)
+}
+
+func TestPerClusS3RestoreDiffName(t *testing.T) {
+	if os.Getenv("AWS_TEST_ENABLED") != "true" {
+		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
+	}
+	testClusterRestoreS3DifferentName(t, true)
+}
+
+func TestOperWideS3RestoreDiffName(t *testing.T) {
+	if os.Getenv("AWS_TEST_ENABLED") != "true" {
+		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
+	}
+	testClusterRestoreS3DifferentName(t, false)
+}
+
+func TestClusterRestoreSameName(t *testing.T) {
 	testClusterRestore(t, false)
 }
 
-func testClusterRestoreDifferentName(t *testing.T) {
-	if os.Getenv(envParallelTest) == envParallelTestTrue {
-		t.Parallel()
-	}
+func TestClusterRestoreDifferentName(t *testing.T) {
 	testClusterRestore(t, true)
 }
 
@@ -69,6 +68,9 @@ func testClusterRestore(t *testing.T, needDataClone bool) {
 }
 
 func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backupPolicy *spec.BackupPolicy) {
+	if os.Getenv(envParallelTest) == envParallelTestTrue {
+		t.Parallel()
+	}
 	f := framework.Global
 
 	origEtcd := e2eutil.NewCluster("test-etcd-", 3)
@@ -168,10 +170,6 @@ func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backup
 }
 
 func testClusterRestoreS3SameName(t *testing.T, perCluster bool) {
-	if os.Getenv(envParallelTest) == envParallelTestTrue {
-		t.Parallel()
-	}
-
 	var bp *spec.BackupPolicy
 	if perCluster {
 		bp = e2eutil.NewS3BackupPolicy(false)
@@ -183,10 +181,6 @@ func testClusterRestoreS3SameName(t *testing.T, perCluster bool) {
 }
 
 func testClusterRestoreS3DifferentName(t *testing.T, perCluster bool) {
-	if os.Getenv(envParallelTest) == envParallelTestTrue {
-		t.Parallel()
-	}
-
 	var bp *spec.BackupPolicy
 	if perCluster {
 		bp = e2eutil.NewS3BackupPolicy(false)


### PR DESCRIPTION
fix https://github.com/coreos/etcd-operator/issues/1134

~~I have added another job "e2eslow-pr" just for PR CI. Mostly sequential/destructive tests.
The nightly master will still run all e2e in one job.~~
~~This PR separates some e2e tests into another package "e2eslow", which will be run as another job.~~
(fixed in other PRs)

Previously we use subtests to guard sequential from parallelizable tests. We have made all test under "e2e" parallelizable so we just parallelize them all. No need to use subtest any more. And we should remove subtest to achieve maximum parallelization.