### PR TITLE
e2e: remove outdated EnvCloudProvider var

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -32,10 +32,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const (
-	EnvCloudProvider = "E2E_CLOUD_PROVIDER"
-)
-
 var Global *Framework
 
 type Framework struct {

--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -95,9 +95,6 @@ func testDisasterRecovery2Members(t *testing.T) {
 // testDisasterRecoveryAll tests disaster recovery that
 // we should make a backup ahead and ooperator will recover cluster from it.
 func testDisasterRecoveryAll(t *testing.T) {
-	if os.Getenv(framework.EnvCloudProvider) == "aws" {
-		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
-	}
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
@@ -189,9 +186,6 @@ func testS3MajorityDown(t *testing.T, perCluster bool) {
 }
 
 func testS3AllDown(t *testing.T, perCluster bool) {
-	if os.Getenv(framework.EnvCloudProvider) == "aws" {
-		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
-	}
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -28,10 +28,6 @@ import (
 )
 
 func TestClusterRestore(t *testing.T) {
-	if os.Getenv(framework.EnvCloudProvider) == "aws" {
-		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
-	}
-
 	t.Run("restore cluster from backup", func(t *testing.T) {
 		t.Run("restore from the same name cluster", testClusterRestoreSameName)
 		t.Run("restore from a different name cluster", testClusterRestoreDifferentName)
@@ -39,10 +35,6 @@ func TestClusterRestore(t *testing.T) {
 }
 
 func TestClusterRestoreS3(t *testing.T) {
-	if os.Getenv(framework.EnvCloudProvider) == "aws" {
-		t.Skip("skipping test due to relying on PodIP reachability. TODO: Remove this skip later")
-	}
-
 	if os.Getenv("AWS_TEST_ENABLED") != "true" {
 		t.Skip("skipping test since AWS_TEST_ENABLED is not set.")
 	}


### PR DESCRIPTION
This field is not maintained anymore.

Let’s clean this up. When we merge PR like this next time, we should test and make sure everything works before merging it.