### PR TITLE
*: move TestRestartOperator to e2eslow/disruptive_test.go

### DIFF
--- a/test/e2e/e2eslow/disruptive_test.go
+++ b/test/e2e/e2eslow/disruptive_test.go
@@ -1,0 +1,64 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2eslow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
+	"github.com/coreos/etcd-operator/test/e2e/framework"
+)
+
+// restart operator should resume cluster
+func TestRestartOperator(t *testing.T) {
+	f := framework.Global
+	testEtcd, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, e2eutil.NewCluster("test-etcd-", 3))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := e2eutil.DeleteCluster(t, f.KubeClient, testEtcd); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	names, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd)
+	if err != nil {
+		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
+	}
+
+	if err := f.DeleteEtcdOperatorCompletely(); err != nil {
+		t.Fatalf("fail to delete etcd operator pod: %v", err)
+	}
+
+	if err := e2eutil.KillMembers(f.KubeClient, f.Namespace, names[0]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 2, 10*time.Second, testEtcd); err != nil {
+		t.Fatalf("failed to wait for killed member to die: %v", err)
+	}
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 10*time.Second, testEtcd); err == nil {
+		t.Fatalf("cluster should not be recovered: operator is deleted")
+	}
+
+	if err := f.SetupEtcdOperator(); err != nil {
+		t.Fatalf("fail to restart etcd operator: %v", err)
+	}
+
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd); err != nil {
+		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
+	}
+}


### PR DESCRIPTION
As part of https://github.com/coreos/etcd-operator/pull/1139

First commit from https://github.com/coreos/etcd-operator/pull/1149