### PR TITLE
*: add readiness probe for operator pod

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
+	"github.com/coreos/etcd-operator/pkg/util/probe"
 
 	"github.com/Sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -313,6 +314,8 @@ func (c *Controller) watch(watchVersion string) (<-chan *Event, <-chan error) {
 			}
 
 			c.logger.Infof("start watching at %v", watchVersion)
+
+			probe.SetReady()
 
 			decoder := json.NewDecoder(resp.Body)
 			for {

--- a/pkg/util/probe/readyz.go
+++ b/pkg/util/probe/readyz.go
@@ -1,0 +1,47 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package probe
+
+import (
+	"net/http"
+	"sync"
+)
+
+const (
+	HTTPReadyzEndpoint = "/readyz"
+)
+
+var (
+	mu    sync.Mutex
+	ready = false
+)
+
+func SetReady() {
+	mu.Lock()
+	ready = true
+	mu.Unlock()
+}
+
+// ReadyzHandler writes back the HTTP status code 200 if the operator is ready, and 500 otherwise
+func ReadyzHandler(w http.ResponseWriter, r *http.Request) {
+	mu.Lock()
+	isReady := ready
+	mu.Unlock()
+	if isReady {
+		w.WriteHeader(http.StatusOK)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}


### PR DESCRIPTION
The operator now creates an http endpoint to indicate its readiness to the kubelet and other components. The endpoint is set to ready right after the controller starts watching for cluster events.

TODO: Set the endpoint to unready if the controller exits or stops?