### PR TITLE
upgradetest: add readiness probe to wait for operator pod

### DIFF
--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -155,3 +155,18 @@ func applyPodPolicyToPodTemplateSpec(clusterName string, pod *v1.PodTemplateSpec
 
 	mergeLabels(pod.Labels, policy.Labels)
 }
+
+// IsPodReady returns false if the Pod Status is nil
+func IsPodReady(pod *v1.Pod) bool {
+	condition := getPodReadyCondition(&pod.Status)
+	return condition != nil && condition.Status == v1.ConditionTrue
+}
+
+func getPodReadyCondition(status *v1.PodStatus) *v1.PodCondition {
+	for i := range status.Conditions {
+		if status.Conditions[i].Type == v1.PodReady {
+			return &status.Conditions[i]
+		}
+	}
+	return nil
+}

--- a/test/e2e/e2eutil/wait_util.go
+++ b/test/e2e/e2eutil/wait_util.go
@@ -240,3 +240,25 @@ func waitPodsDeleted(kubecli kubernetes.Interface, namespace string, timeout tim
 	})
 	return pods, err
 }
+
+// WaitUntilPodReady will wait until the first pod selected by the label 'lo' is ready. So this should be called for lablels that only select one pod.
+func WaitUntilPodReady(kubecli kubernetes.Interface, namespace string, lo metav1.ListOptions, timeout time.Duration) error {
+	var podName string
+	err := retryutil.Retry(5*time.Second, int(timeout/(5*time.Second)), func() (bool, error) {
+		podList, err := kubecli.CoreV1().Pods(namespace).List(lo)
+		if err != nil {
+			return false, err
+		}
+		if len(podList.Items) > 0 {
+			podName = podList.Items[0].Name
+			if k8sutil.IsPodReady(&podList.Items[0]) {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait for pod (%v) to become ready: %v", podName, err)
+	}
+	return nil
+}


### PR DESCRIPTION
The upgradetest framework will now check and wait until the operator pod is ready via the readyz probe, for both `CreateOperator()` and `UpgradeOperator()`.
This way each test would not have to wait longer than necessary for the operator to first become ready while checking for cluster size via `WaitUntilSizeReached()`.

Stress testing for notably flaky tests in #1153 