### PR TITLE
upgradetest: replace WaitEtcdTPR with readiness

### DIFF
--- a/test/e2e/e2eutil/wait_util.go
+++ b/test/e2e/e2eutil/wait_util.go
@@ -240,25 +240,3 @@ func waitPodsDeleted(kubecli kubernetes.Interface, namespace string, timeout tim
 	})
 	return pods, err
 }
-
-// WaitUntilPodReady will wait until the first pod selected by the label 'lo' is ready. So this should be called for lablels that only select one pod.
-func WaitUntilPodReady(kubecli kubernetes.Interface, namespace string, lo metav1.ListOptions, timeout time.Duration) error {
-	var podName string
-	err := retryutil.Retry(5*time.Second, int(timeout/(5*time.Second)), func() (bool, error) {
-		podList, err := kubecli.CoreV1().Pods(namespace).List(lo)
-		if err != nil {
-			return false, err
-		}
-		if len(podList.Items) > 0 {
-			podName = podList.Items[0].Name
-			if k8sutil.IsPodReady(&podList.Items[0]) {
-				return true, nil
-			}
-		}
-		return false, nil
-	})
-	if err != nil {
-		return fmt.Errorf("failed to wait for pod (%v) to become ready: %v", podName, err)
-	}
-	return nil
-}

--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
+	"github.com/coreos/etcd-operator/test/e2e/upgradetest/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -38,8 +39,8 @@ func TestResize(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	if err = k8sutil.WaitEtcdTPRReady(testF.KubeCli.CoreV1().RESTClient(), 3*time.Second, 30*time.Second, testF.KubeNS); err != nil {
-		t.Fatalf("failed to see cluster TPR get created in time: %v", err)
+	if err = framework.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, 30*time.Second); err != nil {
+		t.Fatal(err)
 	}
 
 	testClus, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, e2eutil.NewCluster("upgrade-test-", 3))
@@ -88,8 +89,8 @@ func TestHealOneMemberForOldCluster(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	if err = k8sutil.WaitEtcdTPRReady(testF.KubeCli.CoreV1().RESTClient(), 3*time.Second, 30*time.Second, testF.KubeNS); err != nil {
-		t.Fatalf("failed to see cluster TPR get created in time: %v", err)
+	if err = framework.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, 30*time.Second); err != nil {
+		t.Fatal(err)
 	}
 
 	testEtcd, err := e2eutil.CreateCluster(t, testF.KubeCli, testF.KubeNS, e2eutil.NewCluster("upgrade-test-", 3))
@@ -146,9 +147,8 @@ func testRestoreWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy) {
 			t.Fatalf("failed to delete operator:%v", err)
 		}
 	}()
-	err = k8sutil.WaitEtcdTPRReady(testF.KubeCli.CoreV1().RESTClient(), 3*time.Second, 30*time.Second, testF.KubeNS)
-	if err != nil {
-		t.Fatalf("failed to see cluster TPR get created in time: %v", err)
+	if err = framework.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, 30*time.Second); err != nil {
+		t.Fatal(err)
 	}
 
 	origClus := e2eutil.NewCluster("upgrade-test-", 3)
@@ -263,9 +263,8 @@ func testBackupForOldClusterWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy
 			t.Fatal(err)
 		}
 	}()
-	err = k8sutil.WaitEtcdTPRReady(testF.KubeCli.CoreV1().RESTClient(), 3*time.Second, 30*time.Second, testF.KubeNS)
-	if err != nil {
-		t.Fatalf("failed to see cluster TPR get created in time: %v", err)
+	if err = framework.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, 30*time.Second); err != nil {
+		t.Fatal(err)
 	}
 
 	// Make interval long so no backup is made by the sidecar since we want to make only one backup during the whole test
@@ -345,9 +344,8 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy) {
 			t.Fatalf("failed to delete operator: %v", err)
 		}
 	}()
-	err = k8sutil.WaitEtcdTPRReady(testF.KubeCli.CoreV1().RESTClient(), 3*time.Second, 30*time.Second, testF.KubeNS)
-	if err != nil {
-		t.Fatalf("failed to see cluster TPR get created in time: %v", err)
+	if err = framework.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, 30*time.Second); err != nil {
+		t.Fatal(err)
 	}
 
 	testClus := e2eutil.NewCluster("upgrade-test-", 3)


### PR DESCRIPTION
Fix for #1176 

Also moved `WaitUntilPodReady()` outside from `CreateOperator()` so that the operator can be safely cleaned up incase a test fails due `WaitUntilPodReady()`.