### PR TITLE
cluster: no need to delete service

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -471,17 +471,10 @@ func (c *Cluster) createPod(members etcdutil.MemberSet, m *etcdutil.Member, stat
 	return err
 }
 
-func (c *Cluster) removePodAndService(name string) error {
+func (c *Cluster) removePod(name string) error {
 	ns := c.cluster.Metadata.Namespace
-	err := c.config.KubeCli.Core().Services(ns).Delete(name, nil)
-	if err != nil {
-		if !k8sutil.IsKubernetesResourceNotFoundError(err) {
-			return err
-		}
-	}
-
 	opts := metav1.NewDeleteOptions(podTerminationGracePeriod)
-	err = c.config.KubeCli.Core().Pods(ns).Delete(name, opts)
+	err := c.config.KubeCli.Core().Pods(ns).Delete(name, opts)
 	if err != nil {
 		if !k8sutil.IsKubernetesResourceNotFoundError(err) {
 			return err

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -75,7 +75,7 @@ func (c *Cluster) reconcileMembers(running etcdutil.MemberSet) error {
 	if unknownMembers.Size() > 0 {
 		c.logger.Infof("removing unexpected pods: %v", unknownMembers)
 		for _, m := range unknownMembers {
-			if err := c.removePodAndService(m.Name); err != nil {
+			if err := c.removePod(m.Name); err != nil {
 				return err
 			}
 		}
@@ -170,7 +170,7 @@ func (c *Cluster) removeMember(toRemove *etcdutil.Member) error {
 		}
 	}
 	c.members.Remove(toRemove.Name)
-	if err := c.removePodAndService(toRemove.Name); err != nil {
+	if err := c.removePod(toRemove.Name); err != nil {
 		return err
 	}
 	c.logger.Infof("removed member (%v) with ID (%d)", toRemove.Name, toRemove.ID)
@@ -215,7 +215,7 @@ func (c *Cluster) disasterRecovery(left etcdutil.MemberSet) error {
 	}
 
 	for _, m := range left {
-		err := c.removePodAndService(m.Name)
+		err := c.removePod(m.Name)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We don’t have the “service” anymore since we use subdomains for etcd pods. This is leftover code that we forget to remove.