### PR TITLE
upgrade test: add dismissed change

### DIFF
--- a/test/e2e/upgradetest/framework/framework.go
+++ b/test/e2e/upgradetest/framework/framework.go
@@ -162,7 +162,7 @@ func (f *Framework) UpgradeOperator() error {
 	if err != nil {
 		return fmt.Errorf("failed to wait for pod with old image to get deleted: %v", err)
 	}
-	err = WaitUntilOperatorReady(f.KubeCli, f.KubeNS, 30*time.Second)
+	err = WaitUntilOperatorReady(f.KubeCli, f.KubeNS, 40*time.Second)
 	return err
 }
 


### PR DESCRIPTION
[skip ci]
Should be part of https://github.com/coreos/etcd-operator/pull/1187 but somehow dismissed.