### PR TITLE
Issue 1188. Fix typo in README.md for getting the service URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you are working with [minikube locally](https://github.com/kubernetes/minikub
 ```bash
 $ kubectl create -f example/example-etcd-cluster-nodeport-service.json
 $ export ETCDCTL_API=3
-$ export ETCDCTL_ENDPOINTS=$(minikube service example-etcd-cluster-client --url)
+$ export ETCDCTL_ENDPOINTS=$(minikube service example-etcd-cluster-client-service --url)
 $ etcdctl put foo bar
 ```
 


### PR DESCRIPTION
Submit the pull request for the fix of issue 1188. 

fix https://github.com/coreos/etcd-operator/issues/1188