### PR TITLE
Build proxy support

### DIFF
--- a/hack/build/operator/build
+++ b/hack/build/operator/build
@@ -40,6 +40,10 @@ go_ldflags="-X ${ldKVPairs} -X ${gitHash}"
 go_build operator
 go_build backup
 
-docker build --tag "${IMAGE}" -f hack/build/operator/Dockerfile . 1>/dev/null
+if [ -z ${http_proxy+x} ]; then build_args=""; else build_args="--build-arg http_proxy=${http_proxy}"; fi
+if [ -z ${https_proxy+x} ]; then build_args="${build_args}"; else build_args="${build_args} --build-arg https_proxy=${https_proxy}"; fi
+
+
+docker build --tag "${IMAGE}" -f hack/build/operator/Dockerfile ${build_args} . 1>/dev/null
 # For gcr users, do "gcloud docker -a" to have access.
 docker push "${IMAGE}" 1>/dev/null


### PR DESCRIPTION
The build script wasn't working for me because the http proxy information wasn't being propagated to the docker build environment (and the Dockerfile was running apk). This pull request will pass the proxy if set as a build-arg