### PR TITLE
cluster: fatal error should be wrapped

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 36604f26d3ccf29d96832b2487bf91a8e54f85563bcba45b9f6a4dcf1b003dcc
-updated: 2017-05-15T14:21:27.988384347-07:00
+hash: abfa1d8c2be45a5826712ed0ec8cde1bde9566525cec1e36d85783e42726f1dc
+updated: 2017-06-19T09:44:03.664783187-07:00
 imports:
 - name: bitbucket.org/ww/goautoneg
   version: 75cd24fc2f2c2a2088577d12123ddee5f54e0675
@@ -9,7 +9,7 @@ imports:
   - compute/metadata
   - internal
 - name: github.com/aws/aws-sdk-go
-  version: 9f8b24cb7c7701c78150869d906711a2e7184bc0
+  version: 96358b8282b1a3aa66836d2f2fe66216cc419668
   subpackages:
   - aws
   - aws/awserr
@@ -27,6 +27,7 @@ imports:
   - aws/request
   - aws/session
   - aws/signer/v4
+  - internal/shareddefaults
   - private/protocol
   - private/protocol/query
   - private/protocol/query/queryutil
@@ -39,67 +40,17 @@ imports:
   version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
   subpackages:
   - quantile
-- name: github.com/boltdb/bolt
-  version: 583e8937c61f1af6513608ccc75c97b6abdf4ff9
-- name: github.com/cockroachdb/cmux
-  version: 112f0506e7743d64a6eb8fedbcff13d9979bbf92
 - name: github.com/coreos/etcd
-  version: e5b7ee2d03627ca33201da428b8110ef7c3e95f1
+  version: d267ca9c184e953554257d0acdd1dc9c47d38229
   subpackages:
-  - alarm
-  - auth
   - auth/authpb
-  - client
   - clientv3
-  - compactor
-  - discovery
-  - embed
-  - error
-  - etcdserver
-  - etcdserver/api
-  - etcdserver/api/v2http
-  - etcdserver/api/v2http/httptypes
-  - etcdserver/api/v3rpc
   - etcdserver/api/v3rpc/rpctypes
-  - etcdserver/auth
   - etcdserver/etcdserverpb
-  - etcdserver/membership
-  - etcdserver/stats
-  - lease
-  - lease/leasehttp
-  - lease/leasepb
-  - mvcc
-  - mvcc/backend
   - mvcc/mvccpb
-  - pkg/adt
-  - pkg/contention
-  - pkg/cors
-  - pkg/cpuutil
-  - pkg/crc
   - pkg/fileutil
-  - pkg/httputil
-  - pkg/idutil
-  - pkg/ioutil
-  - pkg/logutil
-  - pkg/monotime
-  - pkg/netutil
-  - pkg/pathutil
-  - pkg/pbutil
-  - pkg/runtime
-  - pkg/schedule
   - pkg/tlsutil
   - pkg/transport
-  - pkg/types
-  - pkg/wait
-  - raft
-  - raft/raftpb
-  - rafthttp
-  - snap
-  - snap/snappb
-  - store
-  - version
-  - wal
-  - wal/walpb
 - name: github.com/coreos/go-semver
   version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
   subpackages:
@@ -159,8 +110,6 @@ imports:
   subpackages:
   - jsonpb
   - proto
-- name: github.com/google/btree
-  version: 925471ac9e2131377a91e1595defec898166fe49
 - name: github.com/google/gofuzz
   version: 44d81051d367757e1c7c6a5a86423ece9afcf63c
 - name: github.com/grpc-ecosystem/go-grpc-prometheus
@@ -177,8 +126,6 @@ imports:
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/jmespath/go-jmespath
   version: 0b12d6b521d83fc7f755e7cfc1b1fbdd35a01a74
-- name: github.com/jonboulle/clockwork
-  version: 72f9bd7c4e0c2a40055ab3d0f09654f730cce982
 - name: github.com/jpillora/go-ogle-analytics
   version: 49dbddd69887519886adf7763e0306e1f33ba50f
 - name: github.com/juju/ratelimit
@@ -195,6 +142,8 @@ imports:
   - pbutil
 - name: github.com/pborman/uuid
   version: a97ce2ca70fa5a848076093f05e639a89ca34d06
+- name: github.com/pkg/errors
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/prometheus/client_golang
   version: c5b7fccd204277076155f10851dad72b76a49317
   subpackages:
@@ -215,20 +164,16 @@ imports:
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
 - name: github.com/Sirupsen/logrus
-  version: c078b1e43f58d563c74cebe63c85789e76ddb627
+  version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: github.com/spf13/pflag
   version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
 - name: github.com/ugorji/go
   version: ded73eae5db7e7a0ef6f55aace87a2873c5d2b74
   subpackages:
   - codec
-- name: github.com/xiang90/probing
-  version: 07dd2e8dfe18522e9c447ba95f2fe95262f63bb2
 - name: golang.org/x/crypto
   version: d172538b2cfce0c13cee31e647d0367aa8cd2486
   subpackages:
-  - bcrypt
-  - blowfish
   - ssh/terminal
 - name: golang.org/x/net
   version: e90d6d0afc4c315a0d87a568ae68577cc15149a0

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,11 +3,13 @@ import:
 - package: k8s.io/client-go
   version: v3.0.0-beta.0
 - package: github.com/coreos/etcd
-  version: v3.1.6
+  version: v3.1.8
 - package: github.com/Sirupsen/logrus
-  version: v0.11.2
+  version: v1.0.0
+- package: github.com/pkg/errors
+  version: v0.8.0
 - package: github.com/aws/aws-sdk-go
-  version: v1.8.23
+  version: v1.8.44
 - package: github.com/coreos/go-semver
   version: v0.2.0
 - package: github.com/pborman/uuid

--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -185,8 +185,7 @@ func (c *Cluster) disasterRecovery(left etcdutil.MemberSet) error {
 	}
 
 	if c.cluster.Spec.Backup == nil {
-		c.logger.Errorf("fail to do disaster recovery: no backup policy has been defined.")
-		return errNoBackupExist
+		return newFatalError("fail to do disaster recovery: no backup policy has been defined")
 	}
 
 	backupNow := false
@@ -210,7 +209,7 @@ func (c *Cluster) disasterRecovery(left etcdutil.MemberSet) error {
 			return err
 		}
 		if !exist {
-			return errNoBackupExist
+			return newFatalError("no backup exist for disaster recovery")
 		}
 	}
 

--- a/pkg/util/etcdutil/member.go
+++ b/pkg/util/etcdutil/member.go
@@ -151,11 +151,11 @@ func (ms MemberSet) ClientURLs() []string {
 func GetCounterFromMemberName(name string) (int, error) {
 	i := strings.LastIndex(name, "-")
 	if i == -1 || i+1 >= len(name) {
-		return 0, fmt.Errorf("name (%s) does not contain '-' or anything after", name)
+		return 0, fmt.Errorf("name (%s) does not contain '-' or anything after '-'", name)
 	}
 	c, err := strconv.Atoi(name[i+1:])
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("could not atoi %s: %v", name[i+1:], err)
 	}
 	return c, nil
 }


### PR DESCRIPTION
ref: https://github.com/coreos/etcd-operator/issues/1200#issuecomment-309193926

This PR makes fatal error a type and uses “pkg/errors” to wrap the fatal error. It also rewrite the isFatalError() func to unwrap the cause as detection.