### PR TITLE
upgradetest: wait for killed members to be deleted

### DIFF
--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -119,6 +119,12 @@ func TestHealOneMemberForOldCluster(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	remaining, err := e2eutil.WaitUntilMembersWithNamesDeleted(t, testF.KubeCli, 30*time.Second, testEtcd, names[2])
+	if err != nil {
+		t.Fatalf("failed to see members(%v) be deleted in time: %v", remaining, err)
+	}
+
 	_, err = e2eutil.WaitUntilSizeReached(t, testF.KubeCli, 3, 60*time.Second, testEtcd)
 	if err != nil {
 		t.Fatalf("failed to heal one member: %v", err)


### PR DESCRIPTION
Since `WaitUntilSizeReached()` looks at the TPR's `Status.Members.Ready` field to calculate the size of the of the cluster, `WaitUntilMembersWithNamesDeleted()` waits until the pods killed by `KillMembers()` are no longer present in the ready members field.

~fixes #1204~
Note: This can't be used after `KillMembers()` in `TestDisasterRecovery` because disaster recovery recreates members with the same names as the original cluster. So looking at the TPR's ready members there is no way to tell which members are from the original cluster and which ones are from the recreated cluster. So we can't wait for the old pods to be deleted just by looking at ready members.