### PR TITLE
upgradetest: wait for pod size instead of ready member size

### DIFF
--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -410,7 +410,7 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy) {
 	if err != nil {
 		t.Fatalf("failed to kill all members: %v", err)
 	}
-	names, err = e2eutil.WaitUntilSizeReached(t, testF.KubeCli, 3, 180*time.Second, testClus)
+	names, err = e2eutil.WaitUntilPodSizeReached(t, testF.KubeCli, 3, 180*time.Second, testClus)
 	if err != nil {
 		t.Fatalf("failed to recover all members: %v", err)
 	}


### PR DESCRIPTION
fix for #1204
Using `WaitUntilPodSizeReached ()` to check the pods size instead of  `WaitUntilSizeReached()` to check the ready members, should prevent `TestDisasterRecovery` from mistakenly querying one of the terminating pods.   