### PR TITLE
selfHosted: tolerate unready nodes

### DIFF
--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -124,7 +124,7 @@ func applyPodPolicy(clusterName string, pod *v1.Pod, policy *spec.PodPolicy) {
 		pod = PodWithNodeSelector(pod, policy.NodeSelector)
 	}
 	if len(policy.Tolerations) != 0 {
-		pod.Spec.Tolerations = policy.Tolerations
+		pod.Spec.Tolerations = append(pod.Spec.Tolerations, policy.Tolerations...)
 	}
 
 	mergeLabels(pod.Labels, policy.Labels)

--- a/pkg/util/k8sutil/self_hosted.go
+++ b/pkg/util/k8sutil/self_hosted.go
@@ -136,6 +136,15 @@ func NewSelfHostedEtcdPod(m *etcdutil.Member, initialCluster, endpoints []string
 			DNSPolicy:     v1.DNSClusterFirstWithHostNet,
 			Hostname:      m.Name,
 			Subdomain:     clusterName,
+			Tolerations: []v1.Toleration{{
+				Key:      "node.alpha.kubernetes.io/notReady",
+				Operator: v1.TolerationOpExists,
+				Effect:   v1.TaintEffectNoExecute,
+			}, {
+				Key:      "node.alpha.kubernetes.io/unreachable",
+				Operator: v1.TolerationOpExists,
+				Effect:   v1.TaintEffectNoExecute,
+			}},
 		},
 	}
 


### PR DESCRIPTION
and prevent etcd pods from being evicted.

fix https://github.com/coreos/etcd-operator/issues/1117