### PR TITLE
*: audit operator actions to hostPath volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- [GH-1232](https://github.com/coreos/etcd-operator/pull/1232) the operator can now log critical actions like pod creation/deletion to a user specified path via the optional flag `debug-logfile-path`. The logs will only be generated if the cluster is self hosted and the flag is set. This can be used in conjunction with a persistent volume to persist the critical actions to disk for later inspection.
+
 ### Changed
 
 ### Removed

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/coreos/etcd-operator/pkg/backup/s3/s3config"
 	"github.com/coreos/etcd-operator/pkg/chaos"
 	"github.com/coreos/etcd-operator/pkg/controller"
+	"github.com/coreos/etcd-operator/pkg/debug"
 	"github.com/coreos/etcd-operator/pkg/garbagecollection"
 	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
@@ -72,6 +73,7 @@ var (
 
 func init() {
 	flag.BoolVar(&analyticsEnabled, "analytics", true, "Send analytical event (Cluster Created/Deleted etc.) to Google Analytics")
+	flag.StringVar(&debug.DebugFilePath, "debug-logfile-path", "", "only for a self hosted cluster, the path where the debug logfile will be written, recommended to be under: /var/tmp/etcd-operator/debug/ to avoid any issue with lack of write permissions")
 
 	flag.StringVar(&pvProvisioner, "pv-provisioner", constants.PVProvisionerGCEPD, "persistent volume provisioner type")
 	flag.StringVar(&awsSecret, "backup-aws-secret", "",

--- a/pkg/cluster/self_hosted.go
+++ b/pkg/cluster/self_hosted.go
@@ -135,6 +135,10 @@ func (c *Cluster) addOneSelfHostedMember() error {
 	if err != nil {
 		return err
 	}
+	if c.isDebugLoggerEnabled() {
+		c.debugLogger.LogPodCreation(pod)
+	}
+
 	// wait for the new pod to start and add itself into the etcd cluster.
 	oldN := c.members.Size()
 	err = c.waitNewMember(oldN, 6, newMember.Name)
@@ -157,6 +161,9 @@ func (c *Cluster) newSelfHostedSeedMember() error {
 	_, err := k8sutil.CreateAndWaitPod(c.config.KubeCli, c.cluster.Metadata.Namespace, pod, 3*60*time.Second)
 	if err != nil {
 		return err
+	}
+	if c.isDebugLoggerEnabled() {
+		c.debugLogger.LogPodCreation(pod)
 	}
 
 	c.logger.Infof("self-hosted cluster created with seed member (%s)", newMember.Name)
@@ -194,6 +201,9 @@ func (c *Cluster) migrateBootMember() error {
 	_, err = k8sutil.CreateAndWaitPod(c.config.KubeCli, ns, pod, 3*60*time.Second)
 	if err != nil {
 		return err
+	}
+	if c.isDebugLoggerEnabled() {
+		c.debugLogger.LogPodCreation(pod)
 	}
 
 	if c.cluster.Spec.SelfHosted.SkipBootMemberRemoval {

--- a/pkg/debug/debug_logger.go
+++ b/pkg/debug/debug_logger.go
@@ -1,0 +1,84 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package debug
+
+import (
+	"os"
+	"path"
+
+	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
+
+	"github.com/Sirupsen/logrus"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+var (
+	// This flag should be set to enable debug logging
+	DebugFilePath string
+)
+
+type DebugLogger struct {
+	// regular log to stdout
+	logger *logrus.Entry
+	// log to file for debugging self hosted clusters
+	fileLogger *logrus.Logger
+}
+
+func New(clusterName string) *DebugLogger {
+	if len(DebugFilePath) == 0 {
+		return nil
+	}
+
+	logger := logrus.WithField("pkg", "debug")
+	err := os.MkdirAll(path.Dir(DebugFilePath), 0755)
+	if err != nil {
+		logger.Errorf("Could not create debug log directory (%v), debug logging will not be performed: %v", path.Dir(DebugFilePath), err)
+		return nil
+	}
+
+	logFile, err := os.OpenFile(DebugFilePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+	if err != nil {
+		logger.Errorf("failed to open debug log file(%v): %v", DebugFilePath, err)
+		return nil
+	}
+
+	l := logrus.New()
+	l.Out = logFile
+	l.Infof("Starting debug logs for self-hosted etcd cluster: %v", clusterName)
+	return &DebugLogger{
+		logger:     logrus.WithField("pkg", "debug"),
+		fileLogger: l,
+	}
+}
+
+func (dl *DebugLogger) LogPodCreation(pod *v1.Pod) {
+	podSpec, err := k8sutil.PodSpecToPrettyJSON(pod)
+	if err != nil {
+		dl.fileLogger.Infof("failed to get readable spec for pod(%v): %v ", pod.Name, err)
+	}
+	dl.fileLogger.Infof("created pod (%s) with spec: %s\n", pod.Name, podSpec)
+}
+
+func (dl *DebugLogger) LogPodDeletion(podName string) {
+	dl.fileLogger.Infof("deleted pod (%s)", podName)
+}
+
+func (dl *DebugLogger) LogClusterSpecUpdate(oldSpec, newSpec string) {
+	dl.fileLogger.Infof("spec update: \nOld:\n%v \nNew:\n%v\n", oldSpec, newSpec)
+}
+
+func (dl *DebugLogger) LogMessage(msg string) {
+	dl.fileLogger.Infof(msg)
+}

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -15,6 +15,7 @@
 package k8sutil
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/coreos/etcd-operator/pkg/spec"
@@ -167,4 +168,12 @@ func getPodReadyCondition(status *v1.PodStatus) *v1.PodCondition {
 		}
 	}
 	return nil
+}
+
+func PodSpecToPrettyJSON(pod *v1.Pod) (string, error) {
+	bytes, err := json.MarshalIndent(pod.Spec, "", "    ")
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
 }


### PR DESCRIPTION
Partially addresses #1205 

The operator will now audit the following actions for a self-hosted cluster to a hostPath volume:
- Create an etcd pod
- Delete an etcd pod
- A spec update to the cluster
- Deleting a failed cluster

To enable the auditing a hostPath volume must be mounted to the mountPath `/var/tmp/etcd-operator` as shown below. The hostPath itself can be anything but should ideally be `/var/tmp` so the operator container can write to the volume even when running as non-root.
```
spec:
  containers:
  - name: etcd-operator
    volumeMounts:
    - mountPath: /var/tmp/etcd-operator
      name: audit-volume
  volumes:
  - name: audit-volume
    hostPath:
      path: /var/tmp/
```
The audit file will be named `<cluster-name>.log` .
If no volume is mounted at the desired mountPath the operator will not audit and function normally as before.