### PR TITLE
e2e: fix tls tests interference

### DIFF
--- a/test/e2e/e2eslow/tls_test.go
+++ b/test/e2e/e2eslow/tls_test.go
@@ -15,9 +15,10 @@
 package e2eslow
 
 import (
+	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -26,33 +27,38 @@ import (
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
 
-var createTLSSecretsOnce sync.Once
-
 func TestTLS(t *testing.T) {
 	testTLS(t, false)
 }
 
 func testTLS(t *testing.T, selfHosted bool) {
 	f := framework.Global
-	clusterName := "tls-test"
-	memberPeerTLSSecret := "etcd-peer-tls"
-	memberClientTLSSecret := "etcd-server-tls"
-	operatorClientTLSSecret := "etcd-client-tls"
-	createTLSSecretsOnce.Do(func() {
-		err := e2eutil.PreparePeerTLSSecret(clusterName, f.Namespace, memberPeerTLSSecret)
+	suffix := fmt.Sprintf("-%d", rand.Uint64())
+	clusterName := "tls-test" + suffix
+	memberPeerTLSSecret := "etcd-peer-tls" + suffix
+	memberClientTLSSecret := "etcd-server-tls" + suffix
+	operatorClientTLSSecret := "etcd-client-tls" + suffix
+
+	err := e2eutil.PreparePeerTLSSecret(clusterName, f.Namespace, memberPeerTLSSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certsDir, err := ioutil.TempDir("", "etcd-operator-tls-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(certsDir)
+	err = e2eutil.PrepareClientTLSSecret(certsDir, clusterName, f.Namespace, memberClientTLSSecret, operatorClientTLSSecret)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err := e2eutil.DeleteSecrets(f.KubeClient, f.Namespace, memberPeerTLSSecret, memberClientTLSSecret, operatorClientTLSSecret)
 		if err != nil {
 			t.Fatal(err)
 		}
-		certsDir, err := ioutil.TempDir("", "etcd-operator-tls-")
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer os.RemoveAll(certsDir)
-		err = e2eutil.PrepareClientTLSSecret(certsDir, clusterName, f.Namespace, memberClientTLSSecret, operatorClientTLSSecret)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
+	}()
 
 	c := e2eutil.NewCluster("", 3)
 	c.Metadata.Name = clusterName
@@ -68,7 +74,7 @@ func testTLS(t *testing.T, selfHosted bool) {
 	if selfHosted {
 		c = e2eutil.ClusterWithSelfHosted(c, &spec.SelfHostedPolicy{})
 	}
-	c, err := e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, c)
+	c, err = e2eutil.CreateCluster(t, f.KubeClient, f.Namespace, c)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/e2eutil/util.go
+++ b/test/e2e/e2eutil/util.go
@@ -33,6 +33,17 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 )
 
+func DeleteSecrets(kubecli kubernetes.Interface, namespace string, secretNames ...string) error {
+	var retErr error
+	for _, sname := range secretNames {
+		err := kubecli.CoreV1().Secrets(namespace).Delete(sname, metav1.NewDeleteOptions(0))
+		if err != nil {
+			retErr = fmt.Errorf("failed to delete secret (%s): %v; %v", sname, err, retErr)
+		}
+	}
+	return retErr
+}
+
 func KillMembers(kubecli kubernetes.Interface, namespace string, names ...string) error {
 	for _, name := range names {
 		err := kubecli.CoreV1().Pods(namespace).Delete(name, metav1.NewDeleteOptions(0))


### PR DESCRIPTION
We shouldn't have two tests have the same cluster name to guard async deletion.
But we can't use GenerateName because we need it explicit to create certs.