### PR TITLE
e2e/recovery_test: wait for pod size instead of ready member size

### DIFF
--- a/test/e2e/e2eutil/wait_util.go
+++ b/test/e2e/e2eutil/wait_util.go
@@ -63,7 +63,6 @@ func WaitUntilPodSizeReached(t *testing.T, kubeClient kubernetes.Interface, size
 			nodeNames = append(nodeNames, pod.Spec.NodeName)
 		}
 		LogfWithTimestamp(t, "waiting size (%d), etcd pods: names (%v), nodes (%v)", size, names, nodeNames)
-		// TODO: Change this to check for ready members and not just cluster pods
 		if len(names) != size {
 			return false, nil
 		}

--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -69,7 +69,7 @@ func TestOneMemberRecovery(t *testing.T) {
 	if err := e2eutil.KillMembers(f.KubeClient, f.Namespace, names[2]); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd); err != nil {
+	if _, err := e2eutil.WaitUntilPodSizeReached(t, f.KubeClient, 3, 60*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
 	}
 }
@@ -155,7 +155,7 @@ func testDisasterRecoveryWithCluster(t *testing.T, numToKill int, cl *spec.Clust
 	if err := e2eutil.KillMembers(f.KubeClient, f.Namespace, toKill...); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := e2eutil.WaitUntilSizeReached(t, f.KubeClient, 3, 120*time.Second, testEtcd); err != nil {
+	if _, err := e2eutil.WaitUntilPodSizeReached(t, f.KubeClient, 3, 120*time.Second, testEtcd); err != nil {
 		t.Fatalf("failed to resize to 3 members etcd cluster: %v", err)
 	}
 	// TODO: add checking of data in etcd


### PR DESCRIPTION
Use `WaitUntilPodSizeReached()` to check the pods size, instead of `WaitUntilSizeReached()` which looks at the TPR's ready members, in the tests `TestOneMemberRecovery` and `TestDisasterRecovery`.

Before this the tests would mistakenly assume that the cluster had been recovered to size 3 after killing one or all members. The issue being that there is a delay between killing a member pod, and the cluster TPR getting updated to reflect that the removal of that member.

We fixed the same problem for other tests that use `KillMember()` in upgradetest and e2e tests in #1208 and #1101 