### PR TITLE
cluster: split multi line logs into individual messages

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
@@ -605,7 +606,11 @@ func (c *Cluster) logClusterCreation() {
 	if err != nil {
 		c.logger.Errorf("failed to marshal cluster spec: %v", err)
 	}
-	c.logger.Infof("creating cluster with \nSpec:\n%v", string(specBytes))
+
+	c.logger.Info("creating cluster with Spec:")
+	for _, m := range strings.Split(string(specBytes), "\n") {
+		c.logger.Info(m)
+	}
 }
 
 func (c *Cluster) logSpecUpdate(newSpec spec.ClusterSpec) {
@@ -617,5 +622,14 @@ func (c *Cluster) logSpecUpdate(newSpec spec.ClusterSpec) {
 	if err != nil {
 		c.logger.Errorf("failed to marshal cluster spec: %v", err)
 	}
-	c.logger.Infof("spec update: \nOld:\n%v \nNew:\n%v", string(oldSpecBytes), string(newSpecBytes))
+
+	c.logger.Infof("spec update: Old Spec:")
+	for _, m := range strings.Split(string(oldSpecBytes), "\n") {
+		c.logger.Info(m)
+	}
+
+	c.logger.Infof("New Spec:")
+	for _, m := range strings.Split(string(newSpecBytes), "\n") {
+		c.logger.Info(m)
+	}
 }


### PR DESCRIPTION
Changes #1210 to split the readable logs into multiple lines, so that each line has the field `cluster-name=example-etcd-cluster` appended to it for ease of inspection of the logs.

Visually the changes look like so:
```
Spec:
{
    "size": 3,
    "baseImage": "quay.io/coreos/etcd",
    "version": "3.1.8"
}
```
now looks like
```
time="2017-06-30T22:32:12Z" level=info msg="{" cluster-name=example-etcd-cluster pkg=cluster
time="2017-06-30T22:32:12Z" level=info msg="    "size": 3," cluster-name=example-etcd-cluster pkg=cluster
time="2017-06-30T22:32:12Z" level=info msg="    "baseImage": "quay.io/coreos/etcd"," cluster-name=example-etcd-cluster pkg=cluster
time="2017-06-30T22:32:12Z" level=info msg="    "version": "3.1.8"" cluster-name=example-etcd-cluster pkg=cluster
time="2017-06-30T22:32:12Z" level=info msg="}" cluster-name=example-etcd-cluster pkg=cluster
```