### PR TITLE
upgrade_e2e: delete endpoint after delete operator

### DIFF
--- a/test/e2e/upgradetest/framework/framework.go
+++ b/test/e2e/upgradetest/framework/framework.go
@@ -142,7 +142,12 @@ func (f *Framework) DeleteOperator(name string) error {
 		LabelSelector: labels.SelectorFromSet(operatorLabelSelector(name)).String(),
 	}
 	_, err = e2eutil.WaitPodsDeletedCompletely(f.KubeCli, f.KubeNS, 30*time.Second, lo)
-	return err
+	if err != nil {
+		return err
+	}
+	// This is assumption coupled with endpoint resource lock.
+	// TODO: change this if we change to use another kind of lock, e.g. configmap.
+	return f.KubeCli.CoreV1().Endpoints(f.KubeNS).Delete("etcd-operator", metav1.NewDeleteOptions(0))
 }
 
 func (f *Framework) UpgradeOperator(name string) error {


### PR DESCRIPTION
Upgrade test flakes caused by that even though two tests now uses different names for deployment , their endpoint locks still share the same name.

We could simply delete the endpoint after deleting the operator in each test.