### PR TITLE
pkg/cluster: be smart about number of master nodes before remove any …

### DIFF
--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -151,6 +151,29 @@ func (c *Cluster) removeOneMember() error {
 }
 
 func (c *Cluster) removeDeadMember(toRemove *etcdutil.Member) error {
+	if c.cluster.Spec.SelfHosted != nil {
+		selectedNodes, err := c.selectSchedulableNodes()
+		if err != nil {
+			return err
+		}
+
+		// If we do not have enough master nodes, we should simply wait for the old node
+		// to be online again.
+		//
+		// Removing the etcd member will not help us to recover the cluster to the desired
+		// number of members, since we do not have enough master nodes for self hosted etcd.
+		//
+		// Instead, there is a large chance that the old node is taken offline for maintenance
+		// or experiencing temporary network partition. When it comes back, it will recover itself
+		// since we persist data for self hosted case.
+
+		if nodeNum := len(selectedNodes); nodeNum < c.cluster.Spec.Size {
+			c.logger.Warningf("ignored removing failed member (%s). Not enough master nodes (%v) to recover, want at least %d", toRemove.Name, selectedNodes, c.cluster.Spec.Size)
+			c.logger.Infof("waiting for the failed master node to recover, or more master nodes")
+			return nil
+		}
+	}
+
 	c.logger.Infof("removing dead member %q", toRemove.Name)
 	c.status.AppendRemovingDeadMember(toRemove.Name)
 

--- a/pkg/util/k8sutil/node_util.go
+++ b/pkg/util/k8sutil/node_util.go
@@ -1,0 +1,30 @@
+// Copyright 2016 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8sutil
+
+import (
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+// IsNodeReady checks if the Node condition is ready.
+func IsNodeReady(n v1.Node) bool {
+	for _, cd := range n.Status.Conditions {
+		if cd.Type == v1.NodeReady {
+			return cd.Status == v1.ConditionTrue
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
…member from the cluster


 If we do not have enough master nodes, we should simply wait for the old node to be online again.

Removing the etcd member will not help us to recover the cluster to the desired number of members, since we do not have enough master nodes for self hosted etcd.

Instead, there is a large chance that the old node is taken offline for maintenance temporary experiencing network partition. When it comes back, it will recover itself since we persist data for self hosted case.

/cc @hongchaodeng @hasbro17 
