### PR TITLE
k8sutil: get rid of 5s sleep in etcd 3.1+

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -244,9 +244,10 @@ func NewEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 		"etcd_cluster": clusterName,
 	}
 
-	// TODO: fix "sleep 5".
-	// Without waiting some time, there is high rate of flakes in DNS setup.
-	commands = fmt.Sprintf("sleep 5; %s", commands)
+	if strings.HasPrefix(cs.Version, "3.0.") {
+		// DNS entries might not warm up initially. 3.0.x etcd will exit without retrying.
+		commands = fmt.Sprintf("sleep 5; %s", commands)
+	}
 	container := containerWithLivenessProbe(etcdContainer(commands, cs.BaseImage, cs.Version), etcdLivenessProbe(cs.TLS.IsSecureClient()))
 
 	if cs.Pod != nil {


### PR DESCRIPTION
Now that etcd will retry resolving DNS names in 3.1+, we don't need to 5s sleep anymore