### PR TITLE
(feat) add support for s3 path prefix configuration

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -77,7 +77,7 @@ func New(kclient kubernetes.Interface, clusterName, ns string, sp spec.ClusterSp
 	case spec.BackupStorageTypePersistentVolume, spec.BackupStorageTypeDefault:
 		be = &fileBackend{dir: bdir}
 	case spec.BackupStorageTypeS3:
-		s3cli, err := s3.New(os.Getenv(env.AWSS3Bucket), path.Join(ns, clusterName))
+		s3cli, err := s3.New(os.Getenv(env.AWSS3Bucket), sp.Backup.S3.S3Path, path.Join(ns, clusterName))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cluster/backupstorage/s3.go
+++ b/pkg/cluster/backupstorage/s3.go
@@ -29,6 +29,7 @@ type s3 struct {
 
 func NewS3Storage(s3Ctx s3config.S3Context, kubecli kubernetes.Interface, clusterName, ns string, p spec.BackupPolicy) (Storage, error) {
 	prefix := path.Join(ns, clusterName)
+
 	var dir string
 
 	s3cli, err := func() (*backups3.S3, error) {
@@ -41,9 +42,9 @@ func NewS3Storage(s3Ctx s3config.S3Context, kubecli kubernetes.Interface, cluste
 			if err != nil {
 				return nil, err
 			}
-			return backups3.NewFromSessionOpt(p.S3.S3Bucket, prefix, *options)
+			return backups3.NewFromSessionOpt(p.S3.S3Bucket, p.S3.S3Path, prefix, *options)
 		} else {
-			return backups3.New(s3Ctx.S3Bucket, prefix)
+			return backups3.New(s3Ctx.S3Bucket, p.S3.S3Path, prefix)
 		}
 	}()
 	if err != nil {

--- a/pkg/spec/backup.go
+++ b/pkg/spec/backup.go
@@ -85,6 +85,9 @@ type S3Source struct {
 	// S3Bucket overwrites the default etcd operator wide bucket.
 	S3Bucket string `json:"s3Bucket,omitempty"`
 
+	// S3Path to be used to prefix the bucket path
+	S3Path string `json:"s3Path,omitempty"`
+
 	// The name of the secret object that stores the AWS credential and config files.
 	// The file name of the credential MUST be 'credentials'.
 	// The file name of the config MUST be 'config'.

--- a/test/e2e/e2eutil/wait_util.go
+++ b/test/e2e/e2eutil/wait_util.go
@@ -284,7 +284,7 @@ func WaitBackupDeleted(kubeClient kubernetes.Interface, cl *spec.EtcdCluster, ch
 				return false, nil
 			}
 		case spec.BackupStorageTypeS3:
-			s3cli := backups3.NewFromClient(checkerOpt.S3Bucket, path.Join(cl.Namespace, cl.Name), checkerOpt.S3Cli)
+			s3cli := backups3.NewFromClient(checkerOpt.S3Bucket, "", path.Join(cl.Namespace, cl.Name), checkerOpt.S3Cli)
 			keys, err := s3cli.List()
 			if err != nil {
 				return false, err


### PR DESCRIPTION
#1305 I have tested this in the following configuration.  Which results in files under
`mybucket/path/etcd/v1/kube-system/kube-etcd/` for a self-hosted etcd setup

```
  backup:
    backupIntervalInSecond: 300
    maxBackups: 5
    s3:
      awsSecret: aws
      s3Bucket: mybucket
      s3Path: path/etcd
    storageType: S3
```