### PR TITLE
e2e: replace WaitEtcdTPRReady with WaitUntilOperatorReady

### DIFF
--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -95,3 +95,8 @@ func ClusterWithSelfHosted(cl *spec.Cluster, sh *spec.SelfHostedPolicy) *spec.Cl
 	cl.Spec.SelfHosted = sh
 	return cl
 }
+
+// NameLabelSelector returns a label selector of the form name=<name>
+func NameLabelSelector(name string) map[string]string {
+	return map[string]string{"name": name}
+}

--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/coreos/etcd-operator/pkg/spec"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
-	"github.com/coreos/etcd-operator/test/e2e/upgradetest/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -45,7 +44,7 @@ func TestResize(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	err = framework.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, name)
+	err = e2eutil.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,7 +97,7 @@ func TestHealOneMemberForOldCluster(t *testing.T) {
 			t.Fatal(err)
 		}
 	}()
-	err = framework.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, name)
+	err = e2eutil.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +165,7 @@ func testRestoreWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy) {
 			t.Fatalf("failed to delete operator:%v", err)
 		}
 	}()
-	err = framework.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, name)
+	err = e2eutil.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +281,7 @@ func testBackupForOldClusterWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy
 			t.Fatal(err)
 		}
 	}()
-	err = framework.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, name)
+	err = e2eutil.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, name)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +364,7 @@ func testDisasterRecoveryWithBackupPolicy(t *testing.T, bp *spec.BackupPolicy) {
 			t.Fatalf("failed to delete operator: %v", err)
 		}
 	}()
-	err = framework.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, name)
+	err = e2eutil.WaitUntilOperatorReady(testF.KubeCli, testF.KubeNS, name)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The framework for the e2e tests now uses `WaitUntilOperatorReady()` while setting up the etcd operator instead of waiting for the TPR, similar to the upgrade test framework.