### PR TITLE
*: update CHANGELOG and upgrade_guide for TPR to CRD migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
-## [Unreleased 0.4.3]
+## [Unreleased 0.5.0]
+
+**BREAKING CHANGE**: The cluster object will now be defined via a [Custom Resource Definition(CRD)](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/) instead of a [Third Party Resource(TPR)](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-third-party-resource/). See the `Changed` section below for details.
 
 ### Added
 
 ### Changed
+- With k8s 1.7 and onwards TPRs have been deprecated and are replaced with CRD. See the k8s 1.7 [blogpost](http://blog.kubernetes.io/2017/06/kubernetes-1.7-security-hardening-stateful-application-extensibility-updates.html) or [release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md#major-themes) for more details. For this release a live migration of the cluster spec from TPR to CRD is not supported. To preserve the cluster state during the upgrade you will need to create a backup of the cluster and recreate the cluster from the backup after upgrading the operator. See the [upgrade guide](https://github.com/coreos/etcd-operator/blob/master/doc/user/upgrade/upgrade_guide.md) for more detailed steps on how to do that.
+
+- Changes in the cluster object's type metadata:
+  - The `apiVersion` field has been changed from `etcd.coreos.com/v1beta1` to `etcd.database.coreos.com/v1beta2`
+  - The `kind` field has been changed from `Cluster` to `EtcdCluster`
 
 ### Removed
 

--- a/doc/user/upgrade/upgrade_guide.md
+++ b/doc/user/upgrade/upgrade_guide.md
@@ -22,6 +22,48 @@ $ kubectl edit deployment/etcd-operator
 ### Incompatible upgrade
 In the case of an incompatible upgrade, the process requires restoring a new cluster from backup. See the [incompatible upgrade guide](incompatible_upgrade.md) for more information.
 
+## v0.4.x -> v0.5.x
+For any `0.4.x` versions, please update to `0.5.0` first.
+
+The `0.5.0` release introduces a breaking change in moving from [TPR](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-third-party-resource/) to [CRD](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/). To preserve the cluster state across the upgrade, the cluster must be recreated from backup after the upgrade.
+### Prerequisite:
+Kubernetes cluster version must be 1.7+.
+
+### Steps to upgrade:
+- Create a backup of your current cluster data. See the following guides on how to enable and create backups:
+    - [backup config guide](https://github.com/coreos/etcd-operator/blob/master/doc/user/backup_config.md) to enable backups fro your cluster
+    - [backup service guide](https://github.com/coreos/etcd-operator/blob/master/doc/user/backup_service.md) to create a backup
+- Delete the cluster TPR object. The etcd-operator will delete all resources(pods, services, deployments) associated with the cluster:
+    - `kubectl -n <namespace> delete cluster <cluster-name>`
+- Delete the etcd-operator deployment
+- Delete the TPR
+    - `kubectl delete thirdpartyresource clusters.etcd.coreos.com `
+- Replace the existing RBAC rules for the etcd-operator by editing or recreating the `ClusterRole` with the [new rules for CRD](https://github.com/coreos/etcd-operator/blob/master/doc/user/rbac.md#create-clusterrole).
+- Recreate the etcd-operator deployment with the `0.5.0` image.
+- Create a new cluster that restores from the backup of the previous cluster. The new cluster CR spec should look as follows:
+```
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
+metadata:
+  name: <cluster-name>
+spec:
+  size: <cluster-size>
+  version: "3.1.8"
+  backup:
+    # The same backup spec used to save the backup of the previous cluster
+    . . .
+    . . .
+  restore:
+    backupClusterName: <previous-cluster-name>
+    storageType: <storage-type-of-backup-spec>
+```
+The two points of interest in the above CR spec are:
+  1. The `apiVersion` and `kind` fields have been changed as mentioned in the `0.5.0` release notes
+  2. The `spec.restore` field needs to be specified according your backup configuration. See [spec examples guide](https://github.com/coreos/etcd-operator/blob/master/doc/user/spec_examples.md#three-members-cluster-that-restores-from-previous-pv-backup) on how to specify the `spec.restore` field for your particular backup configuration.
+
+## v0.3.x -> v0.4.x
+Upgrade to `v0.4.0` first.
+See the release notes of `v0.4.0` for noticeable changes: https://github.com/coreos/etcd-operator/releases/tag/v0.4.0
 
 ## v0.2.x -> v0.3.x
 ### Prerequisite:


### PR DESCRIPTION
The CHANGELOG highlights the transition to CRD.

The upgrade guide lists steps on how to upgrade to using CRD by recreating the new cluster from backup.

Testing out the upgrade guide steps out manually to make sure they work.


