### PR TITLE
backup: increase default snapshot timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Default timeout for snapshots done by backup sidecar increased from 5 seconds to 1 minute
+
 ### Removed
 
 ### Fixed

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -221,7 +221,7 @@ func (b *Backup) writeSnap(m *etcdutil.Member, rev int64) error {
 		return err
 	}
 
-	ctx, cancel = context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
+	ctx, cancel = context.WithTimeout(context.Background(), constants.DefaultSnapshotTimeout)
 	rc, err := etcdcli.Maintenance.Snapshot(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to receive snapshot (%v)", err)

--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -19,6 +19,7 @@ import "time"
 const (
 	DefaultDialTimeout      = 5 * time.Second
 	DefaultRequestTimeout   = 5 * time.Second
+	DefaultSnapshotTimeout  = 1 * time.Minute
 	DefaultSnapshotInterval = 1800 * time.Second
 
 	DefaultBackupPodHTTPPort = 19999


### PR DESCRIPTION
For larger databases, a snapshot can take much longer than the 5 seconds previously given. This approach is not exactly elegant, but for the snapshot in the backup, give it a larger timeout.