### PR TITLE
doc/user/op_guide: Fix typo verb tense create vs create

### DIFF
--- a/doc/user/op_guide.md
+++ b/doc/user/op_guide.md
@@ -10,7 +10,7 @@ Create deployment:
 $ kubectl create -f example/deployment.yaml
 ```
 
-etcd operator will automatically creates a Kubernetes Custom Resource Definition (CRD):
+etcd operator will automatically create a Kubernetes Custom Resource Definition (CRD):
 
 ```bash
 $ kubectl get customresourcedefinitions


### PR DESCRIPTION
as downstream in https://github.com/coreos-inc/coreos-pages/pull/1773

[skip ci]