### PR TITLE
[WIP] *: Add initial PersistentVolume feature

### DIFF
--- a/example/example-etcd-cluster-with-pv.yaml
+++ b/example/example-etcd-cluster-with-pv.yaml
@@ -1,0 +1,11 @@
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdCluster"
+metadata:
+  name: "example-etcd-cluster"
+spec:
+  size: 3
+  version: "3.1.8"
+  pod:
+    usePV: true
+    pvPolicy:
+      volumeSizeInMB: 1024

--- a/hack/test
+++ b/hack/test
@@ -88,7 +88,10 @@ function e2e_pass {
 
 	# Run all the tests by default
 	E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-.*}
-	go test "./test/e2e/" -run "$E2E_TEST_SELECTOR" -timeout 30m --race --kubeconfig $KUBECONFIG --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
+	# Run tests with PV support disabled
+	go test -v "./test/e2e/" -run "$E2E_TEST_SELECTOR" -timeout 30m --race --kubeconfig $KUBECONFIG --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
+	# Run tests with PV support enabled
+	PV_TEST=true go test -v "./test/e2e/" -run "$E2E_TEST_SELECTOR" -timeout 30m --race --kubeconfig $KUBECONFIG --operator-image $OPERATOR_IMAGE --namespace ${TEST_NAMESPACE}
 }
 
 function e2eslow_pass {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -321,6 +321,13 @@ func (c *Cluster) run(stopC <-chan struct{}) {
 				continue
 			}
 
+			pvcs, err := c.pollPVCs()
+			if err != nil {
+				c.logger.Errorf("failed to poll pvcs: %v", err)
+				reconcileFailed.WithLabelValues("failed to poll vcs").Inc()
+				continue
+			}
+
 			if len(pending) > 0 {
 				// Pod startup might take long, e.g. pulling image. It would deterministically become running or succeeded/failed later.
 				c.logger.Infof("skip reconciliation: running (%v), pending (%v)", k8sutil.GetPodNames(running), k8sutil.GetPodNames(pending))
@@ -345,7 +352,7 @@ func (c *Cluster) run(stopC <-chan struct{}) {
 					break
 				}
 			}
-			rerr = c.reconcile(running)
+			rerr = c.reconcile(running, pvcs)
 			if rerr != nil {
 				c.logger.Errorf("failed to reconcile: %v", rerr)
 				break
@@ -415,7 +422,12 @@ func (c *Cluster) startSeedMember(recoverFromBackup bool) error {
 		SecureClient: c.isSecureClient(),
 	}
 	ms := etcdutil.NewMemberSet(m)
-	if err := c.createPod(ms, m, "new", recoverFromBackup); err != nil {
+	if c.UsePodPV() {
+		if err := c.createPVC(m); err != nil {
+			return fmt.Errorf("failed to create persistent volume claim for seed member (%s): %v", m.Name, err)
+		}
+	}
+	if err := c.createPod(ms, m, "new", recoverFromBackup, c.UsePodPV()); err != nil {
 		return fmt.Errorf("failed to create seed member (%s): %v", m.Name, err)
 	}
 	c.memberCounter++
@@ -430,6 +442,10 @@ func (c *Cluster) isSecurePeer() bool {
 
 func (c *Cluster) isSecureClient() bool {
 	return c.cluster.Spec.TLS.IsSecureClient()
+}
+
+func (c *Cluster) UsePodPV() bool {
+	return c.cluster.Spec.Pod != nil && c.cluster.Spec.Pod.UsePV
 }
 
 // bootstrap creates the seed etcd member for a new cluster.
@@ -470,13 +486,19 @@ func (c *Cluster) setupServices() error {
 	return k8sutil.CreatePeerService(c.config.KubeCli, c.cluster.Name, c.cluster.Namespace, c.cluster.AsOwner())
 }
 
-func (c *Cluster) createPod(members etcdutil.MemberSet, m *etcdutil.Member, state string, needRecovery bool) error {
+func (c *Cluster) createPVC(m *etcdutil.Member) error {
+	pvc := k8sutil.NewPVC(m, c.cluster.Spec, c.cluster.Name, c.cluster.Namespace, c.config.PVProvisioner, c.cluster.AsOwner())
+	_, err := c.config.KubeCli.Core().PersistentVolumeClaims(c.cluster.Namespace).Create(pvc)
+	return err
+}
+
+func (c *Cluster) createPod(members etcdutil.MemberSet, m *etcdutil.Member, state string, needRecovery, usePVC bool) error {
 	token := ""
 	if state == "new" {
 		token = uuid.New()
 	}
 
-	pod := k8sutil.NewEtcdPod(m, members.PeerURLPairs(), c.cluster.Name, state, token, c.cluster.Spec, c.cluster.AsOwner())
+	pod := k8sutil.NewEtcdPod(m, members.PeerURLPairs(), c.cluster.Name, state, token, c.cluster.Spec, usePVC, c.cluster.AsOwner())
 	if needRecovery {
 		k8sutil.AddRecoveryToPod(pod, c.cluster.Name, token, m, c.cluster.Spec)
 	}
@@ -499,6 +521,25 @@ func (c *Cluster) removePod(name string) error {
 	if c.isDebugLoggerEnabled() {
 		c.debugLogger.LogPodDeletion(name)
 	}
+
+	return nil
+}
+
+func (c *Cluster) removePVC(name string) error {
+	ns := c.cluster.Namespace
+	err := c.config.KubeCli.Core().PersistentVolumeClaims(ns).Delete(name, nil)
+	if err != nil {
+		if !k8sutil.IsKubernetesResourceNotFoundError(err) {
+			return err
+		}
+		if c.isDebugLoggerEnabled() {
+			c.debugLogger.LogMessage(fmt.Sprintf("pvc (%s) not found while trying to delete it", name))
+		}
+	}
+	if c.isDebugLoggerEnabled() {
+		c.debugLogger.LogPVCDeletion(name)
+	}
+
 	return nil
 }
 
@@ -528,6 +569,29 @@ func (c *Cluster) pollPods() (running, pending []*v1.Pod, err error) {
 	}
 
 	return running, pending, nil
+}
+
+func (c *Cluster) pollPVCs() (pvcs []*v1.PersistentVolumeClaim, err error) {
+	pvcList, err := c.config.KubeCli.Core().PersistentVolumeClaims(c.cluster.Namespace).List(k8sutil.ClusterListOpt(c.cluster.Name))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list running pvcs: %v", err)
+	}
+
+	for i := range pvcList.Items {
+		pvc := &pvcList.Items[i]
+		if len(pvc.OwnerReferences) < 1 {
+			c.logger.Warningf("pollPVCs: ignore pvc %v: no owner", pvc.Name)
+			continue
+		}
+		if pvc.OwnerReferences[0].UID != c.cluster.UID {
+			c.logger.Warningf("pollPVCs: ignore pvc %v: owner (%v) is not %v",
+				pvc.Name, pvc.OwnerReferences[0].UID, c.cluster.UID)
+			continue
+		}
+		pvcs = append(pvcs, pvc)
+	}
+
+	return pvcs, nil
 }
 
 func (c *Cluster) updateMemberStatus(members etcdutil.MemberSet) {

--- a/pkg/debug/debug_logger.go
+++ b/pkg/debug/debug_logger.go
@@ -75,6 +75,10 @@ func (dl *DebugLogger) LogPodDeletion(podName string) {
 	dl.fileLogger.Infof("deleted pod (%s)", podName)
 }
 
+func (dl *DebugLogger) LogPVCDeletion(pvcName string) {
+	dl.fileLogger.Infof("deleted pvc (%s)", pvcName)
+}
+
 func (dl *DebugLogger) LogClusterSpecUpdate(oldSpec, newSpec string) {
 	dl.fileLogger.Infof("spec update: \nOld:\n%v \nNew:\n%v\n", oldSpec, newSpec)
 }

--- a/pkg/util/etcdutil/member.go
+++ b/pkg/util/etcdutil/member.go
@@ -70,6 +70,10 @@ func (m *Member) PeerURL() string {
 	return fmt.Sprintf("%s://%s:2380", m.peerScheme(), m.FQDN())
 }
 
+func (m *Member) PVCName() string {
+	return fmt.Sprintf("%s-pvc", m.Name)
+}
+
 type MemberSet map[string]*Member
 
 func NewMemberSet(ms ...*Member) MemberSet {
@@ -187,4 +191,12 @@ func clusterNameFromMemberName(mn string) string {
 		panic(fmt.Sprintf("unexpected member name: %s", mn))
 	}
 	return mn[:i]
+}
+
+func MemberNameFromPVCName(pn string) string {
+	i := strings.LastIndex(pn, "-")
+	if i == -1 {
+		panic(fmt.Sprintf("unexpected pvc name: %s", pn))
+	}
+	return pn[:i]
 }

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -22,7 +22,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	envPVTest     = "PV_TEST"
+	envPVTestTrue = "true"
+)
+
 func NewCluster(genName string, size int) *spec.EtcdCluster {
+	usePV := false
+	if os.Getenv(envPVTest) == envPVTestTrue {
+		usePV = true
+	}
+
 	return &spec.EtcdCluster{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       spec.CRDResourceKind,
@@ -33,6 +43,9 @@ func NewCluster(genName string, size int) *spec.EtcdCluster {
 		},
 		Spec: spec.ClusterSpec{
 			Size: size,
+			Pod: &spec.PodPolicy{
+				UsePV: usePV,
+			},
 		},
 	}
 }


### PR DESCRIPTION
this patch adds initial persistent volume feature for etcd data.

When the usePV option is enabled in the etcd cluster spec every
created pod will get a related persistent volume claim and the pod
restart policy will be set to RestartAlways.

This initial patch only covers the case where a pod crashes (or a node
restart before the related pod is evicted by the k8s node
controller). When using a persistent volume, instead of deleting the pod
and creating a new one, the pod will be restarted by k8s.

A future patch will change the reconcile logic to also handle cases
where one or more pods are deleted (manually or by k8s) recreating the
same pod using the same pvc.

The etcd data pvc will be garbage collected like the other cluster
resources.

Questions:
* I'm using the same backup storage class (the name isn't great since it starts with `etcd-backup-`. Should we define different storage classes using the same provisioner or permit different provisioner for backup and data? 

* I'll add some questions inline in the code.

TODO:
- [ ] Check all the tests on your infrastructure (I'm testing on a local k8s cluster disabling tests that needs S3 and updating the generated storage class with another pv provisioner).