### PR TITLE
Pass EtcdEnv vars through to the backup pod spec

### DIFF
--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -153,6 +153,14 @@ func applyPodPolicyToPodTemplateSpec(clusterName string, pod *v1.PodTemplateSpec
 	}
 
 	mergeLabels(pod.Labels, policy.Labels)
+
+	if len(policy.EtcdEnv) != 0 {
+		for i := range pod.Spec.Containers {
+			if pod.Spec.Containers[i].Name == "backup" {
+				pod.Spec.Containers[i].Env = append(pod.Spec.Containers[i].Env, policy.EtcdEnv...)
+			}
+		}
+	}
 }
 
 // IsPodReady returns false if the Pod Status is nil


### PR DESCRIPTION
This allows passing through env vars to the backup pod by using the existing pod policy.

The reason for this is that I run our clusters with a non-standard `KUBERNETES_SERVICE_HOST`. I understand I may also be able to override the `-master` flag, but this seems more flexible.