### PR TITLE
Add global storageclass flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Finally, it is safe to upgrade operator. It's highly recommended to save a backu
 
 ### Added
 
+- A new `--storageclass` flag exists, allowing more granular control over how etcd clusters are backed up to PVs.
+
 ### Changed
 
 - Default timeout for snapshots done by backup sidecar increased from 5 seconds to 1 minute

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -53,6 +53,7 @@ import (
 var (
 	analyticsEnabled bool
 	pvProvisioner    string
+	storageClass     string
 	namespace        string
 	name             string
 	awsSecret        string
@@ -71,6 +72,7 @@ func init() {
 	flag.StringVar(&debug.DebugFilePath, "debug-logfile-path", "", "only for a self hosted cluster, the path where the debug logfile will be written, recommended to be under: /var/tmp/etcd-operator/debug/ to avoid any issue with lack of write permissions")
 
 	flag.StringVar(&pvProvisioner, "pv-provisioner", constants.PVProvisionerGCEPD, "persistent volume provisioner type")
+	flag.StringVar(&storageClass, "storageclass", "", "Storage class type")
 	flag.StringVar(&awsSecret, "backup-aws-secret", "",
 		"The name of the kube secret object that stores the AWS credential file. The file name must be 'credentials'.")
 	flag.StringVar(&awsConfig, "backup-aws-config", "",
@@ -203,6 +205,7 @@ func newControllerConfig() controller.Config {
 		Namespace:      namespace,
 		ServiceAccount: serviceAccount,
 		PVProvisioner:  pvProvisioner,
+		StorageClass:   storageClass,
 		S3Context: s3config.S3Context{
 			AWSSecret: awsSecret,
 			AWSConfig: awsConfig,

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -71,8 +71,8 @@ func init() {
 	flag.BoolVar(&analyticsEnabled, "analytics", true, "Send analytical event (Cluster Created/Deleted etc.) to Google Analytics")
 	flag.StringVar(&debug.DebugFilePath, "debug-logfile-path", "", "only for a self hosted cluster, the path where the debug logfile will be written, recommended to be under: /var/tmp/etcd-operator/debug/ to avoid any issue with lack of write permissions")
 
-	flag.StringVar(&pvProvisioner, "pv-provisioner", constants.PVProvisionerGCEPD, "persistent volume provisioner type")
-	flag.StringVar(&storageClass, "storageclass", "", "Storage class type")
+	flag.StringVar(&pvProvisioner, "pv-provisioner", constants.PVProvisionerGCEPD, "The persistent volume provisioner type used when backing up etcd. This cannot be used with --storageclass")
+	flag.StringVar(&storageClass, "storageclass", "", "The Kubernetes StorageClass used when backing up etcd to persistent volumes. This cannot be used with --pv-provisioner")
 	flag.StringVar(&awsSecret, "backup-aws-secret", "",
 		"The name of the kube secret object that stores the AWS credential file. The file name must be 'credentials'.")
 	flag.StringVar(&awsConfig, "backup-aws-config", "",

--- a/doc/user/backup_config.md
+++ b/doc/user/backup_config.md
@@ -2,6 +2,7 @@
 
 In etcd operator, we provide the following options to save cluster backups to:
 - Persistent Volume (PV) on GCE or AWS
+- Persistent Volume (PV) with StorageClasses
 - S3 bucket on AWS
 
 This docs talks about how to configure etcd operator to use these backup options.
@@ -17,6 +18,12 @@ This is essentially saving backups to an instance of GCE PD.
 If running on AWS Kubernetes, pass the flag `--pv-provisioner=kubernetes.io/aws-ebs` to operator.
 See [AWS deployment](../../example/deployment-aws.yaml).
 This is essentially saving backups on an instance of AWS EBS.
+
+## PV with StorageClass
+
+If your Kubernetes supports [StorageClass](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storageclasses), pass the flag `--storageclass=Name of StorageClass` to operator.
+With StorageClass can can control more in detail how to persist date on PersistentVolumes. See [Deployment](../../example/deployment-storageclass.yaml).
+This is essentially saving backups on an PersistentVolumes with a predefined Storageclasses.
 
 ## S3 on AWS
 

--- a/doc/user/backup_config.md
+++ b/doc/user/backup_config.md
@@ -7,7 +7,18 @@ In etcd operator, we provide the following options to save cluster backups to:
 
 This docs talks about how to configure etcd operator to use these backup options.
 
+
+## PV with --storageclass
+
+If your Kubernetes supports the [StorageClass](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storageclasses) resource, you can pass the flag `--storageclass` to the operator. This flag provides more granular control over how to persist etcd data to PersistentVolumes. This is essentially saving backups to a PersistentVolume with a predefined StorageClass.
+
+For an example of how this is used, see this [Deployment manifest](../../example/deployment-storageclass.yaml).
+
+You must set `--pv-provisioner=none` to use this feature.
+
 ## PV on GCE
+
+**Note: It is recommended to use --storageclass because --pv-provisioner will be deprecated in a future release**
 
 By default, operator supports saving backup to PV on GCE.
 This is done by passing flag `--pv-provisioner=kubernetes.io/gce-pd` to operator, which is also the default value.
@@ -15,20 +26,16 @@ This is essentially saving backups to an instance of GCE PD.
 
 ## PV on AWS
 
+**Note: It is recommended to use --storageclass because --pv-provisioner will be deprecated in a future release**
+
 If running on AWS Kubernetes, pass the flag `--pv-provisioner=kubernetes.io/aws-ebs` to operator.
 See [AWS deployment](../../example/deployment-aws.yaml).
 This is essentially saving backups on an instance of AWS EBS.
 
-## PV with StorageClass
-
-If your Kubernetes supports [StorageClass](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#storageclasses), pass the flag `--storageclass=Name of StorageClass` to operator.
-With StorageClass can can control more in detail how to persist date on PersistentVolumes. See [Deployment](../../example/deployment-storageclass.yaml).
-This is essentially saving backups on an PersistentVolumes with a predefined Storageclasses.
-
 ## S3 on AWS
 
 Saving backups to S3 is also supported. The S3 backup policy can be set at two levels:
-- **operator level:** The same S3 configurations (bucket and secret names) will be used for all S3 backup enabled clusters created by the operator 
+- **operator level:** The same S3 configurations (bucket and secret names) will be used for all S3 backup enabled clusters created by the operator
 - **cluster level:** Each cluster can specify its own S3 configuration.
 
 If configurations for both levels are specified then the cluster level configuration will override the operator level configuration.

--- a/example/deployment-storageclass.yaml
+++ b/example/deployment-storageclass.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etcd-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: etcd-operator
+    spec:
+      containers:
+      - name: etcd-operator
+        image: quay.io/coreos/etcd-operator:v0.2.4
+        command:
+        - "/bin/sh"
+        - "-c"
+        - "/usr/local/bin/etcd-operator --storageclass=generic"
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name

--- a/example/deployment-storageclass.yaml
+++ b/example/deployment-storageclass.yaml
@@ -1,3 +1,11 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -15,7 +23,7 @@ spec:
         command:
         - "/bin/sh"
         - "-c"
-        - "/usr/local/bin/etcd-operator --storageclass=generic"
+        - "/usr/local/bin/etcd-operator --storageclass=fast --pv-provisioner=none"
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/example/storageclass.yaml
+++ b/example/storageclass.yaml
@@ -1,0 +1,7 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fast
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd

--- a/example/storageclass.yaml
+++ b/example/storageclass.yaml
@@ -1,7 +1,0 @@
-kind: StorageClass
-apiVersion: storage.k8s.io/v1
-metadata:
-  name: fast
-provisioner: kubernetes.io/gce-pd
-parameters:
-  type: pd-ssd

--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -80,7 +80,7 @@ func (bm *backupManager) setupStorage() (s backupstorage.Storage, err error) {
 		if c.PVProvisioner == constants.PVProvisionerNone {
 			return nil, errNoPVForBackup
 		}
-		s, err = backupstorage.NewPVStorage(c.KubeCli, cl.Name, cl.Namespace, c.PVProvisioner, *b)
+		s, err = backupstorage.NewPVStorage(c.KubeCli, cl.Name, cl.Namespace, c.PVProvisioner, c.StorageClass, *b)
 	case spec.BackupStorageTypeS3:
 		if len(c.S3Context.AWSConfig) == 0 && b.S3 == nil {
 			return nil, errNoS3ConfigForBackup

--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -77,7 +77,7 @@ func (bm *backupManager) setupStorage() (s backupstorage.Storage, err error) {
 	b := cl.Spec.Backup
 	switch b.StorageType {
 	case spec.BackupStorageTypePersistentVolume, spec.BackupStorageTypeDefault:
-		if c.PVProvisioner == constants.PVProvisionerNone {
+		if c.PVProvisioner == constants.PVProvisionerNone && c.StorageClass == "" {
 			return nil, errNoPVForBackup
 		}
 		s, err = backupstorage.NewPVStorage(c.KubeCli, cl.Name, cl.Namespace, c.PVProvisioner, c.StorageClass, *b)

--- a/pkg/cluster/backupstorage/pv.go
+++ b/pkg/cluster/backupstorage/pv.go
@@ -11,15 +11,17 @@ type pv struct {
 	clusterName   string
 	namespace     string
 	pvProvisioner string
+	storageClass  string
 	backupPolicy  spec.BackupPolicy
 	kubecli       kubernetes.Interface
 }
 
-func NewPVStorage(kubecli kubernetes.Interface, cn, ns, pvp string, backupPolicy spec.BackupPolicy) (Storage, error) {
+func NewPVStorage(kubecli kubernetes.Interface, cn, ns, pvp string, stc string, backupPolicy spec.BackupPolicy) (Storage, error) {
 	s := &pv{
 		clusterName:   cn,
 		namespace:     ns,
 		pvProvisioner: pvp,
+		storageClass:  stc,
 		backupPolicy:  backupPolicy,
 		kubecli:       kubecli,
 	}
@@ -27,7 +29,7 @@ func NewPVStorage(kubecli kubernetes.Interface, cn, ns, pvp string, backupPolicy
 }
 
 func (s *pv) Create() error {
-	return k8sutil.CreateAndWaitPVC(s.kubecli, s.clusterName, s.namespace, s.pvProvisioner, s.backupPolicy.PV.VolumeSizeInMB)
+	return k8sutil.CreateAndWaitPVC(s.kubecli, s.clusterName, s.namespace, s.pvProvisioner, s.storageClass, s.backupPolicy.PV.VolumeSizeInMB)
 }
 
 func (s *pv) Clone(from string) error {

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -59,6 +59,7 @@ type clusterEvent struct {
 
 type Config struct {
 	PVProvisioner  string
+	StorageClass   string
 	ServiceAccount string
 	s3config.S3Context
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -76,6 +76,7 @@ type Config struct {
 	Namespace      string
 	ServiceAccount string
 	PVProvisioner  string
+	StorageClass   string
 	s3config.S3Context
 	KubeCli    kubernetes.Interface
 	KubeExtCli apiextensionsclient.Interface
@@ -245,6 +246,7 @@ func (c *Controller) findAllClusters() (string, error) {
 func (c *Controller) makeClusterConfig() cluster.Config {
 	return cluster.Config{
 		PVProvisioner:  c.PVProvisioner,
+		StorageClass:   c.StorageClass,
 		ServiceAccount: c.Config.ServiceAccount,
 		S3Context:      c.S3Context,
 
@@ -266,7 +268,7 @@ func (c *Controller) initResource() (string, error) {
 			return "", fmt.Errorf("fail to create CRD: %v", err)
 		}
 	}
-	if c.Config.PVProvisioner != constants.PVProvisionerNone {
+	if c.Config.PVProvisioner != constants.PVProvisionerNone && c.Config.StorageClass != "" {
 		err = k8sutil.CreateStorageClass(c.KubeCli, c.PVProvisioner)
 		if err != nil {
 			if !k8sutil.IsKubernetesResourceAlreadyExistError(err) {

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -49,7 +49,8 @@ const (
 )
 
 func CreateStorageClass(kubecli kubernetes.Interface, pvProvisioner string) error {
-	// We need to get rid of prefix because naming doesn't support "/".
+	// We need
+	// get rid of prefix because naming doesn't support "/".
 	name := storageClassPrefix + "-" + path.Base(pvProvisioner)
 	class := &v1beta1storage.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
@@ -61,9 +62,14 @@ func CreateStorageClass(kubecli kubernetes.Interface, pvProvisioner string) erro
 	return err
 }
 
-func CreateAndWaitPVC(kubecli kubernetes.Interface, clusterName, ns, pvProvisioner string, volumeSizeInMB int) error {
+func CreateAndWaitPVC(kubecli kubernetes.Interface, clusterName, ns, pvProvisioner string, storageClass string, volumeSizeInMB int) error {
 	name := makePVCName(clusterName)
-	storageClassName := storageClassPrefix + "-" + path.Base(pvProvisioner)
+	var storageClassName string
+	if storageClass != "" {
+		storageClassName = storageClass
+	} else {
+		storageClassName = storageClassPrefix + "-" + path.Base(pvProvisioner)
+	}
 	claim := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -49,8 +49,7 @@ const (
 )
 
 func CreateStorageClass(kubecli kubernetes.Interface, pvProvisioner string) error {
-	// We need
-	// get rid of prefix because naming doesn't support "/".
+	// We need to get rid of prefix because naming doesn't support "/".
 	name := storageClassPrefix + "-" + path.Base(pvProvisioner)
 	class := &v1beta1storage.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This PR supersedes https://github.com/coreos/etcd-operator/pull/949 and introduces a new global `--storageclass` flag. If the user wants to use `--storageclass`, they must set `--pv-provisioner=none`.

It's also worth noting that this PR doesn't implement cluster-specific storage classes, just globally. This can be done at a later date.