### PR TITLE
Add support for etcd 3.2 to backup version matrix

### DIFF
--- a/pkg/backup/version.go
+++ b/pkg/backup/version.go
@@ -24,6 +24,7 @@ import (
 var compatibilityMap = map[string]map[string]struct{}{
 	"3.0": {"2.3": struct{}{}, "3.0": struct{}{}},
 	"3.1": {"3.0": struct{}{}, "3.1": struct{}{}},
+	"3.2": {"3.1": struct{}{}, "3.2": struct{}{}},
 }
 
 func getMajorMinorVersionFromBackup(name string) (string, error) {


### PR DESCRIPTION
Currently when I try to restore etc 3.2 backup (e.g. during TPR->CRD upgrade) I get an error that "version 3.2 is not compatible with version 3.2".

This PR adds 3.2 to backup/restore compatibility matrix.