### PR TITLE
spec: add PVSource to PodPolicy

### DIFF
--- a/pkg/spec/backup.go
+++ b/pkg/spec/backup.go
@@ -67,24 +67,14 @@ func (bp *BackupPolicy) Validate() error {
 }
 
 type StorageSource struct {
+	// PV represents a Persistent Volume resource, operator will claim the
+	// required size before creating the etcd cluster for backup purpose.
+	// If the snapshot size is larger than the size specified operator would
+	// kill the cluster and report failure condition in status.
 	PV *PVSource `json:"pv,omitempty"`
 	S3 *S3Source `json:"s3,omitempty"`
 	// ABS represents an Azure Blob Storage resource for storing etcd backups
 	ABS *ABSSource `json:"abs,omitempty"`
-}
-
-type PVSource struct {
-	// VolumeSizeInMB specifies the required volume size to perform backups.
-	// Operator will claim the required size before creating the etcd cluster for backup
-	// purpose.
-	// If the snapshot size is larger than the size specified, backup fails.
-	VolumeSizeInMB int `json:"volumeSizeInMB"`
-
-	// StorageClass indicates what Kubernetes storage class will be used to
-	// snapshot etcd cluster state to a persistent volume. This enables the user
-	// to have fine-grained control over how backups work, since it uses the
-	// existing StorageClass mechanism in Kubernetes.
-	StorageClass string `json:"storageClass"`
 }
 
 // TODO: support per cluster S3 Source configuration.

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -62,6 +62,17 @@ func (c *EtcdCluster) AsOwner() metav1.OwnerReference {
 	}
 }
 
+type PVSource struct {
+	// VolumeSizeInMB specifies the required volume size.
+	VolumeSizeInMB int `json:"volumeSizeInMB"`
+
+	// StorageClass indicates what Kubernetes storage class will be used.
+	// This enables the user to have fine-grained control over how persistent
+	// volumes are created since it uses the existing StorageClass mechanism in
+	// Kubernetes.
+	StorageClass string `json:"storageClass"`
+}
+
 type ClusterSpec struct {
 	// Size is the expected size of the etcd cluster.
 	// The etcd-operator will eventually make the size of the running
@@ -154,6 +165,11 @@ type PodPolicy struct {
 	// bootstrap the cluster (for example `--initial-cluster` flag).
 	// This field cannot be updated.
 	EtcdEnv []v1.EnvVar `json:"etcdEnv,omitempty"`
+
+	// PV represents a Persistent Volume resource.
+	// If defined new pods will use a persistent volume to store etcd data.
+	// TODO(sgotti) unimplemented
+	PV *PVSource `json:"pv,omitempty"`
 }
 
 func (c *ClusterSpec) Validate() error {


### PR DESCRIPTION
As requested by @hongchaodeng here (https://github.com/coreos/etcd-operator/pull/1349#issuecomment-321013872) I opened this PR to discuss only spec changes to add pv support for etcd data.

I wanted to propose to directly use StorageClass in the spec instead of the `--pv-provisioner` option but I noticed this has been already accepted during my vacations in #1361. So I used it, moving it from spec/backup.go to spec/cluster.go and added PVSource also to PodPolicy.

This patch adds the initial spec changes (without implementation) to
support storing etcd data inside a persistent volume.

The PVSource type used by the backups policy is now shared between
backups and pod policies.

Since this only a spec change the required spec validation isn't part of this patch.