### PR TITLE
feat(abs): add operator logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Expose `/metrics` endpoint at port 8080
 - Add cluster S3 spec `prefix` feature. Let user choose a prefix under the bucket.
+- Cluster backups can now be saved using Azure Blob Storage (ABS).
 
 ### Changed
 

--- a/pkg/backup/abs/abs.go
+++ b/pkg/backup/abs/abs.go
@@ -17,17 +17,12 @@ package abs
 import (
 	"fmt"
 	"io"
-	"os"
 	"path"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 )
 
-const (
-	v1                        = "v1/"
-	azureStorageAccountEnvVar = "AZURE_STORAGE_ACCOUNT"
-	azureStorageKeyEnvVar     = "AZURE_STORAGE_KEY"
-)
+const v1 = "v1/"
 
 // ABS is a helper to wrap complex ABS logic
 type ABS struct {
@@ -37,15 +32,7 @@ type ABS struct {
 }
 
 // New returns a new ABS object for a given container using credentials set in the environment
-func New(container, prefix string) (*ABS, error) {
-	accountName := os.Getenv(azureStorageAccountEnvVar)
-	if accountName == "" {
-		return nil, fmt.Errorf("missing required environment variable of %s", azureStorageAccountEnvVar)
-	}
-	accountKey := os.Getenv(azureStorageKeyEnvVar)
-	if accountKey == "" {
-		return nil, fmt.Errorf("missing required environment variable of %s", azureStorageKeyEnvVar)
-	}
+func New(container, accountName, accountKey, prefix string) (*ABS, error) {
 	basicClient, err := storage.NewBasicClient(accountName, accountKey)
 	if err != nil {
 		return nil, fmt.Errorf("create ABS client failed: %v", err)

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -92,7 +92,10 @@ func New(kclient kubernetes.Interface, clusterName, ns string, sp spec.ClusterSp
 			S3:  s3cli,
 		}
 	case spec.BackupStorageTypeABS:
-		absCli, err := abs.New(os.Getenv(env.ABSContainer), path.Join(ns, clusterName))
+		absCli, err := abs.New(os.Getenv(env.ABSContainer),
+			os.Getenv(env.ABSStorageAccount),
+			os.Getenv(env.ABSStorageKey),
+			path.Join(ns, clusterName))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/backup/env/env.go
+++ b/pkg/backup/env/env.go
@@ -15,8 +15,10 @@
 package env
 
 const (
-	ClusterSpec  = "CLUSTER_SPEC"
-	AWSS3Bucket  = "AWS_S3_BUCKET"
-	AWSConfig    = "AWS_CONFIG_FILE"
-	ABSContainer = "AZURE_STORAGE_CONTAINER"
+	ClusterSpec       = "CLUSTER_SPEC"
+	AWSS3Bucket       = "AWS_S3_BUCKET"
+	AWSConfig         = "AWS_CONFIG_FILE"
+	ABSContainer      = "AZURE_STORAGE_CONTAINER"
+	ABSStorageAccount = "AZURE_STORAGE_ACCOUNT"
+	ABSStorageKey     = "AZURE_STORAGE_KEY"
 )

--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -43,6 +43,7 @@ const (
 var (
 	errNoPVForBackup       = errors.New("no backup could be created due to PVProvisioner (none) is set")
 	errNoS3ConfigForBackup = errors.New("no backup could be created due to S3 configuration not set")
+	errNoABSCredsForBackup = errors.New("no backup could be created due to ABS credentials not set")
 )
 
 type backupManager struct {
@@ -91,6 +92,11 @@ func (bm *backupManager) setupStorage() (s backupstorage.Storage, err error) {
 			return nil, errNoS3ConfigForBackup
 		}
 		s, err = backupstorage.NewS3Storage(c.S3Context, c.KubeCli, cl.Name, cl.Namespace, *b)
+	case spec.BackupStorageTypeABS:
+		if b.ABS == nil {
+			return nil, errNoABSCredsForBackup
+		}
+		s, err = backupstorage.NewABSStorage(c.KubeCli, cl.Name, cl.Namespace, *b)
 	}
 	return s, err
 }
@@ -163,6 +169,10 @@ func (bm *backupManager) makeSidecarDeployment() *appsv1beta1.Deployment {
 			k8sutil.AttachS3ToPodSpec(&podTemplate.Spec, *ss)
 		} else {
 			k8sutil.AttachOperatorS3ToPodSpec(&podTemplate.Spec, c.S3Context)
+		}
+	case spec.BackupStorageTypeABS:
+		if ws := cl.Spec.Backup.ABS; ws != nil {
+			k8sutil.AttachABSToPodSpec(&podTemplate.Spec, *ws)
 		}
 	}
 	name := k8sutil.BackupSidecarName(cl.Name)

--- a/pkg/cluster/backupstorage/abs.go
+++ b/pkg/cluster/backupstorage/abs.go
@@ -1,0 +1,94 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backupstorage
+
+import (
+	"path"
+
+	backupabs "github.com/coreos/etcd-operator/pkg/backup/abs"
+	"github.com/coreos/etcd-operator/pkg/spec"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+type abs struct {
+	clusterName  string
+	namespace    string
+	backupPolicy spec.BackupPolicy
+	kubecli      kubernetes.Interface
+	abscli       *backupabs.ABS
+}
+
+// NewABSStorage returns a new ABS Storage implementation using the given kubecli, cluster name, namespace and backup policy
+func NewABSStorage(kubecli kubernetes.Interface, clusterName, ns string, p spec.BackupPolicy) (Storage, error) {
+	prefix := path.Join(ns, clusterName)
+
+	abscli, err := func() (*backupabs.ABS, error) {
+		account, key, err := setupABSCreds(kubecli, ns, p.ABS.ABSSecret)
+		if err != nil {
+			return nil, err
+		}
+		return backupabs.New(p.ABS.ABSContainer, account, key, prefix)
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	ws := &abs{
+		kubecli:      kubecli,
+		clusterName:  clusterName,
+		backupPolicy: p,
+		namespace:    ns,
+		abscli:       abscli,
+	}
+	return ws, nil
+}
+
+func (a *abs) Create() error {
+	// TODO: check if container exists?
+	return nil
+}
+
+func (a *abs) Clone(from string) error {
+	prefix := a.namespace + "/" + from
+	return a.abscli.CopyPrefix(prefix)
+}
+
+func (a *abs) Delete() error {
+	if a.backupPolicy.AutoDelete {
+		names, err := a.abscli.List()
+		if err != nil {
+			return err
+		}
+		for _, n := range names {
+			err = a.abscli.Delete(n)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func setupABSCreds(kubecli kubernetes.Interface, ns, secret string) (account, key string, err error) {
+	se, err := kubecli.CoreV1().Secrets(ns).Get(secret, metav1.GetOptions{})
+	if err != nil {
+		return "", "", err
+	}
+	account = string(se.Data[spec.ABSStorageAccount])
+	key = string(se.Data[spec.ABSStorageKey])
+	return
+}

--- a/pkg/spec/backup.go
+++ b/pkg/spec/backup.go
@@ -26,6 +26,11 @@ const (
 
 	AWSSecretCredentialsFileName = "credentials"
 	AWSSecretConfigFileName      = "config"
+
+	// ABSStorageAccount defines the key for the Azure Storage Account value in the ABS Kubernetes secret
+	ABSStorageAccount = "storage-account"
+	// ABSStorageKey defines the key for the Azure Storage Key value in the ABS Kubernetes secret
+	ABSStorageKey = "storage-key"
 )
 
 var errPVZeroSize = errors.New("PV backup should not have 0 size volume")

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -183,6 +183,29 @@ func AttachOperatorS3ToPodSpec(ps *v1.PodSpec, s3Ctx s3config.S3Context) {
 	})
 }
 
+// AttachABSToPodSpec attaches ABS credentials to a Pod
+func AttachABSToPodSpec(ps *v1.PodSpec, ws spec.ABSSource) {
+	storageAccountSelector := v1.SecretKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{Name: ws.ABSSecret},
+		Key:                  spec.ABSStorageAccount,
+	}
+	storageKeySelector := v1.SecretKeySelector{
+		LocalObjectReference: v1.LocalObjectReference{Name: ws.ABSSecret},
+		Key:                  spec.ABSStorageKey,
+	}
+
+	ps.Containers[0].Env = append(ps.Containers[0].Env, v1.EnvVar{
+		Name:      backupenv.ABSStorageAccount,
+		ValueFrom: &v1.EnvVarSource{SecretKeyRef: &storageAccountSelector},
+	}, v1.EnvVar{
+		Name:      backupenv.ABSStorageKey,
+		ValueFrom: &v1.EnvVarSource{SecretKeyRef: &storageKeySelector},
+	}, v1.EnvVar{
+		Name:  backupenv.ABSContainer,
+		Value: ws.ABSContainer,
+	})
+}
+
 func NewBackupPodTemplate(clusterName, account string, sp spec.ClusterSpec) v1.PodTemplateSpec {
 	b, err := json.Marshal(sp)
 	if err != nil {


### PR DESCRIPTION
(Re-issue of https://github.com/coreos/etcd-operator/pull/1369)

TODO:
 - [x] Revise approach on passing storage credentials to pod (currently uses non-thread-safe `os.Setenv()`)