### PR TITLE
pod-policy: add automountServiceAccountToken to the pod policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Expose `/metrics` endpoint at port 8080
 - Add cluster S3 spec `prefix` feature. Let user choose a prefix under the bucket.
+- Add `automountServiceAccountToken` to pod policy. Let users disable automounting of the Kubernetes access token into etcd-operator controlled pods.
 
 ### Changed
 

--- a/pkg/spec/cluster.go
+++ b/pkg/spec/cluster.go
@@ -170,6 +170,10 @@ type PodPolicy struct {
 	// If defined new pods will use a persistent volume to store etcd data.
 	// TODO(sgotti) unimplemented
 	PV *PVSource `json:"pv,omitempty"`
+
+	// By default, kubernetes will mount a service account token into the etcd pods.
+	// AutomountServiceAccountToken indicates whether pods running with the service account should have an API token automatically mounted.
+	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty"`
 }
 
 func (c *ClusterSpec) Validate() error {

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -127,6 +127,9 @@ func applyPodPolicy(clusterName string, pod *v1.Pod, policy *spec.PodPolicy) {
 	if len(policy.Tolerations) != 0 {
 		pod.Spec.Tolerations = policy.Tolerations
 	}
+	if policy.AutomountServiceAccountToken != nil {
+		pod.Spec.AutomountServiceAccountToken = policy.AutomountServiceAccountToken
+	}
 
 	mergeLabels(pod.Labels, policy.Labels)
 
@@ -150,6 +153,9 @@ func applyPodPolicyToPodTemplateSpec(clusterName string, pod *v1.PodTemplateSpec
 	}
 	if len(policy.Tolerations) != 0 {
 		pod.Spec.Tolerations = policy.Tolerations
+	}
+	if policy.AutomountServiceAccountToken != nil {
+		pod.Spec.AutomountServiceAccountToken = policy.AutomountServiceAccountToken
 	}
 
 	mergeLabels(pod.Labels, policy.Labels)


### PR DESCRIPTION
By default, Kubernetes will mount a service account token into the etcd
pods. This allows users to disable this via the pod-policy.