### PR TITLE
doc: add a note on TLS to the RBAC docs

### DIFF
--- a/doc/user/rbac.md
+++ b/doc/user/rbac.md
@@ -95,7 +95,19 @@ rules:
 EOF
 ```
 
-If you need use s3 backup, add these to above input:
+If you plan on setting up TLS in any of your clusters, add this to the above
+input:
+
+```
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+```
+
+If you need to use S3 backup, add this to the above input:
 
 ```
 - apiGroups: 


### PR DESCRIPTION
In order to create an `etcd` cluster with TLS enabled, the service account being used needs access to the `etcd-client-tls`, `etcd-peer-tls` and `etcd-server-tls` secrets.

---

Since one needs `secrets` for both TLS and S3 I don't know whether it would be preferable to include `secrets` right away here:

https://github.com/coreos/etcd-operator/blame/master/doc/user/rbac.md#L81

Any thoughts?