### PR TITLE
*: document resource labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Read [RBAC docs](./doc/user/rbac.md) for how to setup RBAC rules for etcd operat
 
 Read [Developer Guide](./doc/dev/developer_guide.md) for setting up development environment if you want to contribute.
 
+See the [Resources and Labels](./doc/user/resource_labels.md) doc for an overview of the resources created by the etcd-operator.
+
 ## Requirements
 
 - Kubernetes 1.7+

--- a/doc/user/resource_labels.md
+++ b/doc/user/resource_labels.md
@@ -1,0 +1,10 @@
+## Resource Labels
+The etcd-operator creates the following Kubernetes resources for each etcd cluster:
+- Pods for the etcd nodes
+- Deployment for the backup side car
+- Services for the etcd client, peer and backup service
+- Persistent Volume Claim, if backup is enabled with the storage type as PersistentVolume
+
+where each resource has the following labels:
+- `app=etcd`
+- `etcd_cluster=<cluster-name>`

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -67,11 +67,8 @@ func CreateAndWaitPVC(kubecli kubernetes.Interface, clusterName, ns, storageClas
 	name := makePVCName(clusterName)
 	claim := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				"etcd_cluster": clusterName,
-				"app":          "etcd",
-			},
+			Name:   name,
+			Labels: LabelsForCluster(clusterName),
 			Annotations: map[string]string{
 				"volume.beta.kubernetes.io/storage-class": storageClass,
 			},

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -190,10 +190,7 @@ func CreateAndWaitPod(kubecli kubernetes.Interface, ns string, pod *v1.Pod, time
 }
 
 func newEtcdServiceManifest(svcName, clusterName, clusterIP string, ports []v1.ServicePort) *v1.Service {
-	labels := map[string]string{
-		"app":          "etcd",
-		"etcd_cluster": clusterName,
-	}
+	labels := LabelsForCluster(clusterName)
 	svc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   svcName,


### PR DESCRIPTION
@hongchaodeng I've listed out all the resource labels I could see but PTAL and let me know if we need to align them better.

Only the backup sidecar pod uses the `app=etcd_backup_tool` label which I think was required to select it in e2e testing.