### PR TITLE
*: create event for new member added

### DIFF
--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -141,6 +141,10 @@ func (c *Cluster) addOneMember() error {
 	}
 	c.memberCounter++
 	c.logger.Infof("added member (%s)", newMember.Name)
+	_, err = c.eventsCli.Create(k8sutil.NewMemberAddEvent(newMember.Name, c.cluster))
+	if err != nil {
+		c.logger.Errorf("failed to create new member add event: %v", err)
+	}
 	return nil
 }
 

--- a/pkg/util/k8sutil/events_util.go
+++ b/pkg/util/k8sutil/events_util.go
@@ -1,0 +1,40 @@
+package k8sutil
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func NewMemberAddEvent(memberName string, cl *api.EtcdCluster) *v1.Event {
+	t := time.Now()
+	return &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: cl.Name + "-",
+			Namespace:    cl.Namespace,
+		},
+		InvolvedObject: v1.ObjectReference{
+			APIVersion:      api.SchemeGroupVersion.String(),
+			Kind:            api.CRDResourceKind,
+			Name:            cl.Name,
+			Namespace:       cl.Namespace,
+			UID:             cl.UID,
+			ResourceVersion: cl.ResourceVersion,
+		},
+		Type:    v1.EventTypeNormal,
+		Reason:  "New Member Added",
+		Message: fmt.Sprintf("New member %s added to cluster", memberName),
+		Source: v1.EventSource{
+			Component: os.Getenv("MY_POD_NAME"),
+		},
+		// Each New Member Add event is unique so it should not be collapsed with other events
+		FirstTimestamp: metav1.Time{Time: t},
+		LastTimestamp:  metav1.Time{Time: t},
+		Count:          int32(1),
+	}
+}


### PR DESCRIPTION
Part of #1412 
With this `kubectl describe etcdcluster <cluster-name>` shows the events like:

```
Events:
  FirstSeen	LastSeen	Count	From				SubObjectPath	Type		Reason			Message
  ---------	--------	-----	----				-------------	--------	------			-------
  30s		30s		1	etcd-operator-3106627829-lkfgx			Normal		New Member Added	New member example-etcd-cluster-0000 added to cluster
  22s		22s		1	etcd-operator-3106627829-lkfgx			Normal		New Member Added	New member example-etcd-cluster-0001 added to cluster
  12s		12s		1	etcd-operator-3106627829-lkfgx			Normal		New Member Added	New member example-etcd-cluster-0002 added to cluster
```