### PR TITLE
*: use consts for operator pod name and namespace

### DIFF
--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -23,6 +23,7 @@ import (
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
 	"github.com/coreos/etcd-operator/pkg/backup"
 	"github.com/coreos/etcd-operator/pkg/backup/env"
+	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/version"
 
@@ -46,7 +47,7 @@ func init() {
 
 	flag.Parse()
 
-	namespace = os.Getenv("MY_POD_NAMESPACE")
+	namespace = os.Getenv(constants.EnvOperatorPodNamespace)
 	if len(namespace) == 0 {
 		namespace = "default"
 	}

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -73,13 +73,13 @@ func init() {
 }
 
 func main() {
-	namespace = os.Getenv("MY_POD_NAMESPACE")
+	namespace = os.Getenv(constants.EnvOperatorPodNamespace)
 	if len(namespace) == 0 {
-		logrus.Fatalf("must set env MY_POD_NAMESPACE")
+		logrus.Fatalf("must set env (%s)", constants.EnvOperatorPodNamespace)
 	}
-	name = os.Getenv("MY_POD_NAME")
+	name = os.Getenv(constants.EnvOperatorPodName)
 	if len(name) == 0 {
-		logrus.Fatalf("must set env MY_POD_NAME")
+		logrus.Fatalf("must set env (%s)", constants.EnvOperatorPodName)
 	}
 
 	c := make(chan os.Signal, 1)

--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -30,4 +30,7 @@ const (
 	PVProvisionerGCEPD  = "kubernetes.io/gce-pd"
 	PVProvisionerAWSEBS = "kubernetes.io/aws-ebs"
 	PVProvisionerNone   = "none"
+
+	EnvOperatorPodName      = "MY_POD_NAME"
+	EnvOperatorPodNamespace = "MY_POD_NAMESPACE"
 )

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -183,7 +183,7 @@ func NewBackupPodTemplate(clusterName, account string, sp api.ClusterSpec) v1.Po
 					"--etcd-cluster=" + clusterName,
 				},
 				Env: []v1.EnvVar{{
-					Name:      "MY_POD_NAMESPACE",
+					Name:      constants.EnvOperatorPodNamespace,
 					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
 				}, {
 					Name:  backupenv.ClusterSpec,

--- a/pkg/util/k8sutil/events_util.go
+++ b/pkg/util/k8sutil/events_util.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
+	"github.com/coreos/etcd-operator/pkg/util/constants"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,7 +31,7 @@ func NewMemberAddEvent(memberName string, cl *api.EtcdCluster) *v1.Event {
 		Reason:  "New Member Added",
 		Message: fmt.Sprintf("New member %s added to cluster", memberName),
 		Source: v1.EventSource{
-			Component: os.Getenv("MY_POD_NAME"),
+			Component: os.Getenv(constants.EnvOperatorPodName),
 		},
 		// Each New Member Add event is unique so it should not be collapsed with other events
 		FirstTimestamp: metav1.Time{Time: t},

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/coreos/etcd-operator/pkg/client"
+	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/pkg/util/probe"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
@@ -118,11 +119,11 @@ func (f *Framework) SetupEtcdOperator() error {
 					Command:         cmd,
 					Env: []v1.EnvVar{
 						{
-							Name:      "MY_POD_NAMESPACE",
+							Name:      constants.EnvOperatorPodNamespace,
 							ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
 						},
 						{
-							Name:      "MY_POD_NAME",
+							Name:      constants.EnvOperatorPodName,
 							ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},
 						},
 					},

--- a/test/e2e/upgradetest/framework/framework.go
+++ b/test/e2e/upgradetest/framework/framework.go
@@ -19,6 +19,7 @@ import (
 	"os"
 
 	"github.com/coreos/etcd-operator/pkg/client"
+	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/pkg/util/probe"
 	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
@@ -103,11 +104,11 @@ func (f *Framework) CreateOperator(name string) error {
 						Command:         cmd,
 						Env: []v1.EnvVar{
 							{
-								Name:      "MY_POD_NAMESPACE",
+								Name:      constants.EnvOperatorPodNamespace,
 								ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
 							},
 							{
-								Name:      "MY_POD_NAME",
+								Name:      constants.EnvOperatorPodName,
 								ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},
 							},
 						},


### PR DESCRIPTION
Add constants for using `MY_POD_NAME` and `MY_POD_NAMESPACE` in different places.