### PR TITLE
*: add events for remove member and replace dead member

### DIFF
--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -179,6 +179,10 @@ func (c *Cluster) removeDeadMember(toRemove *etcdutil.Member) error {
 	}
 
 	c.logger.Infof("removing dead member %q", toRemove.Name)
+	_, err := c.eventsCli.Create(k8sutil.ReplacingDeadMemberEvent(toRemove.Name, c.cluster))
+	if err != nil {
+		c.logger.Errorf("failed to create replacing dead member event: %v", err)
+	}
 
 	return c.removeMember(toRemove)
 }
@@ -195,6 +199,10 @@ func (c *Cluster) removeMember(toRemove *etcdutil.Member) error {
 		}
 	}
 	c.members.Remove(toRemove.Name)
+	_, err = c.eventsCli.Create(k8sutil.MemberRemoveEvent(toRemove.Name, c.cluster))
+	if err != nil {
+		c.logger.Errorf("failed to create remove member event: %v", err)
+	}
 	if err := c.removePod(toRemove.Name); err != nil {
 		return err
 	}

--- a/pkg/util/k8sutil/events_util.go
+++ b/pkg/util/k8sutil/events_util.go
@@ -13,6 +13,30 @@ import (
 )
 
 func NewMemberAddEvent(memberName string, cl *api.EtcdCluster) *v1.Event {
+	event := newClusterEvent(cl)
+	event.Type = v1.EventTypeNormal
+	event.Reason = "New Member Added"
+	event.Message = fmt.Sprintf("New member %s added to cluster", memberName)
+	return event
+}
+
+func MemberRemoveEvent(memberName string, cl *api.EtcdCluster) *v1.Event {
+	event := newClusterEvent(cl)
+	event.Type = v1.EventTypeNormal
+	event.Reason = "Member Removed"
+	event.Message = fmt.Sprintf("Existing member %s removed from the cluster", memberName)
+	return event
+}
+
+func ReplacingDeadMemberEvent(memberName string, cl *api.EtcdCluster) *v1.Event {
+	event := newClusterEvent(cl)
+	event.Type = v1.EventTypeNormal
+	event.Reason = "Replacing Dead Member"
+	event.Message = fmt.Sprintf("The dead member %s is being replaced", memberName)
+	return event
+}
+
+func newClusterEvent(cl *api.EtcdCluster) *v1.Event {
 	t := time.Now()
 	return &v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
@@ -27,13 +51,10 @@ func NewMemberAddEvent(memberName string, cl *api.EtcdCluster) *v1.Event {
 			UID:             cl.UID,
 			ResourceVersion: cl.ResourceVersion,
 		},
-		Type:    v1.EventTypeNormal,
-		Reason:  "New Member Added",
-		Message: fmt.Sprintf("New member %s added to cluster", memberName),
 		Source: v1.EventSource{
 			Component: os.Getenv(constants.EnvOperatorPodName),
 		},
-		// Each New Member Add event is unique so it should not be collapsed with other events
+		// Each cluster event is unique so it should not be collapsed with other events
 		FirstTimestamp: metav1.Time{Time: t},
 		LastTimestamp:  metav1.Time{Time: t},
 		Count:          int32(1),


### PR DESCRIPTION
Added events for removing a member, and replacing a dead member.
The following events are generated from:
- Creating a 3 member cluster
- Scaling cluster size to 4 members
- Deleting the pod of the 4th member `example-etcd-cluster-0003`
- Scaling cluster size back to 3 members

```
Events:
  FirstSeen	LastSeen	Count	From				SubObjectPath	Type		Reason			Message
  ---------	--------	-----	----				-------------	--------	------			-------
  7m		7m		1	etcd-operator-3106627829-m7m56			Normal		New Member Added	New member example-etcd-cluster-0000 added to cluster
  7m		7m		1	etcd-operator-3106627829-m7m56			Normal		New Member Added	New member example-etcd-cluster-0001 added to cluster
  7m		7m		1	etcd-operator-3106627829-m7m56			Normal		New Member Added	New member example-etcd-cluster-0002 added to cluster
  4m		4m		1	etcd-operator-3106627829-m7m56			Normal		New Member Added	New member example-etcd-cluster-0003 added to cluster
  3m		3m		1	etcd-operator-3106627829-m7m56			Normal		Replacing Dead Member	The dead member example-etcd-cluster-0003 is being replaced
  3m		3m		1	etcd-operator-3106627829-m7m56			Normal		Member Removed		Existing member example-etcd-cluster-0003 removed from the cluster
  3m		3m		1	etcd-operator-3106627829-m7m56			Normal		New Member Added	New member example-etcd-cluster-0004 added to cluster
  30s		30s		1	etcd-operator-3106627829-m7m56			Normal		Member Removed		Existing member example-etcd-cluster-0000 removed from the cluster
```