### PR TITLE
*: add member upgraded event

### DIFF
--- a/pkg/cluster/upgrade.go
+++ b/pkg/cluster/upgrade.go
@@ -49,5 +49,10 @@ func (c *Cluster) upgradeOneMember(memberName string) error {
 		return fmt.Errorf("fail to update the etcd member (%s): %v", memberName, err)
 	}
 	c.logger.Infof("finished upgrading the etcd member %v", memberName)
+	_, err = c.eventsCli.Create(k8sutil.MemberUpgradedEvent(memberName, k8sutil.GetEtcdVersion(oldpod), c.cluster.Spec.Version, c.cluster))
+	if err != nil {
+		c.logger.Errorf("failed to create member upgraded event: %v", err)
+	}
+
 	return nil
 }

--- a/pkg/util/k8sutil/events_util.go
+++ b/pkg/util/k8sutil/events_util.go
@@ -36,6 +36,14 @@ func ReplacingDeadMemberEvent(memberName string, cl *api.EtcdCluster) *v1.Event 
 	return event
 }
 
+func MemberUpgradedEvent(memberName, oldVersion, newVersion string, cl *api.EtcdCluster) *v1.Event {
+	event := newClusterEvent(cl)
+	event.Type = v1.EventTypeNormal
+	event.Reason = "Member Upgraded"
+	event.Message = fmt.Sprintf("Member %s upgraded from %s to %s ", memberName, oldVersion, newVersion)
+	return event
+}
+
 func newClusterEvent(cl *api.EtcdCluster) *v1.Event {
 	t := time.Now()
 	return &v1.Event{


### PR DESCRIPTION
Addresses #1412 
Events for upgrade now look like:
```
Events:
  FirstSeen	LastSeen	Count	From				SubObjectPath	Type		Reason			Message
  ---------	--------	-----	----				-------------	--------	------			-------
  2m		2m		1	etcd-operator-3106627829-813mj			Normal		New Member Added	New member example-etcd-cluster-0000 added to cluster
  1m		1m		1	etcd-operator-3106627829-813mj			Normal		New Member Added	New member example-etcd-cluster-0001 added to cluster
  1m		1m		1	etcd-operator-3106627829-813mj			Normal		New Member Added	New member example-etcd-cluster-0002 added to cluster
  1m		1m		1	etcd-operator-3106627829-813mj			Normal		Member Upgraded		Member example-etcd-cluster-0000 upgraded from 3.1.8 to 3.1.9
  56s		56s		1	etcd-operator-3106627829-813mj			Normal		Member Upgraded		Member example-etcd-cluster-0001 upgraded from 3.1.8 to 3.1.9
  48s		48s		1	etcd-operator-3106627829-813mj			Normal		Member Upgraded		Member example-etcd-cluster-0002 upgraded from 3.1.8 to 3.1.9
```