### PR TITLE
Add caveat regarding v2 API data.

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ example-etcd-cluster-0003       1/1       Running   0          1m
 
 ## Disaster recovery
 
+> 🚨 Backup is currently only supported with etcd v3 API data. Any data stored using the etcd v2 API will **not** be backed up.
+
 If the majority of etcd members crash, but at least one backup exists for the cluster, the etcd operator can restore the entire cluster from the backup.
 
 By default, the etcd operator creates a storage class on initialization:


### PR DESCRIPTION
We're experimenting with the etcd operator on staging. We're only using it with reproducible data, but we wanted to test the backups all the same, and discovered that v2 data isn't backed up.

This is fine, since most people use the v3 API now anyway.

However, as a cluster operator I would like to disable v2, so consider this PR my +1 to #1315