### PR TITLE
cluster: fix ignore cluster update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fix the problem that operator might keep failing on version conflict updating CR status.
+
 ### Deprecated
 
 ### Security

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -1,0 +1,58 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"testing"
+
+	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// When EtcdCluster update event happens, local object ref should be updated.
+func TestUpdateEventUpdateLocalClusterObj(t *testing.T) {
+	oldVersion := "123"
+	newVersion := "321"
+
+	oldObj := &api.EtcdCluster{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: api.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			ResourceVersion: oldVersion,
+			Name:            "test",
+			Namespace:       metav1.NamespaceDefault,
+		},
+	}
+	newObj := oldObj.DeepCopy()
+	newObj.ResourceVersion = newVersion
+
+	c := &Cluster{
+		cluster: oldObj,
+	}
+	e := &clusterEvent{
+		typ:     eventModifyCluster,
+		cluster: newObj,
+	}
+
+	err := c.handleUpdateEvent(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.cluster.ResourceVersion != newVersion {
+		t.Errorf("expect version=%s, get=%s", newVersion, c.cluster.ResourceVersion)
+	}
+}


### PR DESCRIPTION
fix https://github.com/coreos/etcd-operator/issues/1329

In some case we might ignore cluster update for some immutable fields,
e.g. PodPolicy update. But local cluster object isn't updated and
it might keep failing on version conflict on status report.