### PR TITLE
*: expose setupAWSConfig and construct BackupManager with NewBackupManager

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -67,6 +67,17 @@ type BackupController struct {
 	recentBackupsStatus []backupapi.BackupStatus
 }
 
+// NewBackupManager creates a BackupManager.
+func NewBackupManager(kclient kubernetes.Interface, clusterName string, namespace string, etcdTLSConfig *tls.Config, be backend.Backend) *BackupManager {
+	return &BackupManager{
+		kclient:       kclient,
+		clusterName:   clusterName,
+		namespace:     namespace,
+		etcdTLSConfig: etcdTLSConfig,
+		be:            be,
+	}
+}
+
 // NewBackupController creates a BackupController.
 func NewBackupController(kclient kubernetes.Interface, clusterName, ns string, sp api.ClusterSpec, listenAddr string) (*BackupController, error) {
 	bdir := path.Join(constants.BackupMountDir, PVBackupV1, clusterName)

--- a/pkg/cluster/backupstorage/s3.go
+++ b/pkg/cluster/backupstorage/s3.go
@@ -37,7 +37,7 @@ func NewS3Storage(kubecli kubernetes.Interface, clusterName, ns string, p api.Ba
 		if err := os.MkdirAll(dir, 0700); err != nil {
 			return nil, err
 		}
-		options, err := setupAWSConfig(kubecli, ns, p.S3.AWSSecret, dir)
+		options, err := SetupAWSConfig(kubecli, ns, p.S3.AWSSecret, dir)
 		if err != nil {
 			return nil, err
 		}
@@ -87,7 +87,8 @@ func (s *s3) Delete() error {
 	return nil
 }
 
-func setupAWSConfig(kubecli kubernetes.Interface, ns, secret, dir string) (*session.Options, error) {
+// SetupAWSConfig setup local AWS config/credential files from Kubernetes aws secret.
+func SetupAWSConfig(kubecli kubernetes.Interface, ns, secret, dir string) (*session.Options, error) {
 	options := &session.Options{}
 	options.SharedConfigState = session.SharedConfigEnable
 


### PR DESCRIPTION
This pr exposes SetupAWSConfig in backupstorage/s3.go so that etcd backup operator can use it to set up aws credentials.

In addition, it creates NewBackupManager to construct BackupManager so that BackupManager's private fields don't have to be exposed.