### PR TITLE
*: create services even when cluster is running

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -177,7 +177,14 @@ func (c *Cluster) setup() error {
 	}
 
 	if shouldCreateCluster {
-		return c.create()
+		err := c.create()
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := c.setupServices(); err != nil {
+		return fmt.Errorf("cluster create: fail to create client service LB: %v", err)
 	}
 	return nil
 }
@@ -204,10 +211,6 @@ func (c *Cluster) create() error {
 		if err := c.prepareSeedMember(); err != nil {
 			return err
 		}
-	}
-
-	if err := c.setupServices(); err != nil {
-		return fmt.Errorf("cluster create: fail to create client service LB: %v", err)
 	}
 	return nil
 }

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -145,7 +145,10 @@ func createService(kubecli kubernetes.Interface, svcName, clusterName, ns, clust
 	svc := newEtcdServiceManifest(svcName, clusterName, clusterIP, ports)
 	addOwnerRefToObject(svc.GetObjectMeta(), owner)
 	_, err := kubecli.CoreV1().Services(ns).Create(svc)
-	return err
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
 }
 
 // CreateAndWaitPod is a workaround for self hosted and util for testing.


### PR DESCRIPTION
If we restore cluster seed member and render cluster in Running phase,
the services would need be setup by etcd operator.
We also need to make create services sync-style -- if it already exists,
we can continue.