### PR TITLE
pkg/controller: rename restorecontroller to restore-operator

### DIFF
--- a/cmd/restore-operator/main.go
+++ b/cmd/restore-operator/main.go
@@ -20,7 +20,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/coreos/etcd-operator/pkg/controller/restorecontroller"
+	controller "github.com/coreos/etcd-operator/pkg/controller/restore-operator"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	version "github.com/coreos/etcd-operator/version/restore-operator"
 
@@ -90,7 +90,7 @@ func createRecorder(kubecli kubernetes.Interface, name, namespace string) record
 }
 
 func run(stop <-chan struct{}) {
-	c := restorecontroller.New()
+	c := controller.New()
 	err := c.Start(context.TODO())
 	if err != nil {
 		logrus.Fatalf("etcd restore operator stopped with error: %v", err)

--- a/pkg/controller/restore-operator/controller.go
+++ b/pkg/controller/restore-operator/controller.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package restorecontroller
+package controller
 
 import (
 	"context"

--- a/pkg/controller/restore-operator/operator.go
+++ b/pkg/controller/restore-operator/operator.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package restorecontroller
+package controller
 
 import (
 	"context"

--- a/pkg/controller/restore-operator/sync.go
+++ b/pkg/controller/restore-operator/sync.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package restorecontroller
+package controller
 
 import (
 	"fmt"


### PR DESCRIPTION
this pr is meant to keep naming consistent on using keyword restore operator in pkg/controller.
