### PR TITLE
*: expose startHTTP

### DIFF
--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -74,5 +74,6 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("failed to create backup sidecar: %v", err)
 	}
+	bk.StartHTTP()
 	bk.Run()
 }

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -127,8 +127,6 @@ func NewBackupController(kclient kubernetes.Interface, clusterName, ns string, s
 // Run starts BackupController controller where it
 // controlls backups based on backup policy and HTTP backup requests.
 func (bc *BackupController) Run() {
-	go bc.startHTTP()
-
 	lastSnapRev := bc.backupManager.getLatestBackupRev()
 	interval := constants.DefaultSnapshotInterval
 	if bc.policy.BackupIntervalInSecond != 0 {

--- a/pkg/backup/http.go
+++ b/pkg/backup/http.go
@@ -31,7 +31,8 @@ const (
 	HTTPHeaderRevision    = "X-Revision"
 )
 
-func (bc *BackupController) startHTTP() {
+// StartHTTP starts to listen for incoming backup http requests.
+func (bc *BackupController) StartHTTP() {
 	http.HandleFunc(backupapi.APIV1+"/backup", bc.backupServer.ServeBackup)
 	http.HandleFunc(backupapi.APIV1+"/backupnow", bc.serveBackupNow)
 	http.HandleFunc(backupapi.APIV1+"/status", bc.serveStatus)


### PR DESCRIPTION
Separate controller.Run() from startHTTP() allows backup to have a choice
on what to run and not to run.

This is important because backup will be adding a flag to enable only
serve backup http requests.