### PR TITLE
backup: add feature-gate to serve backup only

### DIFF
--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -127,8 +127,6 @@ func NewBackupController(kclient kubernetes.Interface, clusterName, ns string, s
 // Run starts BackupController controller where it
 // controlls backups based on backup policy and HTTP backup requests.
 func (bc *BackupController) Run() {
-	go bc.startHTTP()
-
 	lastSnapRev := bc.backupManager.getLatestBackupRev()
 	interval := constants.DefaultSnapshotInterval
 	if bc.policy.BackupIntervalInSecond != 0 {

--- a/pkg/backup/http.go
+++ b/pkg/backup/http.go
@@ -31,7 +31,7 @@ const (
 	HTTPHeaderRevision    = "X-Revision"
 )
 
-func (bc *BackupController) startHTTP() {
+func (bc *BackupController) StartHTTP() {
 	http.HandleFunc(backupapi.APIV1+"/backup", bc.backupServer.ServeBackup)
 	http.HandleFunc(backupapi.APIV1+"/backupnow", bc.serveBackupNow)
 	http.HandleFunc(backupapi.APIV1+"/status", bc.serveStatus)


### PR DESCRIPTION
We want to reuse the backup binary to do:
- backend credentials setup
- TLS setup (potentially)
- HTTP

This is the first step to provide a feature gate and
simply disable periodic backup logic.