### PR TITLE
*: ignore event with invalid cluster spec at the controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 is specified, backup binary changes to serve http backup requests only mode.
 
 ### Changed
+- An EtcdCluster CR with an invalid spec will not be marked as failed. Any changes that result in an invalid spec will be ignored and logged by the operator.
 
 ### Removed
 

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -134,11 +134,7 @@ func New(config Config, cl *api.EtcdCluster) *Cluster {
 }
 
 func (c *Cluster) setup() error {
-	err := c.cluster.Spec.Validate()
-	if err != nil {
-		return fmt.Errorf("invalid cluster spec: %v", err)
-	}
-
+	var err error
 	var shouldCreateCluster bool
 	switch c.status.Phase {
 	case api.ClusterPhaseNone:

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -92,8 +92,11 @@ func (c *Controller) handleClusterEvent(event *Event) error {
 		return fmt.Errorf("ignore failed cluster (%s). Please delete its CR", clus.Name)
 	}
 
-	// TODO: add validation to spec update.
 	clus.Spec.Cleanup()
+
+	if err := clus.Spec.Validate(); err != nil {
+		return fmt.Errorf("invalid cluster spec. please fix the following problem with the cluster spec: %v", err)
+	}
 
 	switch event.Type {
 	case kwatch.Added:

--- a/pkg/controller/informer.go
+++ b/pkg/controller/informer.go
@@ -123,7 +123,10 @@ func (c *Controller) syncEtcdClus(clus *api.EtcdCluster) {
 		Type:   kwatch.Added,
 		Object: clus,
 	}
-	if _, ok := c.clusters[clus.Name]; ok { // re-watch or restart could give ADD event
+	// re-watch or restart could give ADD event.
+	// If for an ADD event the cluster spec is invalid then it is not added to the local cache
+	// so modifying that cluster will result in another ADD event
+	if _, ok := c.clusters[clus.Name]; ok {
 		ev.Type = kwatch.Modified
 	}
 


### PR DESCRIPTION
~The backup policy should be validated not only when the cluster spec is created but also when the cluster spec's backup policy is updated.~

The cluster spec is now validated in the controller. Any event with an invalid spec is ignored and logged.