### PR TITLE
*: add flags to not create global resources CRD and StorageClass

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -59,15 +59,22 @@ var (
 	chaosLevel int
 
 	printVersion bool
+
+	createCRD          bool
+	createStorageClass bool
 )
 
 func init() {
 	flag.StringVar(&debug.DebugFilePath, "debug-logfile-path", "", "only for a self hosted cluster, the path where the debug logfile will be written, recommended to be under: /var/tmp/etcd-operator/debug/ to avoid any issue with lack of write permissions")
-	flag.StringVar(&pvProvisioner, "pv-provisioner", constants.PVProvisionerGCEPD, "persistent volume provisioner type")
+	flag.StringVar(&pvProvisioner, "pv-provisioner", constants.PVProvisionerGCEPD, "persistent volume provisioner type. DEPRECATION WARNING: the pv-provisioner flag will be removed in next release.")
 	flag.StringVar(&listenAddr, "listen-addr", "0.0.0.0:8080", "The address on which the HTTP server will listen to")
 	// chaos level will be removed once we have a formal tool to inject failures.
 	flag.IntVar(&chaosLevel, "chaos-level", -1, "DO NOT USE IN PRODUCTION - level of chaos injected into the etcd clusters created by the operator.")
 	flag.BoolVar(&printVersion, "version", false, "Show version and quit")
+	// create-crd will be removed once the default behavior is not to create a CRD
+	flag.BoolVar(&createCRD, "create-crd", false, "The operator will not create the EtcdCluster CRD when this flag is set to false.")
+	// create-storage-class will be removed once the default behavior is not to create storage class
+	flag.BoolVar(&createStorageClass, "create-storage-class", false, "The operator will not create any StorageClass when this flag is set to false. This flag needs to be true before the --pv-provisioner flag can be used to set a provisioner for a new StorageClass.")
 	flag.DurationVar(&gcInterval, "gc-interval", 10*time.Minute, "GC interval")
 	flag.Parse()
 }
@@ -81,6 +88,8 @@ func main() {
 	if len(name) == 0 {
 		logrus.Fatalf("must set env (%s)", constants.EnvOperatorPodName)
 	}
+
+	logrus.Infof("DEPRECATION WARNING: the pv-provisioner flag will be removed in next release.")
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c)
@@ -165,12 +174,14 @@ func newControllerConfig() controller.Config {
 	}
 
 	cfg := controller.Config{
-		Namespace:      namespace,
-		ServiceAccount: serviceAccount,
-		PVProvisioner:  pvProvisioner,
-		KubeCli:        kubecli,
-		KubeExtCli:     k8sutil.MustNewKubeExtClient(),
-		EtcdCRCli:      client.MustNewInCluster(),
+		Namespace:          namespace,
+		ServiceAccount:     serviceAccount,
+		PVProvisioner:      pvProvisioner,
+		KubeCli:            kubecli,
+		KubeExtCli:         k8sutil.MustNewKubeExtClient(),
+		EtcdCRCli:          client.MustNewInCluster(),
+		CreateCRD:          createCRD,
+		CreateStorageClass: createStorageClass,
 	}
 
 	return cfg

--- a/pkg/apis/etcd/v1beta2/backup.go
+++ b/pkg/apis/etcd/v1beta2/backup.go
@@ -67,6 +67,7 @@ func (bp *BackupPolicy) Validate() error {
 		if pv := bp.StorageSource.PV; pv == nil || pv.VolumeSizeInMB <= 0 {
 			return errPVZeroSize
 		}
+		// TODO: the backup policy should be invalid if pv.StorageClass == "" and --create-storage-class == false
 	}
 	return nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -53,12 +53,14 @@ type Controller struct {
 }
 
 type Config struct {
-	Namespace      string
-	ServiceAccount string
-	PVProvisioner  string
-	KubeCli        kubernetes.Interface
-	KubeExtCli     apiextensionsclient.Interface
-	EtcdCRCli      versioned.Interface
+	Namespace          string
+	ServiceAccount     string
+	PVProvisioner      string
+	KubeCli            kubernetes.Interface
+	KubeExtCli         apiextensionsclient.Interface
+	EtcdCRCli          versioned.Interface
+	CreateCRD          bool
+	CreateStorageClass bool
 }
 
 func (c *Config) Validate() error {
@@ -140,9 +142,11 @@ func (c *Controller) makeClusterConfig() cluster.Config {
 }
 
 func (c *Controller) initCRD() error {
-	err := k8sutil.CreateCRD(c.KubeExtCli)
-	if err != nil {
-		return err
+	if c.Config.CreateCRD {
+		err := k8sutil.CreateCRD(c.KubeExtCli)
+		if err != nil {
+			return err
+		}
 	}
 	return k8sutil.WaitCRDReady(c.KubeExtCli)
 }

--- a/pkg/controller/informer.go
+++ b/pkg/controller/informer.go
@@ -76,7 +76,7 @@ func (c *Controller) initResource() error {
 	if err != nil && !k8sutil.IsKubernetesResourceAlreadyExistError(err) {
 		return fmt.Errorf("fail to create CRD: %v", err)
 	}
-	if c.Config.PVProvisioner != constants.PVProvisionerNone {
+	if c.Config.CreateStorageClass && (c.Config.PVProvisioner != constants.PVProvisionerNone) {
 		err = k8sutil.CreateStorageClass(c.KubeCli, c.PVProvisioner)
 		if err != nil && !k8sutil.IsKubernetesResourceAlreadyExistError(err) {
 			return fmt.Errorf("fail to create storage class: %v", err)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -103,7 +103,7 @@ func (f *Framework) setup() error {
 
 func (f *Framework) SetupEtcdOperator() error {
 	// TODO: unify this and the yaml file in example/
-	cmd := []string{"/usr/local/bin/etcd-operator"}
+	cmd := []string{"/usr/local/bin/etcd-operator", "--create-crd=true", "--create-storage-class=true"}
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "etcd-operator",

--- a/test/e2e/upgradetest/framework/framework.go
+++ b/test/e2e/upgradetest/framework/framework.go
@@ -73,7 +73,7 @@ func New(fc Config) (*Framework, error) {
 }
 
 func (f *Framework) CreateOperator(name string) error {
-	cmd := []string{"/usr/local/bin/etcd-operator"}
+	cmd := []string{"/usr/local/bin/etcd-operator", "--create-crd=true", "--create-storage-class=true"}
 	image := f.OldImage
 	d := &appsv1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Addresses #1527 

The default behavior of the etcd-operator is now to not create global resources (CRD, StorageClass). This is governed by the flag `no-global-cluster-resource` which is true by default.

In this default mode the `--pv-provisioner` flag will have no effect. Any backup policy of type `PV` without a `StorageClass` field will be invalid because the operator will not create any StorageClass resource.

To revert back to the old behavior of the operator the flag `no-global-cluster-resource` needs to be set to false.

