### PR TITLE
controller: fix CreateCRD condition check

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -142,11 +142,9 @@ func (c *Controller) makeClusterConfig() cluster.Config {
 }
 
 func (c *Controller) initCRD() error {
-	if c.Config.CreateCRD {
-		err := k8sutil.CreateCRD(c.KubeExtCli)
-		if err != nil {
-			return err
-		}
+	err := k8sutil.CreateCRD(c.KubeExtCli)
+	if err != nil {
+		return fmt.Errorf("failed to create CRD: %v", err)
 	}
 	return k8sutil.WaitCRDReady(c.KubeExtCli)
 }

--- a/pkg/controller/informer.go
+++ b/pkg/controller/informer.go
@@ -72,12 +72,14 @@ func (c *Controller) run() {
 }
 
 func (c *Controller) initResource() error {
-	err := c.initCRD()
-	if err != nil && !k8sutil.IsKubernetesResourceAlreadyExistError(err) {
-		return fmt.Errorf("fail to create CRD: %v", err)
+	if c.Config.CreateCRD {
+		err := c.initCRD()
+		if err != nil {
+			return fmt.Errorf("fail to init CRD: %v", err)
+		}
 	}
 	if c.Config.CreateStorageClass && (c.Config.PVProvisioner != constants.PVProvisionerNone) {
-		err = k8sutil.CreateStorageClass(c.KubeCli, c.PVProvisioner)
+		err := k8sutil.CreateStorageClass(c.KubeCli, c.PVProvisioner)
 		if err != nil && !k8sutil.IsKubernetesResourceAlreadyExistError(err) {
 			return fmt.Errorf("fail to create storage class: %v", err)
 		}

--- a/pkg/util/k8sutil/crd.go
+++ b/pkg/util/k8sutil/crd.go
@@ -68,7 +68,10 @@ func CreateCRD(clientset apiextensionsclient.Interface) error {
 		},
 	}
 	_, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
-	return err
+	if err != nil && !IsKubernetesResourceAlreadyExistError(err) {
+		return err
+	}
+	return nil
 }
 
 func WaitCRDReady(clientset apiextensionsclient.Interface) error {


### PR DESCRIPTION
If the `create-crd` flag is false then the operator should also not be **waiting** for the crd to become ready since it does not have the rbac permissions to get a crd.

So if `create-crd` is false then this will skip the `initCRD()` altogether.