### PR TITLE
e2e: tests will use the storage class created by the framework

### DIFF
--- a/test/e2e/cluster_status_test.go
+++ b/test/e2e/cluster_status_test.go
@@ -72,7 +72,7 @@ func TestBackupStatus(t *testing.T) {
 	}
 	f := framework.Global
 
-	bp := e2eutil.NewPVBackupPolicy(true, "")
+	bp := e2eutil.NewPVBackupPolicy(true, f.StorageClassName)
 	testEtcd, err := e2eutil.CreateCluster(t, f.CRClient, f.Namespace, e2eutil.ClusterWithBackup(e2eutil.NewCluster("test-etcd-", 1), bp))
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/recovery_test.go
+++ b/test/e2e/recovery_test.go
@@ -64,17 +64,7 @@ func TestDisasterRecoveryMaj(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
-	testDisasterRecovery(t, 2, "")
-}
-
-// TestDisasterRecoveryMajWithCustomStorageClass ensures that the operator
-// will make a backup using a custom storage class with the state from the
-// one remaining pod.
-func TestDisasterRecoveryMajWithCustomStorageClass(t *testing.T) {
-	if os.Getenv(envParallelTest) == envParallelTestTrue {
-		t.Parallel()
-	}
-	testDisasterRecovery(t, 2, "standard")
+	testDisasterRecovery(t, 2, framework.Global.StorageClassName)
 }
 
 // testDisasterRecoveryAll tests disaster recovery that
@@ -83,7 +73,7 @@ func TestDisasterRecoveryAll(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
-	testDisasterRecovery(t, 3, "")
+	testDisasterRecovery(t, 3, framework.Global.StorageClassName)
 }
 
 func testDisasterRecovery(t *testing.T, numToKill int, storageClass string) {

--- a/test/e2e/restore_test.go
+++ b/test/e2e/restore_test.go
@@ -36,7 +36,7 @@ func TestClusterRestoreDifferentName(t *testing.T) {
 }
 
 func testClusterRestore(t *testing.T, needDataClone bool) {
-	testClusterRestoreWithBackupPolicy(t, needDataClone, e2eutil.NewPVBackupPolicy(false, ""))
+	testClusterRestoreWithBackupPolicy(t, needDataClone, e2eutil.NewPVBackupPolicy(false, framework.Global.StorageClassName))
 }
 
 func testClusterRestoreWithBackupPolicy(t *testing.T, needDataClone bool, backupPolicy *api.BackupPolicy) {

--- a/test/e2e/upgradetest/main_test.go
+++ b/test/e2e/upgradetest/main_test.go
@@ -17,8 +17,10 @@ package upgradetest
 import (
 	"flag"
 	"os"
+	"path"
 	"testing"
 
+	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/test/e2e/upgradetest/framework"
 
 	"github.com/sirupsen/logrus"
@@ -31,13 +33,16 @@ func TestMain(m *testing.M) {
 	kubeNS := flag.String("kube-ns", "default", "upgrade test namespace")
 	oldImage := flag.String("old-image", "", "")
 	newImage := flag.String("new-image", "", "")
+	pvProvisioner := flag.String("pv-provisioner", constants.PVProvisionerGCEPD, "persistent volume provisioner type: the default is kubernetes.io/gce-pd. This should be set according to where the tests are running")
 	flag.Parse()
 
 	cfg := framework.Config{
-		KubeConfig: *kubeconfig,
-		KubeNS:     *kubeNS,
-		OldImage:   *oldImage,
-		NewImage:   *newImage,
+		KubeConfig:       *kubeconfig,
+		KubeNS:           *kubeNS,
+		OldImage:         *oldImage,
+		NewImage:         *newImage,
+		StorageClassName: "e2e-" + path.Base(*pvProvisioner),
+		Provisioner:      *pvProvisioner,
 	}
 	var err error
 	testF, err = framework.New(cfg)

--- a/test/e2e/upgradetest/upgrade_test.go
+++ b/test/e2e/upgradetest/upgrade_test.go
@@ -139,7 +139,7 @@ func TestHealOneMemberForOldCluster(t *testing.T) {
 // TestRestoreFromBackup tests that new operator could recover a new cluster from a backup of the old cluster.
 func TestRestoreFromBackup(t *testing.T) {
 	t.Run("Restore from PV backup of old cluster", func(t *testing.T) {
-		testRestoreWithBackupPolicy(t, e2eutil.NewPVBackupPolicy(false, ""))
+		testRestoreWithBackupPolicy(t, e2eutil.NewPVBackupPolicy(false, testF.StorageClassName))
 	})
 	t.Run("Restore from S3 backup of old cluster", func(t *testing.T) {
 		t.Run("per cluster s3 policy", func(t *testing.T) {
@@ -253,7 +253,7 @@ func testRestoreWithBackupPolicy(t *testing.T, bp *api.BackupPolicy) {
 // TestBackupForOldCluster tests that new backup sidecar could make backup from old cluster.
 func TestBackupForOldCluster(t *testing.T) {
 	t.Run("PV backup for old cluster", func(t *testing.T) {
-		testBackupForOldClusterWithBackupPolicy(t, e2eutil.NewPVBackupPolicy(true, ""))
+		testBackupForOldClusterWithBackupPolicy(t, e2eutil.NewPVBackupPolicy(true, testF.StorageClassName))
 	})
 	t.Run("S3 backup for old cluster", func(t *testing.T) {
 		t.Run("per cluster s3 policy", func(t *testing.T) {
@@ -333,7 +333,7 @@ func testBackupForOldClusterWithBackupPolicy(t *testing.T, bp *api.BackupPolicy)
 // TestDisasterRecovery tests if the new operator could do disaster recovery from backup of the old cluster.
 func TestDisasterRecovery(t *testing.T) {
 	t.Run("Recover from PV backup", func(t *testing.T) {
-		testDisasterRecoveryWithBackupPolicy(t, e2eutil.NewPVBackupPolicy(true, ""))
+		testDisasterRecoveryWithBackupPolicy(t, e2eutil.NewPVBackupPolicy(true, testF.StorageClassName))
 	})
 	t.Run("Recover from S3 backup", func(t *testing.T) {
 		t.Run("per cluster s3 policy", func(t *testing.T) {


### PR DESCRIPTION
Addresses #1527 
Every test that was using the PVBackupPolicy will now use the storage class created by its framework at the start.
The operator being tested on will not create the storage class itself.

The storage class created by the framework will not be cleaned up at the end since it is a cluster resource and it could be in use by other tests on the cluster.