### PR TITLE
*: update and unify rbac doc and rbac utils with rbac templates

### DIFF
--- a/example/rbac/cluster-role-binding-template.yaml
+++ b/example/rbac/cluster-role-binding-template.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: <ROLE_BINDING_NAME>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: <ROLE_NAME>
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: <NAMESPACE>

--- a/example/rbac/cluster-role-template.yaml
+++ b/example/rbac/cluster-role-template.yaml
@@ -1,0 +1,40 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: <ROLE_NAME>
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+# The following permissions can be removed if not using S3 backup and TLS
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get

--- a/example/rbac/role-binding-template.yaml
+++ b/example/rbac/role-binding-template.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: <ROLE_BINDING_NAME>
+  namespace: <NAMESPACE>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: <ROLE_NAME>
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: <NAMESPACE>

--- a/example/rbac/role-template.yaml
+++ b/example/rbac/role-template.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: <ROLE_NAME>
+  namespace: <NAMESPACE>
+rules:
+- apiGroups:
+  - etcd.database.coreos.com
+  resources:
+  - etcdclusters
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - "*"
+# The following permissions can be removed if not using S3 backup and TLS
+- apiGroups:
+  - ""
+  resources: 
+  - secrets
+  verbs:
+  - get

--- a/hack/ci/rbac_utils.sh
+++ b/hack/ci/rbac_utils.sh
@@ -1,76 +1,22 @@
 #!/usr/bin/env bash
 
 : ${TEST_NAMESPACE:?"Need to set TEST_NAMESPACE"}
+ROLE_NAME=etcd-operator-${TEST_NAMESPACE}
+ROLE_BINDING_NAME=etcd-operator-${TEST_NAMESPACE}
 
 function rbac_cleanup {
-    kubectl delete clusterrolebinding "etcd-operator-${TEST_NAMESPACE}"
-    kubectl delete clusterrole "etcd-operator-${TEST_NAMESPACE}"
+    kubectl delete clusterrolebinding ${ROLE_BINDING_NAME}
+    kubectl delete clusterrole ${ROLE_NAME}
 }
 
 function rbac_setup() {
     # Create ClusterRole
-    cat <<EOF | kubectl create -f -
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
-metadata:
-  name: "etcd-operator-${TEST_NAMESPACE}"
-rules:
-- apiGroups:
-  - etcd.database.coreos.com
-  resources:
-  - etcdclusters
-  verbs:
-  - "*"
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - "*"
-- apiGroups:
-  - storage.k8s.io
-  resources:
-  - storageclasses
-  verbs:
-  - "*"
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - services
-  - endpoints
-  - persistentvolumeclaims
-  - events
-  verbs:
-  - "*"
-- apiGroups:
-  - apps
-  resources:
-  - deployments
-  verbs:
-  - "*"
-- apiGroups:
-  - ""
-  resources:
-  - secrets
-  - configmaps
-  verbs:
-  - get
-EOF
+    sed -e "s/<ROLE_NAME>/${ROLE_NAME}/g" example/rbac/cluster-role-template.yaml | kubectl create -f -
 
-    # Create ClusterRoleBinding in namespace
-    cat <<EOF | kubectl create -f -
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: "etcd-operator-${TEST_NAMESPACE}"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: "etcd-operator-${TEST_NAMESPACE}"
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: $TEST_NAMESPACE
-EOF
+    # Create ClusterRoleBinding
+    sed -e "s/<ROLE_NAME>/${ROLE_NAME}/g" \
+      -e "s/<ROLE_BINDING_NAME>/${ROLE_BINDING_NAME}/g" \
+      -e "s/<NAMESPACE>/${TEST_NAMESPACE}/g" \
+      example/rbac/cluster-role-binding-template.yaml \
+      | kubectl create -f -
 }


### PR DESCRIPTION
Addresses #1527 

This PR updates the RBAC setup guide to explain how to setup RBAC with either a ClusterRole or Role, depending on the `create-crd` flag.

Added RBAC templates at `example/rbac` so that both the RBAC doc and `hack/ci/rbac_utils.sh` use the same permissions.

The rbac_utils still sets up RBAC with a ClusterRole since our e2e tests test the etcd-operator for the default mode of `--create-crd=true`.