### PR TITLE
upgrade_guide.md: add section for 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+The operator will no longer create a storage class specified by `--pv-provisioner` by default. If applicable then see the [upgrade guide](./doc/user/upgrade/upgrade_guide.md) on how to upgrade from `v0.6.0` to `v0.6.1` .
+
 ### Added
 
 - backup binary supports serving backup defined by backupSpec. In addition, when backupSpec

--- a/doc/user/upgrade/upgrade_guide.md
+++ b/doc/user/upgrade/upgrade_guide.md
@@ -22,6 +22,35 @@ $ kubectl edit deployment/etcd-operator
 ### Incompatible upgrade
 In the case of an incompatible upgrade, the process requires restoring a new cluster from backup. See the [incompatible upgrade guide](incompatible_upgrade.md) for more information.
 
+## v0.6.0 -> v0.6.1
+
+In `v0.6.1+` the operator will no longer create a storage class specified by `--pv-provisioner` by default. This behavior is set by the new flag `--create-storage-class` which by default is `false`.
+
+**Note:** If your cluster does not have the following backup policy then you can simply upgrade the operator to the `v0.6.1` image.
+
+Backup policy that has `StorageType=PersistentVolume` but `pv.storageClass` is unset. For example:
+```yaml
+spec:
+    backup:
+      backupIntervalInSecond: 30
+      maxBackups: 5
+      pv:
+        storageClass: ""
+        volumeSizeInMB: 512
+      storageType: PersistentVolume
+```
+
+So if your cluster has the above backup policy then do the following steps before upgrading the operator image to `v0.6.1`.
+
+
+- Confirm the name of the storage class for a given cluster:
+
+  ```sh
+  kubectl -n <namespace> get pvc -l=etcd_cluster=<cluster-name> -o yaml | grep storage-class
+  ```
+
+- Edit your etcd cluster spec by changing the `spec.backup.pv.storageClass` field to the name of the existing storage class from the previous step.
+- Wait for the the backup sidecar to be updated.
 
 ## v0.5.x -> v0.6.0
 


### PR DESCRIPTION
[skip ci]

Added the section for the upgrade guide to `v0.6.1`.
The section explains how to correctly set the storage class name for clusters using a backup policy with PV storage with no storage class name.

Since the storage class is only needed when creating a new cluster this is not a breaking change for users with existing clusters and is required more for the spec to be consistent with the new operator behavior.

So the CHANGELOG does not say **Breaking Change**.


