### PR TITLE
doc: Add script to streamline RBAC setup

### DIFF
--- a/doc/user/op_guide.md
+++ b/doc/user/op_guide.md
@@ -2,9 +2,13 @@
 
 ## Install etcd operator
 
-Before you create the etcd-operator make sure you setup the necessary [rbac rules](./rbac.md) if your Kubernetes version is 1.7 or higher.
+Set up basic [RBAC rules](./rbac.md) for etcd operator:
 
-Create deployment:
+```bash
+$ example/rbac/create_role.sh
+```
+
+Create a deployment for etcd operator:
 
 ```bash
 $ kubectl create -f example/deployment.yaml

--- a/doc/user/rbac.md
+++ b/doc/user/rbac.md
@@ -2,45 +2,6 @@
 
 If RBAC is in place, users need to setup RBAC rules for etcd operator. This doc serves a tutorial for it.
 
-## Quick setup
-
-If you just want to play with etcd operator, there is a quick setup.
-
-It assumes that your cluster has an admin role. For example, on [Tectonic](https://coreos.com/tectonic/),
-there is a `admin` ClusterRole. We are using that here.
-
-Modify or export env `$TEST_NAMESPACE` to a new namespace, then create it:
-
-```bash
-$ kubectl create ns $TEST_NAMESPACE
-```
-
-Then create cluster role binding:
-
-```bash
-$ cat <<EOF | kubectl create -f -
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
-  name: example-etcd-operator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: admin
-subjects:
-- kind: ServiceAccount
-  name: default
-  namespace: $TEST_NAMESPACE
-EOF
-```
-
-Now you can start playing. One you are done, clean them up:
-
-```bash
-$ kubectl delete clusterrolebinding example-etcd-operator
-$ kubectl delete ns $TEST_NAMESPACE
-```
-
 ## Production setup
 
 For production, we recommend users to limit access to only the resources operator needs, and create a specific role, for the operator.

--- a/example/rbac/create_role.sh
+++ b/example/rbac/create_role.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ETCD_OPERATOR_ROOT=$(dirname "${BASH_SOURCE}")/../..
+
+print_usage() {
+  echo "$(basename "$0") - Create Kubernetes RBAC role and role bindings for etcd-operator
+Usage: $(basename "$0") [options...]
+Options:
+  --role-name=STRING         Name of Role or ClusterRole to create
+                               (default=\"etcd-operator\", environment variable: ROLE_NAME)
+  --role-binding-name=STRING Name of RoleBinding or ClusterRoleBinding to create
+                               (default=\"etcd-operator\", environment variable: ROLE_BINDING_NAME)
+  --namespace=STRING         namespace to create role and role binding in. Must already exist.
+                               (default=\"default\", environment vairable: NAMESPACE)
+" >&2
+}
+
+ROLE_NAME="${ROLE_NAME:-etcd-operator}"
+ROLE_BINDING_NAME="${ROLE_BINDING_NAME:-etcd-operator}"
+NAMESPACE="${NAMESPACE:-default}"
+
+for i in "$@"
+do
+case $i in
+    --role-name=*)
+    ROLE_NAME="${i#*=}"
+    ;;
+    --role-binding-name=*)
+    ROLE_BINDING_NAME="${i#*=}"
+    ;;
+    --namespace=*)
+    NAMESPACE="${i#*=}"
+    ;;
+    -h|--help)
+      print_usage
+      exit 0
+    ;;
+    *)
+      print_usage
+      exit 1
+    ;;
+esac
+done
+
+echo "Creating role with ROLE_NAME=${ROLE_NAME}, NAMESPACE=${NAMESPACE}"
+sed -e "s/<ROLE_NAME>/${ROLE_NAME}/g" \
+  -e "s/<NAMESPACE>/${NAMESPACE}/g" \
+  "${ETCD_OPERATOR_ROOT}/example/rbac/cluster-role-template.yaml" | \
+  kubectl create -f -
+
+echo "Creating role binding with ROLE_NAME=${ROLE_NAME}, ROLE_BINDING_NAME=${ROLE_BINDING_NAME}, NAMESPACE=${NAMESPACE}"
+sed -e "s/<ROLE_NAME>/${ROLE_NAME}/g" \
+  -e "s/<ROLE_BINDING_NAME>/${ROLE_BINDING_NAME}/g" \
+  -e "s/<NAMESPACE>/${NAMESPACE}/g" \
+  "${ETCD_OPERATOR_ROOT}/example/rbac/cluster-role-binding-template.yaml" | \
+  kubectl create -f -


### PR DESCRIPTION
Streamline the getting started workflow for developers using k8s 1.7+ with a single command to setup RBAC and clearly document it in the getting started docs.