### PR TITLE
k8sutil: ignore alreadyExist on createService

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -146,7 +146,10 @@ func createService(kubecli kubernetes.Interface, svcName, clusterName, ns, clust
 	svc := newEtcdServiceManifest(svcName, clusterName, clusterIP, ports)
 	addOwnerRefToObject(svc.GetObjectMeta(), owner)
 	_, err := kubecli.CoreV1().Services(ns).Create(svc)
-	return err
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
 }
 
 // CreateAndWaitPod is a workaround for self hosted and util for testing.


### PR DESCRIPTION
All k8sutil methods follow re-entry-ness . It's part of the convention.

Code cleanup.