### PR TITLE
*: restore operator prepares seed and etcd operator takes over

### DIFF
--- a/doc/design/restore_operator.md
+++ b/doc/design/restore_operator.md
@@ -39,7 +39,7 @@ Restore Spec defined as:
 // RestoreSpec defines how to restore an etcd cluster from exsiting backup.
 type RestoreSpec struct {
 	// EtcdCluster defines the same spec that etcd operator will run later.
-	// Using this spec, restore operator will create the seed etcd member that
+	// Using this spec, restore operator will prepare the seed that
 	// etcd operator will pick up later.
 	EtcdCluster ClusterSpec
 	// EtcdBackup defines the same spec that backup operator uses to save the backup.
@@ -57,38 +57,3 @@ type RestoreStatus struct {
 	Reason string
 }
 ```
-
-## OwnerRef Management of Seed Member Pod
-
-Restore operator will set owner reference of seed member Pod to related Restore CR
-
-```
-ownerReferences:
-- apiVersion: etcdrestores.etcd.database.coreos.com/v1beta2
-  kind: EtcdRestore
-	controller: false
-	...
-```
-
-But it is not the managing controller because we want to make etcd operator the one.
-Note that `controller` field is more a sign than real effect.
-
-Restore operator will add a special annotation to seed Member Pod:
-
-```
-"etcdcluster.alpha.etcd.coreos.com/seedmember": "true"
-```
-
-
-etcd operator will find `SeedMember` and append related EtcdCluster onto seed member Pod's OwnerRef.
-
-```
-ownerReferences:
-- apiVersion: etcdclusters.etcd.database.coreos.com/v1beta2
-  kind: EtcdCluster
-	controller: true
-	...
-```
-
-The seed member Pod's lifecycle will be bound to both related EtcdRestore and EtcdCluster resources.
-EtcdBackup and EtcdRestore resources are job-type and we recommend deleting them after finished.

--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -36,21 +36,10 @@ type EtcdRestore struct {
 	Status            RestoreStatus `json:"status,omitempty"`
 }
 
-func (er *EtcdRestore) AsOwner() metav1.OwnerReference {
-	trueVar := true
-	return metav1.OwnerReference{
-		APIVersion: SchemeGroupVersion.String(),
-		Kind:       EtcdRestoreResourceKind,
-		Name:       er.Name,
-		UID:        er.UID,
-		Controller: &trueVar,
-	}
-}
-
 // RestoreSpec defines how to restore an etcd cluster from existing backup.
 type RestoreSpec struct {
 	// ClusterSpec defines the same spec that etcd operator will run later.
-	// using this spec, restore operator will create the seed etcd member that
+	// using this spec, restore operator will prepare the seed that
 	// etcd operator will pick up later.
 	ClusterSpec ClusterSpec `json:"clusterSpec"`
 	// BackupSpec defines the same spec that backup operator uses to save the backup.

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -203,9 +203,6 @@ func (c *Cluster) create() error {
 		}
 	}
 
-	if err := c.setupServices(); err != nil {
-		return fmt.Errorf("cluster create: fail to create client service LB: %v", err)
-	}
 	return nil
 }
 
@@ -246,6 +243,9 @@ func (c *Cluster) send(ev *clusterEvent) {
 }
 
 func (c *Cluster) run() {
+	if err := c.setupServices(); err != nil {
+		c.logger.Errorf("fail to setup etcd services: %v", err)
+	}
 
 	defer func() {
 		c.logger.Infof("deleting the failed cluster")

--- a/pkg/controller/backup-operator/sync.go
+++ b/pkg/controller/backup-operator/sync.go
@@ -62,7 +62,7 @@ func (b *Backup) processItem(key string) error {
 
 	eb := obj.(*api.EtcdBackup)
 	// don't process the CR if it has a status since
-	// having a status means that the CR has been processed before.
+	// having a status means that the backup is either made or failed.
 	if eb.Status.Succeeded || len(eb.Status.Reason) != 0 {
 		return nil
 	}

--- a/pkg/controller/restore-operator/controller.go
+++ b/pkg/controller/restore-operator/controller.go
@@ -28,7 +28,7 @@ import (
 
 func (r *Restore) run(ctx context.Context) {
 	source := cache.NewListWatchFromClient(
-		r.restoreCRCli.EtcdV1beta2().RESTClient(),
+		r.etcdCRCli.EtcdV1beta2().RESTClient(),
 		api.EtcdRestoreResourcePlural,
 		r.namespace,
 		fields.Everything(),

--- a/pkg/controller/restore-operator/operator.go
+++ b/pkg/controller/restore-operator/operator.go
@@ -38,8 +38,8 @@ type Restore struct {
 	informer cache.Controller
 	queue    workqueue.RateLimitingInterface
 
-	kubecli      kubernetes.Interface
-	restoreCRCli versioned.Interface
+	kubecli   kubernetes.Interface
+	etcdCRCli versioned.Interface
 
 	// restoreCRs is a map of cluster name to restore cr.
 	restoreCRs sync.Map
@@ -50,11 +50,11 @@ type Restore struct {
 // New creates a restore operator.
 func New(namespace, mySvcAddr string) *Restore {
 	return &Restore{
-		logger:       logrus.WithField("pkg", "controller"),
-		namespace:    namespace,
-		mySvcAddr:    mySvcAddr,
-		kubecli:      k8sutil.MustNewKubeClient(),
-		restoreCRCli: client.MustNewInCluster(),
+		logger:    logrus.WithField("pkg", "controller"),
+		namespace: namespace,
+		mySvcAddr: mySvcAddr,
+		kubecli:   k8sutil.MustNewKubeClient(),
+		etcdCRCli: client.MustNewInCluster(),
 	}
 }
 


### PR DESCRIPTION
prepareSeed() is changed to:

- create EtcdCluster CR but spec.paused=true and status.phase="Running" .
  - Expect etcd operator to setup the services
- create seed member that would restore data from backup
  - ownerRef to above EtcdCluster CR
- update EtcdCluster CR spec.paused=false
  - etcd operator should pick it up and scale the etcd cluster