### PR TITLE
*: remove pv-provisioner and create-storage-class flags

### DIFF
--- a/doc/user/backup_config.md
+++ b/doc/user/backup_config.md
@@ -29,10 +29,6 @@ This spec field provides more granular control over how to persist etcd data to 
 
 This is essentially saving backups to an instance of GCE PD if running on GCE Kubernetes.
 
-**Note: It is recommended to use the StorageClass spec field because --pv-provisioner will be deprecated in a future release**
-
-### Using the storage class field:
-
 Create your own storage class with the provisioner for GCE PD:
 ```yaml
 apiVersion: storage.k8s.io/v1
@@ -43,18 +39,9 @@ provisioner: kubernetes.io/gce-pd
 ```
 Then specify the name of the above storage class in the cluster backup spec field `spec.backup.pv.storageClass`.
 
-### Using the pv provisioner flag:
-
-This is done by passing the flags `--create-storage-class=true` and `--pv-provisioner=kubernetes.io/gce-pd` to operator and leaving the `spec.backup.pv.storageClass` vaule unset.
-
-
 ## PV on AWS
 
 This is essentially saving backups on an instance of AWS EBS if running on AWS Kubernetes.
-
-**Note: It is recommended to use the StorageClass spec field because --pv-provisioner will be deprecated in a future release**
-
-### Using the storage class field:
 
 Create your own storage class with the provisioner for AWS EBS:
 ```yaml
@@ -65,10 +52,6 @@ metadata:
 provisioner: kubernetes.io/aws-ebs
 ```
 Then specify the name of the above storage class in the cluster backup spec field `spec.backup.pv.storageClass`.
-
-### Using the pv provisioner flag:
-
-This is done by passing the flags `--create-storage-class=true` and `--pv-provisioner=kubernetes.io/aws-ebs` to operator and leaving the `spec.backup.pv.storageClass` vaule unset.
 
 ## S3 on AWS
 

--- a/pkg/cluster/backup_manager.go
+++ b/pkg/cluster/backup_manager.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path"
 	"time"
 
 	"github.com/coreos/etcd-operator/client/experimentalclient"
@@ -29,7 +28,6 @@ import (
 	"github.com/coreos/etcd-operator/pkg/cluster/backupstorage"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 
-	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/sirupsen/logrus"
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,7 +39,6 @@ const (
 )
 
 var (
-	errNoPVForBackup       = errors.New("no backup could be created due to PVProvisioner (none) is set")
 	errNoS3ConfigForBackup = errors.New("no backup could be created due to S3 configuration not set")
 	errNoABSCredsForBackup = errors.New("no backup could be created due to ABS credentials not set")
 )
@@ -80,12 +77,6 @@ func (bm *backupManager) setupStorage() (s backupstorage.Storage, err error) {
 	switch b.StorageType {
 	case api.BackupStorageTypePersistentVolume, api.BackupStorageTypeDefault:
 		storageClass := b.PV.StorageClass
-		if len(storageClass) == 0 {
-			if c.PVProvisioner == constants.PVProvisionerNone {
-				return nil, errNoPVForBackup
-			}
-			storageClass = k8sutil.StorageClassPrefix + "-" + path.Base(c.PVProvisioner)
-		}
 		s, err = backupstorage.NewPVStorage(c.KubeCli, cl.Name, cl.Namespace, storageClass, *b)
 	case api.BackupStorageTypeS3:
 		if b.S3 == nil {

--- a/pkg/cluster/backup_manager_test.go
+++ b/pkg/cluster/backup_manager_test.go
@@ -20,28 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
-	"github.com/coreos/etcd-operator/pkg/util/constants"
 )
-
-func TestNewBackupManagerWithNonePVProvisioner(t *testing.T) {
-	cfg := Config{PVProvisioner: constants.PVProvisionerNone}
-	cl := &api.EtcdCluster{
-		ObjectMeta: metav1.ObjectMeta{Name: "testing"},
-		Spec: api.ClusterSpec{
-			Backup: &api.BackupPolicy{
-				StorageType: api.BackupStorageTypePersistentVolume,
-				StorageSource: api.StorageSource{
-					PV: &api.PVSource{VolumeSizeInMB: 512},
-				},
-				MaxBackups: 1,
-			},
-		},
-	}
-	_, err := newBackupManager(cfg, cl, nil)
-	if err != errNoPVForBackup {
-		t.Errorf("expect err=%v, get=%v", errNoPVForBackup, err)
-	}
-}
 
 func TestNewBackupManagerWithoutS3Config(t *testing.T) {
 	cfg := Config{}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -59,7 +59,6 @@ type clusterEvent struct {
 }
 
 type Config struct {
-	PVProvisioner  string
 	ServiceAccount string
 
 	KubeCli   kubernetes.Interface

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -21,7 +21,6 @@ import (
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
 	"github.com/coreos/etcd-operator/pkg/cluster"
 	"github.com/coreos/etcd-operator/pkg/generated/clientset/versioned"
-	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 
 	"github.com/sirupsen/logrus"
@@ -30,15 +29,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var (
-	supportedPVProvisioners = map[string]struct{}{
-		constants.PVProvisionerGCEPD:  {},
-		constants.PVProvisionerAWSEBS: {},
-		constants.PVProvisionerNone:   {},
-	}
-
-	initRetryWaitTime = 30 * time.Second
-)
+var initRetryWaitTime = 30 * time.Second
 
 type Event struct {
 	Type   kwatch.EventType
@@ -53,24 +44,12 @@ type Controller struct {
 }
 
 type Config struct {
-	Namespace          string
-	ServiceAccount     string
-	PVProvisioner      string
-	KubeCli            kubernetes.Interface
-	KubeExtCli         apiextensionsclient.Interface
-	EtcdCRCli          versioned.Interface
-	CreateCRD          bool
-	CreateStorageClass bool
-}
-
-func (c *Config) Validate() error {
-	if _, ok := supportedPVProvisioners[c.PVProvisioner]; !ok {
-		return fmt.Errorf(
-			"persistent volume provisioner %s is not supported: options = %v",
-			c.PVProvisioner, supportedPVProvisioners,
-		)
-	}
-	return nil
+	Namespace      string
+	ServiceAccount string
+	KubeCli        kubernetes.Interface
+	KubeExtCli     apiextensionsclient.Interface
+	EtcdCRCli      versioned.Interface
+	CreateCRD      bool
 }
 
 func New(cfg Config) *Controller {
@@ -134,7 +113,6 @@ func (c *Controller) handleClusterEvent(event *Event) error {
 
 func (c *Controller) makeClusterConfig() cluster.Config {
 	return cluster.Config{
-		PVProvisioner:  c.PVProvisioner,
 		ServiceAccount: c.Config.ServiceAccount,
 		KubeCli:        c.Config.KubeCli,
 		EtcdCRCli:      c.Config.EtcdCRCli,

--- a/pkg/controller/informer.go
+++ b/pkg/controller/informer.go
@@ -20,8 +20,6 @@ import (
 	"time"
 
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
-	"github.com/coreos/etcd-operator/pkg/util/constants"
-	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 	"github.com/coreos/etcd-operator/pkg/util/probe"
 
 	"k8s.io/apimachinery/pkg/fields"
@@ -76,12 +74,6 @@ func (c *Controller) initResource() error {
 		err := c.initCRD()
 		if err != nil {
 			return fmt.Errorf("fail to init CRD: %v", err)
-		}
-	}
-	if c.Config.CreateStorageClass && (c.Config.PVProvisioner != constants.PVProvisionerNone) {
-		err := k8sutil.CreateStorageClass(c.KubeCli, c.PVProvisioner)
-		if err != nil && !k8sutil.IsKubernetesResourceAlreadyExistError(err) {
-			return fmt.Errorf("fail to create storage class: %v", err)
 		}
 	}
 	return nil

--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -27,10 +27,6 @@ const (
 	OperatorRoot   = "/var/tmp/etcd-operator"
 	BackupMountDir = "/var/etcd-backup"
 
-	PVProvisionerGCEPD  = "kubernetes.io/gce-pd"
-	PVProvisionerAWSEBS = "kubernetes.io/aws-ebs"
-	PVProvisionerNone   = "none"
-
 	EnvOperatorPodName      = "MY_POD_NAME"
 	EnvOperatorPodNamespace = "MY_POD_NAMESPACE"
 )

--- a/pkg/util/k8sutil/backup.go
+++ b/pkg/util/k8sutil/backup.go
@@ -27,7 +27,6 @@ import (
 
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"
-	v1beta1storage "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -35,9 +34,6 @@ import (
 )
 
 const (
-	// StorageClassPrefix is the prefix used when creating custom storage classes
-	// for backups through a given provisioner.
-	StorageClassPrefix        = "etcd-backup"
 	BackupPodSelectorAppField = "etcd_backup_tool"
 	backupPVVolName           = "etcd-backup-storage"
 	awsCredentialDir          = "/root/.aws/"
@@ -46,19 +42,6 @@ const (
 
 	PVBackupV1 = "v1" // TODO: refactor and combine this with pkg/backup.PVBackupV1
 )
-
-func CreateStorageClass(kubecli kubernetes.Interface, pvProvisioner string) error {
-	// We need to get rid of prefix because naming doesn't support "/".
-	name := StorageClassPrefix + "-" + path.Base(pvProvisioner)
-	class := &v1beta1storage.StorageClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Provisioner: pvProvisioner,
-	}
-	_, err := kubecli.StorageV1beta1().StorageClasses().Create(class)
-	return err
-}
 
 func CreateAndWaitPVC(kubecli kubernetes.Interface, clusterName, ns, storageClass string, volumeSizeInMB int) error {
 	name := makePVCName(clusterName)

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -59,7 +59,7 @@ type Framework struct {
 func Setup() error {
 	kubeconfig := flag.String("kubeconfig", "", "kube config path, e.g. $HOME/.kube/config")
 	opImage := flag.String("operator-image", "", "operator image, e.g. gcr.io/coreos-k8s-scale-testing/etcd-operator")
-	pvProvisioner := flag.String("pv-provisioner", constants.PVProvisionerGCEPD, "persistent volume provisioner type: the default is kubernetes.io/gce-pd. This should be set according to where the tests are running")
+	pvProvisioner := flag.String("pv-provisioner", "kubernetes.io/gce-pd", "persistent volume provisioner type: the default is kubernetes.io/gce-pd. This should be set according to where the tests are running")
 	ns := flag.String("namespace", "default", "e2e test namespace")
 	flag.Parse()
 

--- a/test/e2e/upgradetest/main_test.go
+++ b/test/e2e/upgradetest/main_test.go
@@ -20,7 +20,6 @@ import (
 	"path"
 	"testing"
 
-	"github.com/coreos/etcd-operator/pkg/util/constants"
 	"github.com/coreos/etcd-operator/test/e2e/upgradetest/framework"
 
 	"github.com/sirupsen/logrus"
@@ -33,7 +32,7 @@ func TestMain(m *testing.M) {
 	kubeNS := flag.String("kube-ns", "default", "upgrade test namespace")
 	oldImage := flag.String("old-image", "", "")
 	newImage := flag.String("new-image", "", "")
-	pvProvisioner := flag.String("pv-provisioner", constants.PVProvisionerGCEPD, "persistent volume provisioner type: the default is kubernetes.io/gce-pd. This should be set according to where the tests are running")
+	pvProvisioner := flag.String("pv-provisioner", "kubernetes.io/gce-pd", "persistent volume provisioner type: the default is kubernetes.io/gce-pd. This should be set according to where the tests are running")
 	flag.Parse()
 
 	cfg := framework.Config{


### PR DESCRIPTION
Removed all logic related to the `pv-provisioner` and `create-storage-class` flags.

The backup policy validation at the controller now includes checking that storage class must be set, else the event is not handled with a warning.
```
fail to handle event: invalid cluster spec. please fix the following problem with the cluster spec: PV backup must have a storage class set
```