### PR TITLE
hack: build unified image in fmt_build

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -98,6 +98,7 @@ function build_pass {
 	IMAGE=$OPERATOR_IMAGE hack/build/operator/build
 	build_backup_operator
 	build_restore_operator
+	IMAGE=$OPERATOR_IMAGE hack/build/docker_push
 }
 
 function e2e_pass {


### PR DESCRIPTION
fmt_build now builds a unified operator image where it can be used to run backup_operator and restore_operator. 

e2e test can use this image to run backup_operator and restore_operator without requiring individual image.