### PR TITLE
*: generalize CreateCRD and WaitCRDReady

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -57,7 +57,7 @@ func (c *EtcdCluster) AsOwner() metav1.OwnerReference {
 	trueVar := true
 	return metav1.OwnerReference{
 		APIVersion: SchemeGroupVersion.String(),
-		Kind:       CRDResourceKind,
+		Kind:       EtcdClusterResourceKind,
 		Name:       c.Name,
 		UID:        c.UID,
 		Controller: &trueVar,

--- a/pkg/apis/etcd/v1beta2/register.go
+++ b/pkg/apis/etcd/v1beta2/register.go
@@ -21,9 +21,9 @@ import (
 )
 
 const (
-	CRDResourceKind   = "EtcdCluster"
-	CRDResourcePlural = "etcdclusters"
-	groupName         = "etcd.database.coreos.com"
+	EtcdClusterResourceKind   = "EtcdCluster"
+	EtcdClusterResourcePlural = "etcdclusters"
+	groupName                 = "etcd.database.coreos.com"
 
 	EtcdBackupResourceKind   = "EtcdBackup"
 	EtcdBackupResourcePlural = "etcdbackups"
@@ -37,7 +37,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 
 	SchemeGroupVersion = schema.GroupVersion{Group: groupName, Version: "v1beta2"}
-	CRDName            = CRDResourcePlural + "." + groupName
+	EtcdClusterCRDName = EtcdClusterResourcePlural + "." + groupName
 	EtcdBackupCRDName  = EtcdBackupResourcePlural + "." + groupName
 	EtcdRestoreCRDName = EtcdRestoreResourcePlural + "." + groupName
 )

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -120,9 +120,9 @@ func (c *Controller) makeClusterConfig() cluster.Config {
 }
 
 func (c *Controller) initCRD() error {
-	err := k8sutil.CreateCRD(c.KubeExtCli)
+	err := k8sutil.CreateCRD(c.KubeExtCli, api.EtcdClusterCRDName, api.EtcdClusterResourceKind, api.EtcdClusterResourcePlural, "etcd")
 	if err != nil {
 		return fmt.Errorf("failed to create CRD: %v", err)
 	}
-	return k8sutil.WaitCRDReady(c.KubeExtCli)
+	return k8sutil.WaitCRDReady(c.KubeExtCli, api.EtcdClusterCRDName)
 }

--- a/pkg/controller/informer.go
+++ b/pkg/controller/informer.go
@@ -54,7 +54,7 @@ func (c *Controller) Start() error {
 func (c *Controller) run() {
 	source := cache.NewListWatchFromClient(
 		c.Config.EtcdCRCli.EtcdV1beta2().RESTClient(),
-		api.CRDResourcePlural,
+		api.EtcdClusterResourcePlural,
 		c.Config.Namespace,
 		fields.Everything())
 

--- a/pkg/util/k8sutil/crd.go
+++ b/pkg/util/k8sutil/crd.go
@@ -48,22 +48,22 @@ func GetClusterList(restcli rest.Interface, ns string) (*api.EtcdClusterList, er
 }
 
 func listClustersURI(ns string) string {
-	return fmt.Sprintf("/apis/%s/namespaces/%s/%s", api.SchemeGroupVersion.String(), ns, api.CRDResourcePlural)
+	return fmt.Sprintf("/apis/%s/namespaces/%s/%s", api.SchemeGroupVersion.String(), ns, api.EtcdClusterResourcePlural)
 }
 
-func CreateCRD(clientset apiextensionsclient.Interface) error {
+func CreateCRD(clientset apiextensionsclient.Interface, crdName, rkind, rplural, shortName string) error {
 	crd := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: api.CRDName,
+			Name: crdName,
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group:   api.SchemeGroupVersion.Group,
 			Version: api.SchemeGroupVersion.Version,
 			Scope:   apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:     api.CRDResourcePlural,
-				Kind:       api.CRDResourceKind,
-				ShortNames: []string{"etcd"},
+				Plural:     rplural,
+				Kind:       rkind,
+				ShortNames: []string{shortName},
 			},
 		},
 	}
@@ -74,9 +74,9 @@ func CreateCRD(clientset apiextensionsclient.Interface) error {
 	return nil
 }
 
-func WaitCRDReady(clientset apiextensionsclient.Interface) error {
+func WaitCRDReady(clientset apiextensionsclient.Interface, crdName string) error {
 	err := retryutil.Retry(5*time.Second, 20, func() (bool, error) {
-		crd, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(api.CRDName, metav1.GetOptions{})
+		crd, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crdName, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/pkg/util/k8sutil/events_util.go
+++ b/pkg/util/k8sutil/events_util.go
@@ -67,7 +67,7 @@ func newClusterEvent(cl *api.EtcdCluster) *v1.Event {
 		},
 		InvolvedObject: v1.ObjectReference{
 			APIVersion:      api.SchemeGroupVersion.String(),
-			Kind:            api.CRDResourceKind,
+			Kind:            api.EtcdClusterResourceKind,
 			Name:            cl.Name,
 			Namespace:       cl.Namespace,
 			UID:             cl.UID,

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -25,7 +25,7 @@ import (
 func NewCluster(genName string, size int) *api.EtcdCluster {
 	return &api.EtcdCluster{
 		TypeMeta: metav1.TypeMeta{
-			Kind:       api.CRDResourceKind,
+			Kind:       api.EtcdClusterResourceKind,
 			APIVersion: api.SchemeGroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
CreateCRD now creates CRD based on crd name, crd kind, crd plural, and shortName.
WaitCRDReady now waits crd based on crd name.

Replace usage of keyword CRDName and related CRD defs to be prefixed with the keyword EtcdCluster.