### PR TITLE
util: only add shortName if it is not empty

### DIFF
--- a/pkg/util/k8sutil/crd.go
+++ b/pkg/util/k8sutil/crd.go
@@ -61,11 +61,13 @@ func CreateCRD(clientset apiextensionsclient.Interface, crdName, rkind, rplural,
 			Version: api.SchemeGroupVersion.Version,
 			Scope:   apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Plural:     rplural,
-				Kind:       rkind,
-				ShortNames: []string{shortName},
+				Plural: rplural,
+				Kind:   rkind,
 			},
 		},
+	}
+	if len(shortName) != 0 {
+		crd.Spec.Names.ShortNames = []string{shortName}
 	}
 	_, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
 	if err != nil && !IsKubernetesResourceAlreadyExistError(err) {


### PR DESCRIPTION
ShortNames can't be empty. Or else kubernetes api server complains:

```
spec.names.shortNames[0]: Invalid value: "": a DNS-1035 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or 'abc-123', regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')"
```