### PR TITLE
*: support backup operator creation in e2e

### DIFF
--- a/hack/test
+++ b/hack/test
@@ -98,6 +98,7 @@ function build_pass {
 	IMAGE=$OPERATOR_IMAGE hack/build/operator/build
 	build_backup_operator
 	build_restore_operator
+	IMAGE=$OPERATOR_IMAGE hack/build/docker_push
 }
 
 function e2e_pass {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -44,6 +44,8 @@ import (
 
 var Global *Framework
 
+const etcdBackupOperatorName = "etcd-backup-operator"
+
 type Framework struct {
 	opImage          string
 	KubeClient       kubernetes.Interface
@@ -88,6 +90,10 @@ func Teardown() error {
 	if err := Global.deleteEtcdOperator(); err != nil {
 		return err
 	}
+	err := Global.KubeClient.CoreV1().Pods(Global.Namespace).Delete(etcdBackupOperatorName, metav1.NewDeleteOptions(1))
+	if err != nil {
+		return fmt.Errorf("failed to delete etcd backup operator: %v", err)
+	}
 	// TODO: check all deleted and wait
 	Global = nil
 	logrus.Info("e2e teardown successfully")
@@ -107,6 +113,12 @@ func (f *Framework) setup() error {
 			return fmt.Errorf("fail to setup aws: %v", err)
 		}
 	}
+	err := f.SetupEtcdBackupOperator()
+	if err != nil {
+		return fmt.Errorf("failed to create etcd backup operator: %v", err)
+	}
+	logrus.Info("etcd backup operator created successfully")
+
 	logrus.Info("e2e setup successfully")
 	return nil
 }
@@ -188,6 +200,45 @@ func (f *Framework) DeleteEtcdOperatorCompletely() error {
 	if err != nil {
 		return fmt.Errorf("fail to wait etcd operator pod gone from API: %v", err)
 	}
+	return nil
+}
+
+// SetupEtcdBackupOperator creates a etcd backup operator deployment with name as "etcd-backup-operator".
+func (f *Framework) SetupEtcdBackupOperator() error {
+	cmd := []string{"/usr/local/bin/etcd-backup-operator"}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   etcdBackupOperatorName,
+			Labels: map[string]string{"name": etcdBackupOperatorName},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:            etcdBackupOperatorName,
+					Image:           f.opImage,
+					ImagePullPolicy: v1.PullAlways,
+					Command:         cmd,
+					Env: []v1.EnvVar{
+						{
+							Name:      constants.EnvOperatorPodNamespace,
+							ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.namespace"}},
+						},
+						{
+							Name:      constants.EnvOperatorPodName,
+							ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},
+						},
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+		},
+	}
+
+	p, err := k8sutil.CreateAndWaitPod(f.KubeClient, f.Namespace, pod, 60*time.Second)
+	if err != nil {
+		return err
+	}
+	logrus.Infof("etcd backup operator pod is running on node (%s)", p.Spec.NodeName)
 	return nil
 }
 


### PR DESCRIPTION
updates fmt_build to push all operators into one image.
enables e2e framework to run/delete etcd backup operator.