### PR TITLE
reader: add s3 reader for reading backup files

### DIFF
--- a/pkg/backup/reader/reader.go
+++ b/pkg/backup/reader/reader.go
@@ -1,0 +1,23 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reader
+
+import "io"
+
+// Reader defines required reader operations
+type Reader interface {
+	// Open opens up a backup file for reading.
+	Open(path string) (rc io.ReadCloser, err error)
+}

--- a/pkg/backup/reader/s3_reader.go
+++ b/pkg/backup/reader/s3_reader.go
@@ -1,0 +1,63 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reader
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+// ensure s3Reader satisfies reader interface.
+var _ Reader = &s3Reader{}
+
+// s3Reader provides Reader imlementation for reading a file from S3
+type s3Reader struct {
+	s3 *s3.S3
+}
+
+func NewS3Reader(s3 *s3.S3) Reader {
+	return &s3Reader{s3}
+}
+
+// Open opens the file on path where path must be in the format "<s3-bucket-name>/<key>"
+func (s3r *s3Reader) Open(path string) (io.ReadCloser, error) {
+	bucket, key, err := parseBucketAndKey(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse s3 bucket and key: %v", err)
+	}
+	resp, err := s3r.s3.GetObject(&s3.GetObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Body, nil
+}
+
+// parseBucketAndKey parses the path to return the s3 bucket name and key(path in the bucket)
+// returns error if path is not in the format <s3-bucket-name>/<key>
+func parseBucketAndKey(path string) (string, string, error) {
+	toks := strings.SplitN(path, "/", 2)
+	if len(toks) != 2 || len(toks[0]) == 0 || len(toks[1]) == 0 {
+		return "", "", fmt.Errorf("Invalid S3 path (%v)", path)
+	}
+	return toks[0], toks[1], nil
+}


### PR DESCRIPTION
Adresses #1588 

Add a reader interface and s3 reader that the restore-operator can use to read and serve backup files to the seed member pod.

This will replace the use of the backup_server in the restore operator
https://github.com/coreos/etcd-operator/blob/master/pkg/controller/restore-operator/http.go#L62-L68