### PR TITLE
controller/restore-operator: http server takes in restore name to find restore source

### DIFF
--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -57,7 +57,9 @@ type RestoreSource struct {
 }
 
 type S3RestoreSource struct {
-	// The S3 path where the backup is saved.
+	// The full S3 path where the backup is saved.
+	// The format of the path should be: "<s3-bucket-name>/<path-to-backup-file>"
+	// e.g: "etcd-backups/v1/default/example-etcd-cluster/3.1.8_0000000000000001_etcd.backup"
 	Path string `json:"path"`
 
 	// The name of the secret object that stores the AWS credential and config files.

--- a/pkg/controller/restore-operator/operator.go
+++ b/pkg/controller/restore-operator/operator.go
@@ -45,10 +45,10 @@ type Restore struct {
 	etcdCRCli  versioned.Interface
 	kubeExtCli apiextensionsclient.Interface
 
-	// restoreCRs is a map of cluster name to restore cr.
+	// restoreCRs is a map of restore name to restore cr.
 	restoreCRs sync.Map
-	// clusterNames is map of informer's indexer keys to cluster names
-	clusterNames sync.Map
+	// restoreNames is map of informer's indexer keys to restore names
+	restoreNames sync.Map
 }
 
 // New creates a restore operator.

--- a/pkg/controller/restore-operator/sync.go
+++ b/pkg/controller/restore-operator/sync.go
@@ -62,10 +62,10 @@ func (r *Restore) processItem(key string) error {
 		return err
 	}
 	if !exists {
-		cn, ok := r.clusterNames.Load(key)
+		rn, ok := r.restoreNames.Load(key)
 		if ok {
-			r.restoreCRs.Delete(cn)
-			r.clusterNames.Delete(key)
+			r.restoreCRs.Delete(rn)
+			r.restoreNames.Delete(key)
 		}
 		return nil
 	}
@@ -79,9 +79,9 @@ func (r *Restore) handleCR(er *api.EtcdRestore, key string) error {
 	if er.Status.Succeeded || len(er.Status.Reason) != 0 {
 		return nil
 	}
-	clusterName := er.Spec.BackupSpec.ClusterName
-	r.clusterNames.Store(key, clusterName)
-	r.restoreCRs.Store(clusterName, er)
+	restoreName := er.Name
+	r.restoreNames.Store(key, restoreName)
+	r.restoreCRs.Store(restoreName, er)
 	err := r.prepareSeed(er)
 	r.reportStatus(err, er)
 	return err


### PR DESCRIPTION
Addresses #1588 

The http server now accepts the restore-name in a request and uses that to look up the associated restore source, i.e restoreName -> (AWSSecret, S3Path).
The s3Reader is then used to return the backup file.