### PR TITLE
controller/restore-operator: use restore name instead of cluster name

### DIFF
--- a/pkg/controller/restore-operator/operator.go
+++ b/pkg/controller/restore-operator/operator.go
@@ -17,7 +17,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
 	"github.com/coreos/etcd-operator/pkg/client"
@@ -44,11 +43,6 @@ type Restore struct {
 	kubecli    kubernetes.Interface
 	etcdCRCli  versioned.Interface
 	kubeExtCli apiextensionsclient.Interface
-
-	// restoreCRs is a map of cluster name to restore cr.
-	restoreCRs sync.Map
-	// clusterNames is map of informer's indexer keys to cluster names
-	clusterNames sync.Map
 }
 
 // New creates a restore operator.

--- a/pkg/controller/restore-operator/sync.go
+++ b/pkg/controller/restore-operator/sync.go
@@ -62,11 +62,6 @@ func (r *Restore) processItem(key string) error {
 		return err
 	}
 	if !exists {
-		cn, ok := r.clusterNames.Load(key)
-		if ok {
-			r.restoreCRs.Delete(cn)
-			r.clusterNames.Delete(key)
-		}
 		return nil
 	}
 	return r.handleCR(obj.(*api.EtcdRestore), key)
@@ -79,9 +74,6 @@ func (r *Restore) handleCR(er *api.EtcdRestore, key string) error {
 	if er.Status.Succeeded || len(er.Status.Reason) != 0 {
 		return nil
 	}
-	clusterName := er.Spec.BackupSpec.ClusterName
-	r.clusterNames.Store(key, clusterName)
-	r.restoreCRs.Store(clusterName, er)
 	err := r.prepareSeed(er)
 	r.reportStatus(err, er)
 	return err


### PR DESCRIPTION
Part 1 of 2 of #1596

Changes the restore-operator to track a restore via restore CR name instead of spec.BackupSpec.ClusterName.