### PR TITLE
*: add writer to backup manager 

### DIFF
--- a/pkg/backup/backup_manager.go
+++ b/pkg/backup/backup_manager.go
@@ -18,6 +18,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/coreos/etcd-operator/pkg/backup/backend"
@@ -59,13 +60,12 @@ func NewBackupManager(kubecli kubernetes.Interface, clusterName string, namespac
 }
 
 // NewBackupManagerFromWriter creates a BackupManager with backup writer.
-func NewBackupManagerFromWriter(kubecli kubernetes.Interface, etcdTLSConfig *tls.Config, bw writer.Writer, clusterName, namespace string) *BackupManager {
+func NewBackupManagerFromWriter(kubecli kubernetes.Interface, bw writer.Writer, clusterName, namespace string) *BackupManager {
 	return &BackupManager{
-		kubecli:       kubecli,
-		clusterName:   clusterName,
-		namespace:     namespace,
-		etcdTLSConfig: etcdTLSConfig,
-		bw:            bw,
+		kubecli:     kubecli,
+		clusterName: clusterName,
+		namespace:   namespace,
+		bw:          bw,
 	}
 }
 
@@ -92,36 +92,15 @@ func (bm *BackupManager) SaveSnap(lastSnapRev int64) (*backupapi.BackupStatus, e
 	return bs, nil
 }
 
-// SaveSnapWithPath saves latest snapshot to a given path.
-func (bm *BackupManager) SaveSnapWithPath(path string) error {
-	etcdcli, _, err := bm.etcdClientWithMaxRevision()
-	if err != nil {
-		return fmt.Errorf("create etcd client failed: %v", err)
-	}
-	defer etcdcli.Close()
-
-	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultSnapshotTimeout)
-	rc, err := etcdcli.Snapshot(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to receive snapshot (%v)", err)
-	}
-	defer cancel()
-	defer rc.Close()
-
-	return bm.bw.Write(path, rc)
-}
-
 func (bm *BackupManager) writeSnap(mcli clientv3.Maintenance, endpoint string, rev int64) (*backupapi.BackupStatus, error) {
 	start := time.Now()
 
-	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultRequestTimeout)
-	resp, err := mcli.Status(ctx, endpoint)
-	cancel()
+	version, err := getEtcdVersion(mcli, endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	ctx, cancel = context.WithTimeout(context.Background(), constants.DefaultSnapshotTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultSnapshotTimeout)
 	rc, err := mcli.Snapshot(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to receive snapshot (%v)", err)
@@ -129,7 +108,7 @@ func (bm *BackupManager) writeSnap(mcli clientv3.Maintenance, endpoint string, r
 	defer cancel()
 	defer rc.Close()
 
-	n, err := bm.be.Save(resp.Version, rev, rc)
+	n, err := bm.be.Save(version, rev, rc)
 	if err != nil {
 		return nil, err
 	}
@@ -137,12 +116,55 @@ func (bm *BackupManager) writeSnap(mcli clientv3.Maintenance, endpoint string, r
 	bs := &backupapi.BackupStatus{
 		CreationTime:     time.Now().Format(time.RFC3339),
 		Size:             util.ToMB(n),
-		Version:          resp.Version,
+		Version:          version,
 		Revision:         rev,
 		TimeTookInSecond: int(time.Since(start).Seconds() + 1),
 	}
 
 	return bs, nil
+}
+
+// SaveSnapWithPrefix uses backup writer to save latest snapshot to a path prepended with the given prefix
+// and returns file size and full path.
+// the full path has the format of prefix/<etcd_version>_<snapshot_reversion>_etcd.backup
+// e.g prefix = etcd-backups/v1/default/example-etcd-cluster and
+// backup object name = 3.1.8_0000000000000001_etcd.backup
+// full path is "etcd-backups/v1/default/example-etcd-cluster/3.1.8_0000000000000001_etcd.backup".
+func (bm *BackupManager) SaveSnapWithPrefix(prefix string) (string, error) {
+	etcdcli, rev, err := bm.etcdClientWithMaxRevision()
+	if err != nil {
+		return "", fmt.Errorf("create etcd client failed: %v", err)
+	}
+	defer etcdcli.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultSnapshotTimeout)
+	rc, err := etcdcli.Snapshot(ctx)
+	if err != nil {
+		return "", fmt.Errorf("failed to receive snapshot (%v)", err)
+	}
+	defer cancel()
+	defer rc.Close()
+
+	version, err := getEtcdVersion(etcdcli.Maintenance, etcdcli.Endpoints()[0])
+	if err != nil {
+		return "", err
+	}
+	fullPath := path.Join(prefix, util.MakeBackupName(version, rev))
+	_, err = bm.bw.Write(fullPath, rc)
+	if err != nil {
+		return "", fmt.Errorf("failed to write snapshot (%v)", err)
+	}
+	return fullPath, nil
+}
+
+func getEtcdVersion(mcli clientv3.Maintenance, endpoint string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultSnapshotTimeout)
+	resp, err := mcli.Status(ctx, endpoint)
+	cancel()
+	if err != nil {
+		return "", fmt.Errorf("failed to receive etcd version (%v)", err)
+	}
+	return resp.Version, nil
 }
 
 // etcdClientWithMaxRevision gets the etcd member with the maximum kv store revision

--- a/pkg/controller/backup-operator/s3_backup.go
+++ b/pkg/controller/backup-operator/s3_backup.go
@@ -20,14 +20,14 @@ import (
 
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
 	"github.com/coreos/etcd-operator/pkg/backup"
-	"github.com/coreos/etcd-operator/pkg/backup/backend"
 	"github.com/coreos/etcd-operator/pkg/backup/backupapi"
-	backups3 "github.com/coreos/etcd-operator/pkg/backup/s3"
-	"github.com/coreos/etcd-operator/pkg/backup/util"
+	"github.com/coreos/etcd-operator/pkg/backup/writer"
 	"github.com/coreos/etcd-operator/pkg/util/awsutil/s3factory"
 
 	"k8s.io/client-go/kubernetes"
 )
+
+const backupName = "etcd.backup"
 
 // TODO: replace this with generic backend interface for other options (PV, Azure)
 // handleS3 backups up etcd cluster to s3 and return s3 path for the backup file.
@@ -38,19 +38,14 @@ func handleS3(kubecli kubernetes.Interface, s3 *api.S3Source, namespace, cluster
 	}
 	defer cli.Close()
 	prefix := backupapi.ToS3Prefix(s3.Prefix, namespace, clusterName)
-	s3cli := backups3.NewFromClient(s3.S3Bucket, prefix, cli.S3)
-	be := backend.NewS3Backend(s3cli)
-	bm := backup.NewBackupManager(kubecli, clusterName, namespace, nil, be)
-
-	// this SaveSnap takes 0 as lastSnapRev to indicate that it
-	// saves any snapshot with revision > 0.
-	bs, err := bm.SaveSnap(0)
+	// TODO: support TLS.
+	bm := backup.NewBackupManagerFromWriter(kubecli, nil, writer.NewS3Writer(cli.S3), clusterName, namespace)
+	fullS3Path := toS3Path(s3.S3Bucket, prefix, backupName)
+	err = bm.SaveSnapWithPath(fullS3Path)
 	if err != nil {
 		return "", fmt.Errorf("failed to save snapshot (%v)", err)
 	}
-
-	bn := util.MakeBackupName(bs.Version, bs.Revision)
-	return toS3Path(s3.S3Bucket, prefix, bn), nil
+	return fullS3Path, nil
 }
 
 // toS3Path returns the full s3 path of the backup file based s3Bucket, prefix, and backupName.


### PR DESCRIPTION
* backup manager now can write backup to a specific path prefix with the `SaveSnapWithPrefix` function.
* add NewBackupManagerFromWriter factory function to create a BackupManager based on backup writer.
* backup operator uses `SaveSnapWithPrefix` to save snapshot.