### PR TITLE
controller/restore-operator: use s3Reader to read backup

### DIFF
--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -48,7 +48,7 @@ type RestoreSpec struct {
 	BackupSpec BackupSpec `json:"backupSpec"`
 	// TODO: Remove BackupSpec once RestoreSource is implemented
 	// RestoreSource tells the where to get the backup and restore from.
-	RestoreSource RestoreSource `json:",inline"`
+	RestoreSource `json:",inline"`
 }
 
 type RestoreSource struct {
@@ -57,7 +57,9 @@ type RestoreSource struct {
 }
 
 type S3RestoreSource struct {
-	// The S3 path where the backup is saved.
+	// Path is the full s3 path where the backup is saved.
+	// The format of the path must be: "<s3-bucket-name>/<path-to-backup-file>"
+	// e.g: "etcd-backups/v1/default/example-etcd-cluster/3.1.8_0000000000000001_etcd.backup"
 	Path string `json:"path"`
 
 	// The name of the secret object that stores the AWS credential and config files.


### PR DESCRIPTION
Addresses #1588 
Part 2 of #1596 
restore-operator now uses the `S3RestoreSource` of a restore CR to read and return a backup via the s3Reader.
Also fixed the `RestoreSource ` to be embedded so the s3 field can be specified directly in the backup CR like:
```
spec:
  clusterSpec:
    size: 3
    version: "3.1.8"
  s3:
    path: jenkins-etcd-operator/test-prefix/v1/e2e-local/s3-cluster-backup/3.1.8_0000000000000001_etcd.backup
    awsSecret: aws
```