### PR TITLE
*: change seed member query for restore-operator

### DIFF
--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -29,6 +29,7 @@ type EtcdRestoreList struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // EtcdRestore represents a Kubernetes EtcdRestore Custom Resource.
+// The EtcdRestore CR name will be used as the name of the new restored cluster.
 type EtcdRestore struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`

--- a/pkg/backup/backupapi/http.go
+++ b/pkg/backup/backupapi/http.go
@@ -27,11 +27,11 @@ const (
 
 // NewBackupURL creates a URL struct for retrieving an existing backup.
 func NewBackupURL(scheme, host, version string, revision int64) *url.URL {
-	return BackupURLForCluster(scheme, host, "", version, revision)
+	return backupURLForCluster(scheme, host, "", version, revision)
 }
 
-// BackupURLForCluster creates a URL struct for retrieving an existing backup of given cluster.
-func BackupURLForCluster(scheme, host, clusterName, version string, revision int64) *url.URL {
+// backupURLForCluster creates a URL struct for retrieving an existing backup of given cluster.
+func backupURLForCluster(scheme, host, clusterName, version string, revision int64) *url.URL {
 	u := &url.URL{
 		Scheme: scheme,
 		Host:   host,
@@ -45,4 +45,13 @@ func BackupURLForCluster(scheme, host, clusterName, version string, revision int
 	u.RawQuery = uv.Encode()
 
 	return u
+}
+
+// BackupURLForRestore creates a URL struct for retrieving an existing backup specified by a restore CR
+func BackupURLForRestore(scheme, host, restoreName string) *url.URL {
+	return &url.URL{
+		Scheme: scheme,
+		Host:   host,
+		Path:   path.Join(APIV1, "backup", restoreName),
+	}
 }


### PR DESCRIPTION
Addresses #1588 

The restore operator now creates an etcd cluster CR whose name is the restore-name.
The seed member for that cluster uses only the restore-name in its query.

Also fixed a race condition where the restore operator was updating the etcdcluster CR without getting the latest version first. This would cause the following error:
```
Operation cannot be fulfilled on etcdclusters.etcd.database.coreos.com "restore-s3-cluster-backup": the object has been modified; please apply your changes to the latest version and try again
```