### PR TITLE
*: remove BackupSpec from restore CR spec

### DIFF
--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -43,11 +43,6 @@ type RestoreSpec struct {
 	// using this spec, restore operator will prepare the seed that
 	// etcd operator will pick up later.
 	ClusterSpec ClusterSpec `json:"clusterSpec"`
-	// BackupSpec defines the same spec that backup operator uses to save the backup.
-	// restore operator will have the same logic as backup operator to discover
-	// any existing backups and find the one with largest revision.
-	BackupSpec BackupSpec `json:"backupSpec"`
-	// TODO: Remove BackupSpec once RestoreSource is implemented
 	// RestoreSource tells the where to get the backup and restore from.
 	RestoreSource `json:",inline"`
 }

--- a/pkg/apis/etcd/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/etcd/v1beta2/zz_generated.deepcopy.go
@@ -759,7 +759,6 @@ func (in *RestoreSource) DeepCopy() *RestoreSource {
 func (in *RestoreSpec) DeepCopyInto(out *RestoreSpec) {
 	*out = *in
 	in.ClusterSpec.DeepCopyInto(&out.ClusterSpec)
-	in.BackupSpec.DeepCopyInto(&out.BackupSpec)
 	in.RestoreSource.DeepCopyInto(&out.RestoreSource)
 	return
 }


### PR DESCRIPTION
Remove `BackupSpec` now that restore CR uses `RestoreSource`.