### PR TITLE
*: setup restore-operator in e2e framework

### DIFF
--- a/cmd/restore-operator/main.go
+++ b/cmd/restore-operator/main.go
@@ -51,9 +51,9 @@ func main() {
 	if len(name) == 0 {
 		logrus.Fatalf("must set env %s", constants.EnvOperatorPodName)
 	}
-	serviceAddrForSelf = os.Getenv("SERVICE_ADDR")
+	serviceAddrForSelf = os.Getenv(constants.EnvRestoreOperatorServiceName)
 	if len(serviceAddrForSelf) == 0 {
-		logrus.Fatalf("must set env %s", "SERVICE_ADDR")
+		logrus.Fatalf("must set env %s", constants.EnvRestoreOperatorServiceName)
 	}
 	id, err := os.Hostname()
 	if err != nil {

--- a/example/rbac/cluster-role-template.yaml
+++ b/example/rbac/cluster-role-template.yaml
@@ -7,6 +7,8 @@ rules:
   - etcd.database.coreos.com
   resources:
   - etcdclusters
+  - etcdbackups
+  - etcdrestores
   verbs:
   - "*"
 - apiGroups:

--- a/example/rbac/role-template.yaml
+++ b/example/rbac/role-template.yaml
@@ -8,6 +8,8 @@ rules:
   - etcd.database.coreos.com
   resources:
   - etcdclusters
+  - etcdbackups
+  - etcdrestores
   verbs:
   - "*"
 - apiGroups:

--- a/pkg/util/constants/constants.go
+++ b/pkg/util/constants/constants.go
@@ -27,6 +27,7 @@ const (
 	OperatorRoot   = "/var/tmp/etcd-operator"
 	BackupMountDir = "/var/etcd-backup"
 
-	EnvOperatorPodName      = "MY_POD_NAME"
-	EnvOperatorPodNamespace = "MY_POD_NAMESPACE"
+	EnvOperatorPodName            = "MY_POD_NAME"
+	EnvOperatorPodNamespace       = "MY_POD_NAMESPACE"
+	EnvRestoreOperatorServiceName = "SERVICE_ADDR"
 )


### PR DESCRIPTION
Addreses #1611 

The e2e framework will now setup and teardown the restore-operator pod and service.

Additionally, the RBAC permissions needed updating to include `etcdbackups` and `etcdrestores` so that the e2e tests setup the required permissions for backup-operator and restore-operator. 
Our GKE jenkins cluster runs does not require RBAC so this was not detected when the backup-operator e2e test was added.