### PR TITLE
e2e: add e2e test for restore operator

### DIFF
--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -21,20 +21,31 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/s3"
+	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
 	"github.com/coreos/etcd-operator/pkg/util/retryutil"
 	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// TestEtcdBackupOperatorForS3Backup tests if etcd backup operator can save etcd backup to S3.
-func TestEtcdBackupOperatorForS3Backup(t *testing.T) {
+// TestBackupAndRestore runs the backup test first, and only runs the restore test after if the backup test succeeds and sets the S3 path
+func TestBackupAndRestore(t *testing.T) {
 	if os.Getenv(envParallelTest) == envParallelTestTrue {
 		t.Parallel()
 	}
+	s3Path := testEtcdBackupOperatorForS3Backup(t)
+	if len(s3Path) == 0 {
+		t.Fatal("skipping restore test: S3 path not set despite testEtcdBackupOperatorForS3Backup success")
+	}
+	testEtcdRestoreOperatorForS3Source(t, s3Path)
+}
+
+// testEtcdBackupOperatorForS3Backup tests if etcd backup operator can save etcd backup to S3.
+// It returns the full S3 path where the backup is saved.
+func testEtcdBackupOperatorForS3Backup(t *testing.T) string {
 	f := framework.Global
 	testEtcd, err := e2eutil.CreateCluster(t, f.CRClient, f.Namespace, e2eutil.NewCluster("test-etcd-", 3))
 	if err != nil {
@@ -61,6 +72,7 @@ func TestEtcdBackupOperatorForS3Backup(t *testing.T) {
 	// local testing shows that it takes around 1 - 2 seconds from creating backup cr to verifying the backup from s3.
 	// 4 seconds timeout via retry is enough; duration longer than that may indicate internal issues and
 	// is worthy of investigation.
+	s3Path := ""
 	err = retryutil.Retry(time.Second, 4, func() (bool, error) {
 		reb, err := f.CRClient.EtcdV1beta2().EtcdBackups(f.Namespace).Get(eb.Name, metav1.GetOptions{})
 		if err != nil {
@@ -77,6 +89,7 @@ func TestEtcdBackupOperatorForS3Backup(t *testing.T) {
 			if err != nil {
 				return false, fmt.Errorf("failed to get backup %v from s3 : %v", reb.Status.S3Path, err)
 			}
+			s3Path = reb.Status.S3Path
 			return true, nil
 		} else if len(reb.Status.Reason) != 0 {
 			return false, fmt.Errorf("backup failed with reason: %v ", reb.Status.Reason)
@@ -85,5 +98,57 @@ func TestEtcdBackupOperatorForS3Backup(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("failed to verify backup: %v", err)
+	}
+	return s3Path
+}
+
+// testEtcdRestoreOperatorForS3Source tests if the restore-operator can restore an etcd cluster from an S3 restore source
+func testEtcdRestoreOperatorForS3Source(t *testing.T, s3Path string) {
+	f := framework.Global
+
+	restoreSource := api.RestoreSource{S3: e2eutil.NewS3RestoreSource(s3Path, os.Getenv("TEST_AWS_SECRET"))}
+	er := e2eutil.NewEtcdRestore("test-etcd-restore-", "3.1.8", 3, restoreSource)
+	er, err := f.CRClient.EtcdV1beta2().EtcdRestores(f.Namespace).Create(er)
+	if err != nil {
+		t.Fatalf("failed to create etcd restore cr: %v", err)
+	}
+	defer func() {
+		if err := f.CRClient.EtcdV1beta2().EtcdRestores(f.Namespace).Delete(er.Name, nil); err != nil {
+			t.Fatalf("failed to delete etcd restore cr: %v", err)
+		}
+	}()
+
+	// Verify the EtcdRestore CR status "succeeded=true". In practice the time taken to update is 1 second.
+	err = retryutil.Retry(time.Second, 5, func() (bool, error) {
+		er, err := f.CRClient.EtcdV1beta2().EtcdRestores(f.Namespace).Get(er.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to retrieve restore CR: %v", err)
+		}
+		if er.Status.Succeeded {
+			return true, nil
+		} else if len(er.Status.Reason) != 0 {
+			return false, fmt.Errorf("restore failed with reason: %v ", er.Status.Reason)
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to verify restore succeeded: %v", err)
+	}
+
+	// Verify that the restored etcd cluster scales to 3 ready members
+	restoredCluster := &api.EtcdCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      er.Name,
+			Namespace: f.Namespace,
+		},
+		Spec: api.ClusterSpec{
+			Size: 3,
+		},
+	}
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.CRClient, 3, 6, restoredCluster); err != nil {
+		t.Fatalf("failed to see restored etcd cluster(%v) reach 3 members: %v", restoredCluster.Name, err)
+	}
+	if err := e2eutil.DeleteCluster(t, f.CRClient, f.KubeClient, restoredCluster); err != nil {
+		t.Fatalf("failed to delete restored cluster(%v): %v", restoredCluster.Name, err)
 	}
 }

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -75,6 +75,34 @@ func NewS3Backup(clusterName string) *api.EtcdBackup {
 	}
 }
 
+// NewS3RestoreSource returns an S3RestoreSource with the specified path and secret
+func NewS3RestoreSource(path, awsSecret string) *api.S3RestoreSource {
+	return &api.S3RestoreSource{
+		Path:      path,
+		AWSSecret: awsSecret,
+	}
+}
+
+// NewEtcdRestore returns an EtcdRestore CR with the specified RestoreSource
+func NewEtcdRestore(restoreName, version string, size int, restoreSource api.RestoreSource) *api.EtcdRestore {
+	return &api.EtcdRestore{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       api.EtcdRestoreResourceKind,
+			APIVersion: api.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: restoreName,
+		},
+		Spec: api.RestoreSpec{
+			ClusterSpec: api.ClusterSpec{
+				Size:    size,
+				Version: version,
+			},
+			RestoreSource: restoreSource,
+		},
+	}
+}
+
 func NewPVBackupPolicy(cleanup bool, storageClass string) *api.BackupPolicy {
 	return &api.BackupPolicy{
 		BackupIntervalInSecond: 60 * 60,


### PR DESCRIPTION
Addresses #1611 

The e2e test for the restore operator does the following:
- Create an EtcdRestore CR using the awsSecret and S3 path passed in
-  Wait until the CR status has `succeeded=true`
- Verify that the restored etcd cluster reaches the desired size

The restore e2e test needs the S3 path to be set. To do this the backup and restore tests are run sequentially:
- The backup operator test is `testEtcdBackupOperatorForS3Backup` is run first.
- That will return the S3 path if successful.
- The restore operator test runs after that using the S3 path returned by the previous test.