### PR TITLE
[WIP] Add init container script

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/coreos/etcd/pkg/transport"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+const (
+	certDir        = "/certs"
+	caCertFile     = "ca.crt"
+	caKeyFile      = "ca.key"
+	clientCertFile = "etcd-member.crt"
+	clientKeyFile  = "etcd-member.key"
+)
+
+var (
+	caCert *x509.Certificate
+	caKey  *rsa.PrivateKey
+
+	podIP    string
+	peerURLs string
+)
+
+func main() {
+	podIP = os.Getenv("POD_IP")
+	if len(podIP) == 0 {
+		handleErr(errors.New("No POD_IP set"))
+	}
+
+	peerURLs = os.Getenv("PEER_URLS")
+	if len(peerURLs) == 0 {
+		handleErr(errors.New("No PEER_URLS set"))
+	}
+
+	caCertPath := filepath.Join(certDir, caCertFile)
+	ensurePathExists(caCertPath)
+
+	caKeyPath := filepath.Join(certDir, caKeyFile)
+	ensurePathExists(caKeyPath)
+
+	certs, err := certutil.CertsFromFile(caCertPath)
+	handleErr(err)
+	caCert = certs[0]
+
+	caKeyBlob, err := certutil.PrivateKeyFromFile(caKeyPath)
+	handleErr(err)
+
+	var ok bool
+	caKey, ok = caKeyBlob.(*rsa.PrivateKey)
+	if !ok {
+		handleErr(errors.New("Could not convert private key"))
+	}
+
+	createClientPair()
+	createCertPair("peer")
+	createCertPair("server")
+
+	addMember()
+}
+
+func addMember() {
+	peerURLs := strings.Split(peerURLs, ",")
+
+	clientCfg := clientv3.Config{
+		Endpoints:   peerURLs,
+		DialTimeout: 5 * time.Second,
+	}
+
+	newMemberURL := fmt.Sprintf("http://%s:2379", podIP)
+	if strings.HasPrefix(peerURLs[0], "https") {
+		etcdTLSInfo, err := transport.TLSInfo{
+			TrustedCAFile: filepath.Join(certDir, caCertFile),
+			CertFile:      filepath.Join(certDir, clientCertFile),
+			KeyFile:       filepath.Join(certDir, clientKeyFile),
+		}.ClientConfig()
+		handleErr(err)
+		clientCfg.TLS = etcdTLSInfo
+		newMemberURL = fmt.Sprintf("https://%s:2379", podIP)
+	}
+
+	etcdcli, err := clientv3.New(clientCfg)
+	handleErr(err)
+	defer etcdcli.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	res, err := etcdcli.MemberAdd(ctx, []string{newMemberURL})
+	handleErr(err)
+
+	peerURLs = append(peerURLs, newMemberURL)
+	if !reflect.DeepEqual(res.Member.PeerURLs, peerURLs) {
+		handleErr(fmt.Errorf("Response from MemberAdd (%v) did not match %v", res.Member.PeerURLs, peerURLs))
+	}
+
+	cancel()
+}
+
+func createCertPair(filename string) {
+	key, err := certutil.NewPrivateKey()
+	handleErr(err)
+
+	cfg := certutil.Config{
+		CommonName:   fmt.Sprintf("etcd-%s-%s", podIP, filename),
+		Organization: []string{"etcd"},
+		Usages: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageClientAuth,
+			x509.ExtKeyUsageServerAuth,
+		},
+		AltNames: certutil.AltNames{
+			DNSNames: []string{"localhost"},
+			IPs: []net.IP{
+				net.ParseIP(podIP),
+				net.ParseIP("127.0.0.1"),
+			},
+		},
+	}
+	cert, err := certutil.NewSignedCert(cfg, key, caCert, caKey)
+	handleErr(err)
+
+	rootPath := filepath.Join(certDir, filename)
+
+	err = certutil.WriteCert(rootPath+".crt", certutil.EncodeCertPEM(cert))
+	handleErr(err)
+
+	err = certutil.WriteKey(rootPath+".key", certutil.EncodePrivateKeyPEM(key))
+	handleErr(err)
+}
+
+func createClientPair() {
+	key, err := certutil.NewPrivateKey()
+	handleErr(err)
+
+	cfg := certutil.Config{
+		CommonName:   fmt.Sprintf("etcd-%s-client", podIP),
+		Organization: []string{"etcd"},
+		Usages:       []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		AltNames:     certutil.AltNames{},
+	}
+	cert, err := certutil.NewSignedCert(cfg, key, caCert, caKey)
+	handleErr(err)
+
+	rootPath := filepath.Join(certDir, clientCertFile)
+
+	err = certutil.WriteCert(rootPath+".crt", certutil.EncodeCertPEM(cert))
+	handleErr(err)
+
+	err = certutil.WriteKey(rootPath+".key", certutil.EncodePrivateKeyPEM(key))
+	handleErr(err)
+}
+
+func ensurePathExists(path string) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		handleErr(fmt.Errorf("%s does not exist", path))
+	}
+}
+
+func handleErr(err error) {
+	if err != nil {
+		fmt.Printf("Unexpected error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 2b4e18b59c97f36951b11ca898709b4a7d5a2e8ff82d5d31f24d1a3e9fe915a9
-updated: 2017-10-31T09:28:37.903241199-07:00
+updated: 2017-11-03T11:36:48.970750966+01:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -48,7 +48,7 @@ imports:
   - autorest/azure
   - autorest/date
 - name: github.com/beorn7/perks
-  version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
+  version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
   subpackages:
   - quantile
 - name: github.com/coreos/etcd
@@ -180,7 +180,7 @@ imports:
   subpackages:
   - prometheus
 - name: github.com/prometheus/client_model
-  version: fa8ad6fec33561be4280a8f0514318c79d7f6cb6
+  version: 6f3806018612930941127f2a7c6c453ba2c527d2
   subpackages:
   - go
 - name: github.com/prometheus/common
@@ -249,7 +249,7 @@ imports:
   subpackages:
   - rate
 - name: google.golang.org/appengine
-  version: a2e0dc829727a4f957a7428b1f322805cfc1f362
+  version: 9d8544a6b2c7df9cff240fcf92d7b2f59bc13416
   subpackages:
   - internal
   - internal/app_identity

--- a/hack/build/Dockerfile
+++ b/hack/build/Dockerfile
@@ -4,6 +4,8 @@ RUN apk add --no-cache ca-certificates
 ADD _output/bin/etcd-backup-operator /usr/local/bin/etcd-backup-operator
 ADD _output/bin/etcd-restore-operator /usr/local/bin/etcd-restore-operator
 ADD _output/bin/etcd-operator /usr/local/bin/etcd-operator
+ADD _output/bin/etcd-init /usr/local/bin/etcd-init
+
 # TODO: remove etcd-backup deprecating etcd-backup sidecar
 ADD _output/bin/etcd-backup /usr/local/bin
 

--- a/hack/build/init/build
+++ b/hack/build/init/build
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function go_build {
+	echo "building "${1}"..."
+	if [ ! -z ${GOINSTALL+x} ] && [ "${GOINSTALL}" = "y" ]
+	then
+		GOBIN=${bin_dir} GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go install -installsuffix cgo -ldflags "$go_ldflags" ./cmd/${1}/
+		mv ${bin_dir}/${1} ${bin_dir}/etcd-${1}
+	else
+		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${bin_dir}/etcd-${1} -installsuffix cgo -ldflags "$go_ldflags" ./cmd/${1}/
+	fi
+}
+
+if ! which go > /dev/null; then
+	echo "golang needs to be installed"
+	exit 1
+fi
+
+GIT_SHA=`git rev-parse --short HEAD || echo "GitNotFound"`
+
+gitHash="github.com/coreos/etcd-operator/version.GitSHA=${GIT_SHA}"
+
+go_ldflags="-X ${gitHash}"
+
+bin_dir="$(pwd)/_output/bin"
+mkdir -p ${bin_dir} || true
+
+go_build init
+
+docker build --tag "${IMAGE}" -f hack/build/Dockerfile . 1>/dev/null
+# For gcr users, do "gcloud docker -a" to have access.
+docker push "${IMAGE}" 1>/dev/null


### PR DESCRIPTION
This init script does a few things:

- Generates client, peer and serving certs from a provided CA pair (hostPath PV)
- Adds the new member using its POD_IP to the cluster (this will result in temporary failures until the real container starts running)

Some stuff left to do:

- [ ] Add logic if certs already exist
- [ ] DRY things up a bit 
- [ ] Test this with modified [NewSelfHostedEtcdPod](https://github.com/coreos/etcd-operator/blob/master/pkg/util/k8sutil/self_hosted.go#L40) and make sure it works together

@hongchaodeng I wanted to submit my initial work to make sure it's correct. WDYT?