### PR TITLE
e2e: always run aws tests in e2e

### DIFF
--- a/hack/ci/run
+++ b/hack/ci/run
@@ -40,7 +40,6 @@ export E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-.*}
 echo "UNIQUE_BUILD_NAME: ${UNIQUE_BUILD_NAME}"
 echo "OPERATOR_IMAGE: ${OPERATOR_IMAGE}"
 echo "TEST_NAMESPACE: ${TEST_NAMESPACE}"
-echo "AWS_TEST_ENABLED: ${AWS_TEST_ENABLED-}"
 echo "E2E_TEST_SELECTOR: ${E2E_TEST_SELECTOR}"
 
 gcloud docker -a # have docker command access to gcloud 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -123,11 +123,10 @@ func (f *Framework) setup() error {
 		return fmt.Errorf("failed to setup etcd operator: %v", err)
 	}
 	logrus.Info("etcd operator created successfully")
-	if os.Getenv("AWS_TEST_ENABLED") == "true" {
-		if err := f.setupAWS(); err != nil {
-			return fmt.Errorf("fail to setup aws: %v", err)
-		}
+	if err := f.setupAWS(); err != nil {
+		return fmt.Errorf("fail to setup aws: %v", err)
 	}
+	logrus.Info("setup aws successfully")
 	err := f.SetupEtcdBackupOperator()
 	if err != nil {
 		return fmt.Errorf("failed to create etcd backup operator: %v", err)


### PR DESCRIPTION
previously `AWS_TEST_ENABLED` flag indicates whether to run tests that consume AWS resource or not.
Now, all tests including the the AWS must run regardless. 