### PR TITLE
*: Improve go build

### DIFF
--- a/hack/build/backup-operator/build
+++ b/hack/build/backup-operator/build
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
 
+# Note: add `-i` to enable build with caching. e.g ./hack/backup-operator/build -i
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-function go_build {
-	echo "building "${1}"..."
-	if [ ! -z ${GOINSTALL+x} ] && [ "${GOINSTALL}" = "y" ]
-	then
-		GOBIN=${bin_dir} GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go install -installsuffix cgo -ldflags "$go_ldflags" ./cmd/${1}/
-		mv ${bin_dir}/${1} ${bin_dir}/etcd-${1}
-	else
-		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${bin_dir}/etcd-${1} -installsuffix cgo -ldflags "$go_ldflags" ./cmd/${1}/
-	fi
-}
+source hack/lib/build.sh
 
 if ! which go > /dev/null; then
 	echo "golang needs to be installed"
@@ -29,4 +22,4 @@ go_ldflags="-X ${gitHash}"
 bin_dir="$(pwd)/_output/bin"
 mkdir -p ${bin_dir} || true
 
-go_build backup-operator
+GO_BUILD_FLAGS="$@" go_build backup-operator

--- a/hack/build/operator/build
+++ b/hack/build/operator/build
@@ -1,20 +1,12 @@
 #!/usr/bin/env bash
 
+# Note: add `-i` to` enable build with caching. e.g ./hack/operator/build -i
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-# TODO: make this a library?
-function go_build {
-	echo "building "${1}"..."
-	if [ ! -z ${GOINSTALL+x} ] && [ "${GOINSTALL}" = "y" ]
-	then
-		GOBIN=${bin_dir} GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go install -installsuffix cgo -ldflags "$go_ldflags" ./cmd/${1}/
-		mv ${bin_dir}/${1} ${bin_dir}/etcd-${1}
-	else
-		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${bin_dir}/etcd-${1} -installsuffix cgo -ldflags "$go_ldflags" ./cmd/${1}/
-	fi
-}
+source hack/lib/build.sh
 
 if ! which go > /dev/null; then
 	echo "golang needs to be installed"
@@ -39,7 +31,7 @@ gitHash="github.com/coreos/etcd-operator/version.GitSHA=${GIT_SHA}"
 
 go_ldflags="-X ${ldKVPairs} -X ${gitHash}"
 
-go_build operator
+GO_BUILD_FLAGS="$@" go_build operator
 
 docker build --tag "${IMAGE}" -f hack/build/operator/Dockerfile . 1>/dev/null
 # For gcr users, do "gcloud docker -a" to have access.

--- a/hack/build/restore-operator/build
+++ b/hack/build/restore-operator/build
@@ -1,19 +1,12 @@
 #!/usr/bin/env bash
 
+# Note: add `-i` to enable build with caching. e.g ./hack/restore-operator/build -i
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-function go_build {
-	echo "building "${1}"..."
-	if [ ! -z ${GOINSTALL+x} ] && [ "${GOINSTALL}" = "y" ]
-	then
-		GOBIN=${bin_dir} GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go install -installsuffix cgo -ldflags "$go_ldflags" ./cmd/${1}/
-		mv ${bin_dir}/${1} ${bin_dir}/etcd-${1}
-	else
-		GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${bin_dir}/etcd-${1} -installsuffix cgo -ldflags "$go_ldflags" ./cmd/${1}/
-	fi
-}
+source hack/lib/build.sh
 
 if ! which go > /dev/null; then
 	echo "golang needs to be installed"
@@ -29,4 +22,4 @@ go_ldflags="-X ${gitHash}"
 bin_dir="$(pwd)/_output/bin"
 mkdir -p ${bin_dir} || true
 
-go_build restore-operator
+GO_BUILD_FLAGS="$@" go_build restore-operator

--- a/hack/lib/build.sh
+++ b/hack/lib/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+function go_build {
+	echo "building "${1}"..."
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $GO_BUILD_FLAGS -o ${bin_dir}/etcd-${1} -installsuffix cgo -ldflags "$go_ldflags" ./cmd/${1}/
+}


### PR DESCRIPTION
remove go install from build scripts.
go build for operators can now take-in extra flags.
refactor go_build as a standalone lib in hack/lib.