### PR TITLE
test/pod: have run-test-pod wait and cleanup pod

### DIFF
--- a/test/pod/Dockerfile
+++ b/test/pod/Dockerfile
@@ -7,3 +7,5 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.8.2/bi
     && mv ./kubectl /usr/local/bin/kubectl
 
 ADD ./ /go/src/github.com/coreos/etcd-operator
+
+WORKDIR /go/src/github.com/coreos/etcd-operator

--- a/test/pod/README.md
+++ b/test/pod/README.md
@@ -28,7 +28,7 @@ TEST_IMAGE=gcr.io/coreos-k8s-scale-testing/etcd-operator-tests \
 TEST_NAMESPACE=e2e \
 OPERATOR_IMAGE=quay.io/coreos/etcd-operator:dev \
 TEST_S3_BUCKET=jenkins-etcd-operator \
-TEST_AWS_SECRET=aws-secret
+TEST_AWS_SECRET=aws-secret \
 test/pod/run-test-pod
 ```
 

--- a/test/pod/build
+++ b/test/pod/build
@@ -18,4 +18,4 @@ docker build --tag "${TEST_IMAGE}" -f test/pod/Dockerfile . 1>/dev/null
 
 # For gcr users, do "gcloud docker -a" to have access.
 echo "pushing container..."
-docker push "${TEST_IMAGE}" 1>/dev/null
+docker push "${TEST_IMAGE}"

--- a/test/pod/run-test-pod
+++ b/test/pod/run-test-pod
@@ -19,8 +19,13 @@ E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-""}
 TEST_S3_BUCKET=${TEST_S3_BUCKET:-"jenkins-etcd-operator"}
 TEST_AWS_SECRET=${TEST_AWS_SECRET:-"aws-secret"}
 
+POD_NAME=${POD_NAME:-"eop-testing"}
+
+# TODO: Setup RBAC for the test-pod
+
 # Run the test-pod in the given namespace
-sed -e "s|<TEST_IMAGE>|${TEST_IMAGE}|g" \
+sed -e "s|<POD_NAME>|${POD_NAME}|g" \
+    -e "s|<TEST_IMAGE>|${TEST_IMAGE}|g" \
     -e "s|<PASSES>|${PASSES}|g" \
     -e "s|<OPERATOR_IMAGE>|${OPERATOR_IMAGE}|g" \
     -e "s|<E2E_TEST_SELECTOR>|${E2E_TEST_SELECTOR}|g" \
@@ -28,3 +33,37 @@ sed -e "s|<TEST_IMAGE>|${TEST_IMAGE}|g" \
     -e "s|<TEST_AWS_SECRET>|${TEST_AWS_SECRET}|g" \
     test/pod/test-pod.yaml \
     | kubectl -n ${TEST_NAMESPACE} create -f -
+
+function cleanup {
+	kubectl -n ${TEST_NAMESPACE} delete pod ${POD_NAME}
+}
+trap cleanup EXIT
+
+
+PHASE_RUNNING="Running"
+PHASE_SUCCEEDED="Succeeded"
+RETRY_INTERVAL=5
+
+# Wait until pod is running
+echo "Waiting for test-pod to start runnning"
+POD_PHASE=""
+until [ "${POD_PHASE}" == "${PHASE_RUNNING}" ]
+do
+    sleep ${RETRY_INTERVAL}
+    POD_PHASE=$(kubectl -n ${TEST_NAMESPACE} get pod ${POD_NAME} -o jsonpath='{.status.phase}')
+done
+
+# Print out logs until pod stops running
+echo "test-pod logs"
+echo "=============="
+kubectl -n ${TEST_NAMESPACE} logs -f ${POD_NAME}
+echo "=============="
+
+# Check for pod success or failure
+POD_PHASE=$(kubectl -n ${TEST_NAMESPACE} get pod ${POD_NAME} -o jsonpath='{.status.phase}')
+if [ "${POD_PHASE}" == "${PHASE_SUCCEEDED}" ]; then
+    echo "e2e tests finished successfully"
+else
+    echo "e2e tests failed"
+    exit 1
+fi

--- a/test/pod/test-pod.yaml
+++ b/test/pod/test-pod.yaml
@@ -1,15 +1,14 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: eop-tests
+  name: <POD_NAME>
 spec:
   restartPolicy: Never
   containers:
-  - name: eop-tests
+  - name: <POD_NAME>
     image: <TEST_IMAGE>
     imagePullPolicy: Always
-    command: ["/bin/bash"]
-    args: ["-c", "cd /go/src/github.com/coreos/etcd-operator && test/pod/test"]
+    command: ["test/pod/test"]
     env:
       - name: TEST_NAMESPACE
         valueFrom:


### PR DESCRIPTION
[skip ci]
Resolves part of #1640 

The `run-test-pod` script now waits until the test-pod is running, prints out its logs, reports if the pod succeeded or failed and deletes the test-pod.

Additionally a few minor fixes.

/cc @hongchaodeng @fanminshi 