### PR TITLE
test/pod: setup rbac in run-test-pod

### DIFF
--- a/test/pod/README.md
+++ b/test/pod/README.md
@@ -16,9 +16,9 @@ TEST_IMAGE=gcr.io/coreos-k8s-scale-testing/etcd-operator-tests test/pod/build
 ```
 
 ## Run the test-pod
-The `run-test-pod` script sets the image and necessary environment variables for the test-pod before running it:
+The `run-test-pod` script sets up RBAC for the namespace, and necessary environment variables for the test-pod before running it:
 
-- `TEST_NAMESPACE` is the namespace where the test-pod and e2e tests will run. The default serviceaccount must be given sufficient RBAC permissions for the test-pod and e2e tests to run, e.g clusterrolebinding with admin clusterrole.
+- `TEST_NAMESPACE` is the namespace where the test-pod and e2e tests will run.
 - `OPERATOR_IMAGE` is the etcd-operator image used for testing
 - `TEST_S3_BUCKET` is the S3 bucket name used for testing
 - `TEST_AWS_SECRET` is the secret name containing the aws credentials/config files.
@@ -27,7 +27,7 @@ The `run-test-pod` script sets the image and necessary environment variables for
 TEST_IMAGE=gcr.io/coreos-k8s-scale-testing/etcd-operator-tests \
 TEST_NAMESPACE=e2e \
 OPERATOR_IMAGE=quay.io/coreos/etcd-operator:dev \
-TEST_S3_BUCKET=jenkins-etcd-operator \
+TEST_S3_BUCKET=my-bucket \
 TEST_AWS_SECRET=aws-secret \
 test/pod/run-test-pod
 ```

--- a/test/pod/run-test-pod
+++ b/test/pod/run-test-pod
@@ -21,7 +21,20 @@ TEST_AWS_SECRET=${TEST_AWS_SECRET:-"aws-secret"}
 
 POD_NAME=${POD_NAME:-"eop-testing"}
 
-# TODO: Setup RBAC for the test-pod
+# Setup RBAC for the e2e tests
+source hack/ci/rbac_utils.sh
+function cleanup {
+    rbac_cleanup
+    kubectl -n ${TEST_NAMESPACE} delete pod ${POD_NAME}
+}
+trap cleanup EXIT
+
+if rbac_setup ; then
+    echo "RBAC setup success! ==="
+else
+    echo "RBAC setup fail! ==="
+    exit 1
+fi
 
 # Run the test-pod in the given namespace
 sed -e "s|<POD_NAME>|${POD_NAME}|g" \
@@ -33,11 +46,6 @@ sed -e "s|<POD_NAME>|${POD_NAME}|g" \
     -e "s|<TEST_AWS_SECRET>|${TEST_AWS_SECRET}|g" \
     test/pod/test-pod.yaml \
     | kubectl -n ${TEST_NAMESPACE} create -f -
-
-function cleanup {
-	kubectl -n ${TEST_NAMESPACE} delete pod ${POD_NAME}
-}
-trap cleanup EXIT
 
 
 PHASE_RUNNING="Running"


### PR DESCRIPTION
[skip ci]
ref: #1640 
The run-test-pod script now sets up RBAC before running the test-pod.