### PR TITLE
test/pod: timeout if test-pod does not become running

### DIFF
--- a/test/pod/run-test-pod
+++ b/test/pod/run-test-pod
@@ -52,12 +52,22 @@ PHASE_RUNNING="Running"
 PHASE_SUCCEEDED="Succeeded"
 RETRY_INTERVAL=5
 
-# Wait until pod is running
+# Wait until pod is running or timeout
 echo "Waiting for test-pod to start runnning"
+TIMEOUT=90
+ELAPSED=0
 POD_PHASE=""
 until [ "${POD_PHASE}" == "${PHASE_RUNNING}" ]
 do
+    if [ "${ELAPSED}" -ge "${TIMEOUT}" ]; then
+        echo "Timeout waiting for test-pod ${POD_NAME} to become running"
+        echo "=============="
+        kubectl -n ${TEST_NAMESPACE} describe pod ${POD_NAME}
+        echo "=============="
+        exit 1
+    fi
     sleep ${RETRY_INTERVAL}
+    ELAPSED=$(( $ELAPSED + $RETRY_INTERVAL ))
     POD_PHASE=$(kubectl -n ${TEST_NAMESPACE} get pod ${POD_NAME} -o jsonpath='{.status.phase}')
 done
 


### PR DESCRIPTION
[skip ci]
ref: #1640 
The test-pod could fail to become running due to a bad image name or some other issue. So a timeout is needed in run-test-pod otherwise it keeps waiting forever.
