### PR TITLE
k8sutil: fix outdated TolerateUnreadyEndpoints alpha feature

### DIFF
--- a/doc/alpha-features.md
+++ b/doc/alpha-features.md
@@ -5,15 +5,3 @@ Tracking document for alpha features of Kubernetes that etcd operator makes use 
 We track these alpha features as their behavior may change or be deprecated between Kubernetes versions.
 Therefore clusters that use these features need to keep track of any potential changes in upstream releases.
 See the upstream [api versioning documentation](https://github.com/kubernetes/community/blob/master/contributors/devel/api_changes.md#alpha-beta-and-stable-versions) for more information.
-
-
-### TolerateUnreadyEndpointsAnnotation
-
-Used by the etcd client and peer service object.
-
-This alpha annotation will retain the endpoints even if the etcd pod isn't ready.
-This feature is always enabled in endpoint controller in k8s even it is alpha.
-
-References:
-- https://github.com/coreos/etcd-operator/issues/622
-- https://github.com/coreos/etcd-operator/issues/1257

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -57,8 +57,6 @@ const (
 	operatorEtcdTLSVolume    = "etcd-client-tls"
 )
 
-const TolerateUnreadyEndpointsAnnotation = "service.alpha.kubernetes.io/tolerate-unready-endpoints"
-
 func GetEtcdVersion(pod *v1.Pod) string {
 	return pod.Annotations[etcdVersionAnnotationKey]
 }
@@ -196,14 +194,12 @@ func newEtcdServiceManifest(svcName, clusterName, clusterIP string, ports []v1.S
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   svcName,
 			Labels: labels,
-			Annotations: map[string]string{
-				TolerateUnreadyEndpointsAnnotation: "true",
-			},
 		},
 		Spec: v1.ServiceSpec{
-			Ports:     ports,
-			Selector:  labels,
-			ClusterIP: clusterIP,
+			Ports:                    ports,
+			Selector:                 labels,
+			ClusterIP:                clusterIP,
+			PublishNotReadyAddresses: true,
 		},
 	}
 	return svc


### PR DESCRIPTION
See https://github.com/kubernetes/kubernetes/pull/49061/

It has been promoted to a field and old annotations are deprecated