### PR TITLE
Add auto-approver controller

### DIFF
--- a/cmd/auto-approve-csr/main.go
+++ b/cmd/auto-approve-csr/main.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"crypto/x509"
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
+
+	authorization "k8s.io/api/authorization/v1beta1"
+	capi "k8s.io/api/certificates/v1beta1"
+	"k8s.io/client-go/informers"
+	certificatesinformers "k8s.io/client-go/informers/certificates/v1beta1"
+	clientset "k8s.io/client-go/kubernetes"
+	k8s_certificates_v1beta1 "k8s.io/kubernetes/pkg/apis/certificates/v1beta1"
+	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/controller/certificates"
+)
+
+const (
+	// The organization name that needs to be set in the CSR for it
+	// to be approved.
+	crsOrgName = "etcd"
+
+	// Name of ServiceAccount that will have CSRs approved. Etcd pods
+	// need to use this SA when they're created.
+	csrServiceAccount = "etcd-cluster"
+)
+
+type csrRecognizer struct {
+	recognize      func(csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool
+	permission     authorization.ResourceAttributes
+	successMessage string
+}
+
+type sarApprover struct {
+	client      clientset.Interface
+	recognizers []csrRecognizer
+}
+
+func main() {
+	kubeconfig, err := k8sutil.InClusterConfig()
+	if err != nil {
+		logrus.Fatalf("Error when setting up kubeconfig: %v", err)
+	}
+
+	clientBuilder := controller.SimpleControllerClientBuilder{ClientConfig: kubeconfig}
+	client := clientBuilder.ClientOrDie("certificate-controller")
+	sharedInformers := informers.NewSharedInformerFactory(client, 1*time.Second)
+
+	approver, err := NewCSRApprovingController(client, sharedInformers.Certificates().V1beta1().CertificateSigningRequests())
+	if err != nil {
+		logrus.Fatalf("Error encountered when running controller: %v", err)
+	}
+
+	sharedInformers.Start(nil)
+	approver.Run(1, nil)
+}
+
+// NewCSRApprovingController approves CSRs for new etcd pod members
+func NewCSRApprovingController(client clientset.Interface, csrInformer certificatesinformers.CertificateSigningRequestInformer) (*certificates.CertificateController, error) {
+	approver := &sarApprover{client: client, recognizers: recognizers()}
+	return certificates.NewCertificateController(client, csrInformer, approver.handle)
+}
+
+func recognizers() []csrRecognizer {
+	return []csrRecognizer{
+		{
+			recognize:      isSelfNodeClientCert,
+			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "selfnodeclient"},
+			successMessage: "Auto approving self kubelet client certificate after SubjectAccessReview.",
+		},
+		{
+			recognize:      isNodeClientCert,
+			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "nodeclient"},
+			successMessage: "Auto approving kubelet client certificate after SubjectAccessReview.",
+		},
+		{
+			recognize:      isSelfNodeServerCert,
+			permission:     authorization.ResourceAttributes{Group: "certificates.k8s.io", Resource: "certificatesigningrequests", Verb: "create", Subresource: "selfnodeserver"},
+			successMessage: "Auto approving self kubelet server certificate after SubjectAccessReview.",
+		},
+	}
+}
+
+func (a *sarApprover) handle(csr *capi.CertificateSigningRequest) error {
+	if len(csr.Status.Certificate) != 0 {
+		return nil
+	}
+	if approved, denied := certificates.GetCertApprovalCondition(&csr.Status); approved || denied {
+		return nil
+	}
+	x509cr, err := k8s_certificates_v1beta1.ParseCSR(csr)
+	if err != nil {
+		return fmt.Errorf("unable to parse csr %q: %v", csr.Name, err)
+	}
+
+	tried := []string{}
+
+	for _, r := range a.recognizers {
+		if !r.recognize(csr, x509cr) {
+			continue
+		}
+
+		tried = append(tried, r.permission.Subresource)
+
+		approved, err := a.authorize(csr, r.permission)
+		if err != nil {
+			return err
+		}
+		if approved {
+			appendApprovalCondition(csr, r.successMessage)
+			_, err = a.client.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(csr)
+			if err != nil {
+				return fmt.Errorf("error updating approval for csr: %v", err)
+			}
+			return nil
+		}
+	}
+
+	if len(tried) != 0 {
+		return fmt.Errorf("recognized csr %q as %v but subject access review was not approved", csr.Name, tried)
+	}
+
+	return nil
+}
+
+func (a *sarApprover) authorize(csr *capi.CertificateSigningRequest, rattrs authorization.ResourceAttributes) (bool, error) {
+	extra := make(map[string]authorization.ExtraValue)
+	for k, v := range csr.Spec.Extra {
+		extra[k] = authorization.ExtraValue(v)
+	}
+
+	sar := &authorization.SubjectAccessReview{
+		Spec: authorization.SubjectAccessReviewSpec{
+			User:               csr.Spec.Username,
+			UID:                csr.Spec.UID,
+			Groups:             csr.Spec.Groups,
+			Extra:              extra,
+			ResourceAttributes: &rattrs,
+		},
+	}
+	sar, err := a.client.AuthorizationV1beta1().SubjectAccessReviews().Create(sar)
+	if err != nil {
+		return false, err
+	}
+	return sar.Status.Allowed, nil
+}
+
+func appendApprovalCondition(csr *capi.CertificateSigningRequest, message string) {
+	csr.Status.Conditions = append(csr.Status.Conditions, capi.CertificateSigningRequestCondition{
+		Type:    capi.CertificateApproved,
+		Reason:  "AutoApproved",
+		Message: message,
+	})
+}
+
+func hasExactUsages(csr *capi.CertificateSigningRequest, usages []capi.KeyUsage) bool {
+	if len(usages) != len(csr.Spec.Usages) {
+		return false
+	}
+
+	usageMap := map[capi.KeyUsage]struct{}{}
+	for _, u := range usages {
+		usageMap[u] = struct{}{}
+	}
+
+	for _, u := range csr.Spec.Usages {
+		if _, ok := usageMap[u]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+var kubeletClientUsages = []capi.KeyUsage{
+	capi.UsageKeyEncipherment,
+	capi.UsageDigitalSignature,
+	capi.UsageClientAuth,
+}
+
+func isNodeClientCert(csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
+	if !reflect.DeepEqual([]string{crsOrgName}, x509cr.Subject.Organization) {
+		return false
+	}
+	if (len(x509cr.DNSNames) > 0) || (len(x509cr.EmailAddresses) > 0) || (len(x509cr.IPAddresses) > 0) {
+		return false
+	}
+	if !hasExactUsages(csr, kubeletClientUsages) {
+		return false
+	}
+	if x509cr.Subject.CommonName != csrServiceAccount {
+		return false
+	}
+	return true
+}
+
+func isSelfNodeClientCert(csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
+	if !isNodeClientCert(csr, x509cr) {
+		return false
+	}
+	if csr.Spec.Username != x509cr.Subject.CommonName {
+		return false
+	}
+	return true
+}
+
+var kubeletServerUsages = []capi.KeyUsage{
+	capi.UsageKeyEncipherment,
+	capi.UsageDigitalSignature,
+	capi.UsageServerAuth,
+}
+
+func isSelfNodeServerCert(csr *capi.CertificateSigningRequest, x509cr *x509.CertificateRequest) bool {
+	if !reflect.DeepEqual([]string{crsOrgName}, x509cr.Subject.Organization) {
+		return false
+	}
+	if len(x509cr.DNSNames) == 0 || len(x509cr.IPAddresses) == 0 {
+		return false
+	}
+	if !hasExactUsages(csr, kubeletServerUsages) {
+		return false
+	}
+	if x509cr.Subject.CommonName != csrServiceAccount {
+		return false
+	}
+	if csr.Spec.Username != x509cr.Subject.CommonName {
+		return false
+	}
+	return true
+}

--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -12,6 +12,7 @@ spec:
       containers:
       - name: etcd-operator
         image: quay.io/coreos/etcd-operator:v0.6.1
+        command: ["etcd-operator"]
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:
@@ -21,3 +22,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+      - name: auto-csr-approver
+        image: quay.io/coreos/etcd-operator:latest
+        command: ["etcd-auto-approve-csr"]

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2b4e18b59c97f36951b11ca898709b4a7d5a2e8ff82d5d31f24d1a3e9fe915a9
-updated: 2017-10-31T09:28:37.903241199-07:00
+hash: 0353cf3e10c6a38b256aa7b52e6bb217df6aa623c1a5f524ab4aba8009ad33f3
+updated: 2017-11-15T11:28:38.422846658+01:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -38,15 +38,8 @@ imports:
   - service/sts
 - name: github.com/Azure/azure-sdk-for-go
   version: 57db66900881e9fd21fd041a9d013514700ecab3
-  subpackages:
-  - storage
 - name: github.com/Azure/go-autorest
   version: 5432abe734f8d95c78340cd56712f912906e6514
-  subpackages:
-  - autorest
-  - autorest/adal
-  - autorest/azure
-  - autorest/date
 - name: github.com/beorn7/perks
   version: 3ac7bf7a47d159a033b107610db8a1b6575507a4
   subpackages:
@@ -64,13 +57,13 @@ imports:
   - pkg/transport
 - name: github.com/coreos/go-semver
   version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
-  subpackages:
-  - semver
 - name: github.com/coreos/go-systemd
   version: 48702e0da86bd25e76cfef347e2adeb434a0d0a6
   subpackages:
   - daemon
+  - dbus
   - journal
+  - unit
   - util
 - name: github.com/coreos/pkg
   version: fa29b1d70f0beaddd4c7021607cc3c3be8ce94b8
@@ -85,6 +78,11 @@ imports:
   - spew
 - name: github.com/dgrijalva/jwt-go
   version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
+- name: github.com/docker/distribution
+  version: edc3ab29cdff8694dd6feb85cfeb4b5f1b38ed9c
+  subpackages:
+  - digestset
+  - reference
 - name: github.com/emicklei/go-restful
   version: ff4f55a206334ef123e4f79bbf348980da81ca46
   subpackages:
@@ -94,7 +92,7 @@ imports:
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
 - name: github.com/go-ini/ini
-  version: f280b3ba517bf5fc98922624f21fb0e7a92adaec
+  version: 2e44421e256d82ebbf3d4d4fcabe8930b905eff3
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -138,7 +136,7 @@ imports:
   subpackages:
   - diskcache
 - name: github.com/grpc-ecosystem/go-grpc-prometheus
-  version: 6b7015e65d366bf3f19b2b2a000a831940f0f7e0
+  version: 2500245aa6110c562d17020fb31a2c133d737799
 - name: github.com/grpc-ecosystem/grpc-gateway
   version: 84398b94e188ee336f307779b57b3aa91af7063c
   subpackages:
@@ -154,7 +152,7 @@ imports:
 - name: github.com/imdario/mergo
   version: 6633656539c1639d9d78127b7d47c622b5d7b6dc
 - name: github.com/jmespath/go-jmespath
-  version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+  version: 3433f3ea46d9f8019119e7dd41274e112a2359a9
 - name: github.com/json-iterator/go
   version: 36b14963da70d11297d313183d7e6388c8510e1e
 - name: github.com/juju/ratelimit
@@ -169,6 +167,8 @@ imports:
   version: fc2b8d3a73c4867e51861bbdd5ae3c1f0869dd6a
   subpackages:
   - pbutil
+- name: github.com/opencontainers/go-digest
+  version: a6d0ee40d4207ea02364bd3b9e8e77b9159ba1eb
 - name: github.com/pborman/uuid
   version: a97ce2ca70fa5a848076093f05e639a89ca34d06
 - name: github.com/peterbourgon/diskv
@@ -197,8 +197,6 @@ imports:
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
-- name: github.com/satori/uuid
-  version: 5bf94b69c6b68ee1b541973bb8e1144db23a194b
 - name: github.com/sirupsen/logrus
   version: 202f25545ea4cf9b191ff7f846df5d87c9382c2b
 - name: github.com/spf13/pflag
@@ -260,16 +258,25 @@ imports:
   - internal/remote_api
   - internal/urlfetch
   - urlfetch
+- name: google.golang.org/genproto
+  version: 09f6ed296fc66555a25fe4ce95173148778dfa85
+  subpackages:
+  - googleapis/rpc/status
 - name: google.golang.org/grpc
-  version: 777daa17ff9b5daef1cfdf915088a2ada3332bf0
+  version: d2e1b51f33ff8c5e4a15560ff049d200e83726c5
   subpackages:
   - codes
   - credentials
+  - grpclb/grpc_lb_v1
   - grpclog
   - internal
+  - keepalive
   - metadata
   - naming
   - peer
+  - stats
+  - status
+  - tap
   - transport
 - name: gopkg.in/inf.v0
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
@@ -310,6 +317,7 @@ imports:
   - pkg/client/clientset/clientset
   - pkg/client/clientset/clientset/scheme
   - pkg/client/clientset/clientset/typed/apiextensions/v1beta1
+  - pkg/features
 - name: k8s.io/apimachinery
   version: 019ae5ada31de202164b118aee88ee2d14075c31
   subpackages:
@@ -317,9 +325,14 @@ imports:
   - pkg/api/errors
   - pkg/api/meta
   - pkg/api/resource
+  - pkg/api/validation
+  - pkg/apimachinery
+  - pkg/apimachinery/announced
+  - pkg/apimachinery/registered
   - pkg/apis/meta/internalversion
   - pkg/apis/meta/v1
   - pkg/apis/meta/v1/unstructured
+  - pkg/apis/meta/v1/validation
   - pkg/apis/meta/v1alpha1
   - pkg/conversion
   - pkg/conversion/queryparams
@@ -345,6 +358,7 @@ imports:
   - pkg/util/json
   - pkg/util/mergepatch
   - pkg/util/net
+  - pkg/util/rand
   - pkg/util/runtime
   - pkg/util/sets
   - pkg/util/strategicpatch
@@ -356,11 +370,88 @@ imports:
   - pkg/watch
   - third_party/forked/golang/json
   - third_party/forked/golang/reflect
+- name: k8s.io/apiserver
+  version: 9707c008294d447053c0e2737c256ee23f99e5b4
+  subpackages:
+  - pkg/admission
+  - pkg/admission/initializer
+  - pkg/admission/plugin/namespace/lifecycle
+  - pkg/apis/apiserver
+  - pkg/apis/apiserver/install
+  - pkg/apis/apiserver/v1alpha1
+  - pkg/apis/audit
+  - pkg/apis/audit/install
+  - pkg/apis/audit/v1alpha1
+  - pkg/apis/audit/v1beta1
+  - pkg/apis/audit/validation
+  - pkg/audit
+  - pkg/audit/policy
+  - pkg/authentication/authenticator
+  - pkg/authentication/authenticatorfactory
+  - pkg/authentication/group
+  - pkg/authentication/request/anonymous
+  - pkg/authentication/request/bearertoken
+  - pkg/authentication/request/headerrequest
+  - pkg/authentication/request/union
+  - pkg/authentication/request/websocket
+  - pkg/authentication/request/x509
+  - pkg/authentication/serviceaccount
+  - pkg/authentication/token/tokenfile
+  - pkg/authentication/user
+  - pkg/authorization/authorizer
+  - pkg/authorization/authorizerfactory
+  - pkg/authorization/union
+  - pkg/endpoints
+  - pkg/endpoints/discovery
+  - pkg/endpoints/filters
+  - pkg/endpoints/handlers
+  - pkg/endpoints/handlers/negotiation
+  - pkg/endpoints/handlers/responsewriters
+  - pkg/endpoints/metrics
+  - pkg/endpoints/openapi
+  - pkg/endpoints/request
+  - pkg/features
+  - pkg/registry/generic
+  - pkg/registry/generic/registry
+  - pkg/registry/rest
+  - pkg/server
+  - pkg/server/filters
+  - pkg/server/healthz
+  - pkg/server/httplog
+  - pkg/server/mux
+  - pkg/server/options
+  - pkg/server/routes
+  - pkg/server/routes/data/swagger
+  - pkg/server/storage
+  - pkg/storage
+  - pkg/storage/errors
+  - pkg/storage/etcd
+  - pkg/storage/etcd/metrics
+  - pkg/storage/etcd/util
+  - pkg/storage/etcd3
+  - pkg/storage/etcd3/preflight
+  - pkg/storage/names
+  - pkg/storage/storagebackend
+  - pkg/storage/storagebackend/factory
+  - pkg/storage/value
+  - pkg/util/feature
+  - pkg/util/flag
+  - pkg/util/flushwriter
+  - pkg/util/logs
+  - pkg/util/trace
+  - pkg/util/webhook
+  - pkg/util/wsstream
+  - plugin/pkg/audit/log
+  - plugin/pkg/audit/webhook
+  - plugin/pkg/authenticator/token/webhook
+  - plugin/pkg/authorizer/webhook
 - name: k8s.io/client-go
   version: 35ccd4336052e7d73018b1382413534936f34eee
   subpackages:
   - discovery
   - discovery/fake
+  - informers/certificates/v1beta1
+  - informers/internalinterfaces
   - kubernetes
   - kubernetes/scheme
   - kubernetes/typed/admissionregistration/v1alpha1
@@ -387,6 +478,7 @@ imports:
   - kubernetes/typed/settings/v1alpha1
   - kubernetes/typed/storage/v1
   - kubernetes/typed/storage/v1beta1
+  - listers/certificates/v1beta1
   - pkg/version
   - plugin/pkg/client/auth/gcp
   - rest
@@ -411,9 +503,39 @@ imports:
   - util/homedir
   - util/integer
   - util/jsonpath
+  - util/retry
   - util/workqueue
 - name: k8s.io/kube-openapi
   version: 868f2f29720b192240e18284659231b440f9cda5
   subpackages:
   - pkg/common
+- name: k8s.io/kubernetes
+  version: bdaeafa71f6c7c04636251031f93464384d54963
+  subpackages:
+  - pkg/api
+  - pkg/api/helper
+  - pkg/api/install
+  - pkg/api/service
+  - pkg/api/util
+  - pkg/api/v1
+  - pkg/api/v1/helper
+  - pkg/api/v1/pod
+  - pkg/api/validation
+  - pkg/apis/certificates
+  - pkg/apis/certificates/v1beta1
+  - pkg/apis/extensions
+  - pkg/apis/networking
+  - pkg/capabilities
+  - pkg/controller
+  - pkg/controller/certificates
+  - pkg/features
+  - pkg/kubelet/types
+  - pkg/security/apparmor
+  - pkg/serviceaccount
+  - pkg/util/file
+  - pkg/util/hash
+  - pkg/util/net/sets
+  - pkg/util/parsers
+  - pkg/util/pointer
+  - pkg/util/taints
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,5 +1,7 @@
 package: github.com/coreos/etcd-operator
 import:
+- package: k8s.io/kubernetes
+  version: v1.8.2
 - package: k8s.io/client-go
   version: kubernetes-1.8.2
 - package: k8s.io/api

--- a/hack/build/Dockerfile
+++ b/hack/build/Dockerfile
@@ -4,3 +4,4 @@ RUN apk add --no-cache ca-certificates
 ADD _output/bin/etcd-backup-operator /usr/local/bin/etcd-backup-operator
 ADD _output/bin/etcd-restore-operator /usr/local/bin/etcd-restore-operator
 ADD _output/bin/etcd-operator /usr/local/bin/etcd-operator
+ADD _output/bin/etcd-auto-approve-csr /usr/local/bin/etcd-auto-approve-csr

--- a/hack/build/auto-approve-csr/build
+++ b/hack/build/auto-approve-csr/build
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Note: add `-i` to` enable build with caching. e.g ./hack/operator/build -i
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+source hack/lib/build.sh
+
+if ! which go > /dev/null; then
+	echo "golang needs to be installed"
+	exit 1
+fi
+
+if ! which docker > /dev/null; then
+	echo "docker needs to be installed"
+	exit 1
+fi
+
+GIT_SHA=`git rev-parse --short HEAD || echo "GitNotFound"`
+
+bin_dir="$(pwd)/_output/bin"
+mkdir -p ${bin_dir} || true
+
+
+gitHash="github.com/coreos/etcd-operator/version.GitSHA=${GIT_SHA}"
+
+go_ldflags="-X ${gitHash}"
+
+GO_BUILD_FLAGS="$@" go_build auto-approve-csr


### PR DESCRIPTION
This PR adds a new binary which acts as the auto-approve controller for CSRs. It runs as a container inside the operator pod. 

In order for CSRs to be auto-approved, two conditions need to be met:

1. The ServiceName for new etcd pods is set to `etcd-cluster` (this value can be changed if there's a better alternative). If the init container is a member of a Pod with this SA, its CSRs will be approved.
2. The CSR itself needs to specify `etcd` as the Organization in the CSR (again, this can be changed if there's a better alternative).

Most of this has been cribbed from https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/certificates/approver/sarapprove.go.

/cc @hongchaodeng 