### PR TITLE
k8sutil: get rid of /bin/sh in app etcd pod

### DIFF
--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -35,9 +35,9 @@ func etcdVolumeMounts() []v1.VolumeMount {
 	}
 }
 
-func etcdContainer(commands, baseImage, version string) v1.Container {
+func etcdContainer(cmd []string, baseImage, version string) v1.Container {
 	c := v1.Container{
-		Command: []string{"/bin/sh", "-ec", commands},
+		Command: cmd,
 		Name:    "etcd",
 		Image:   ImageName(baseImage, version),
 		Ports: []v1.ContainerPort{

--- a/pkg/util/k8sutil/self_hosted.go
+++ b/pkg/util/k8sutil/self_hosted.go
@@ -81,7 +81,7 @@ done
 	commands = fmt.Sprintf(ft, m.Addr(), commands)
 	commands = fmt.Sprintf("%s; %s", appendHostsCommands(), commands)
 	commands = fmt.Sprintf("flock %s -c \"%s\"", etcdLockPath, commands)
-	c := etcdContainer(commands, cs.BaseImage, cs.Version)
+	c := etcdContainer([]string{"/bin/sh", "-ec", commands}, cs.BaseImage, cs.Version)
 	// On node reboot, there will be two copies of etcd pod: scheduled and checkpointed one.
 	// Checkpointed one will start first. But then the scheduler will detect host port conflict,
 	// and set the pod (in APIServer) failed. This further affects etcd service by removing the endpoints.


### PR DESCRIPTION
fix https://github.com/coreos/etcd-operator/issues/1680


Instead of using "/bin/sh", it splits the commands directly into ["etcd", "--name=xxx", ...]

Based on my manual testing, etcd pods are deleted based on SIGTERM signal.
Note that this does not change self-hosted case.
