### PR TITLE
doc: Improve backup/restore doc

### DIFF
--- a/doc/user/install_guide.md
+++ b/doc/user/install_guide.md
@@ -1,12 +1,14 @@
 # Operation Guide
 
-## Install etcd operator
+## Setup RBAC
 
 Set up basic [RBAC rules](./rbac.md) for etcd operator:
 
 ```bash
 $ example/rbac/create_role.sh
 ```
+
+## Install etcd operator
 
 Create a deployment for etcd operator:
 

--- a/doc/user/walkthrough/backup-operator.md
+++ b/doc/user/walkthrough/backup-operator.md
@@ -10,6 +10,7 @@ Try out etcd backup operator by running it on Kubernetes and then create a `Etcd
 >Note: The demo uses the `default` namespace.
 
 Prerequisites: 
+* Setup RBAC and deploy an etcd operator. See [Install Guide][install_guide]
 * A running etcd cluster named `example-etcd-cluster`. See [instructions][etcd_cluster_deploy] to deploy it.
 
 ### Deploy etcd backup operator
@@ -22,6 +23,14 @@ $ kubectl create -f example/etcd-backup-operator/deployment.yaml
 $ kubectl get pod
 NAME                                    READY     STATUS    RESTARTS   AGE
 etcd-backup-operator-1102130733-hhgt7   1/1       Running   0          3s
+```
+
+Verify that the etcd-backup-operator creates EtcdBackup CRD:
+
+```sh
+$ kubectl get crd
+NAME                                    KIND
+etcdbackups.etcd.database.coreos.com    CustomResourceDefinition.v1beta1.apiextensions.k8s.io
 ```
 
 ### Setup AWS Secret
@@ -92,3 +101,4 @@ kubectl delete -f example/etcd-backup-operator/deployment.yaml
 [s3]:https://aws.amazon.com/s3/
 [etcd_cluster_deploy]:https://github.com/coreos/etcd-operator#create-and-destroy-an-etcd-cluster
 [minikube]:https://github.com/kubernetes/minikube
+[install_guide]:../install_guide.md

--- a/doc/user/walkthrough/restore-operator.md
+++ b/doc/user/walkthrough/restore-operator.md
@@ -15,6 +15,7 @@ The overall workflow is:
 Note that currently the etcd-restore-operator only supports restoring from backups saved on S3.
 
 **Prerequisite**
+- Setup RBAC and deploy an etcd operator. See [Install Guide][install_guide]
 - Have an etcd backup saved on S3. See the [etcd-backup-operator README][backup-operator-README] as one way to save a backup to S3.
 
 >Note: This demo uses the `default` namespace.
@@ -130,3 +131,4 @@ kubect delete -f example/etcd-restore-operator/deployment.yaml
 
 
 [backup-operator-README]:./backup-operator.md
+[install_guide]:../install_guide.md


### PR DESCRIPTION
[skip ci]
Add setting up RBAC and etcd operator as a prerequisite to backup/restore doc.

fix https://github.com/coreos/etcd-operator/issues/1683