### PR TITLE
*: support tls for backup operator

### DIFF
--- a/pkg/apis/etcd/v1beta2/backup_types.go
+++ b/pkg/apis/etcd/v1beta2/backup_types.go
@@ -44,6 +44,13 @@ type BackupSpec struct {
 	StorageType string `json:"storageType"`
 	// BackupStorageSource is the backup storage source.
 	BackupStorageSource `json:",inline"`
+	// ClientTLSSecret is the secret containing the etcd TLS client certs and
+	// must contain the following data items:
+	// data:
+	//    "etcd-client.crt": <pem-encoded-cert>
+	//    "etcd-client.key": <pem-encoded-key>
+	//    "etcd-client-ca.crt": <pem-encoded-ca-cert>
+	ClientTLSSecret string `json:"clientTLSSecret,omitempty"`
 }
 
 // BackupStorageSource contains the supported backup sources.

--- a/pkg/backup/backup_manager.go
+++ b/pkg/backup/backup_manager.go
@@ -45,12 +45,13 @@ type BackupManager struct {
 }
 
 // NewBackupManagerFromWriter creates a BackupManager with backup writer.
-func NewBackupManagerFromWriter(kubecli kubernetes.Interface, bw writer.Writer, clusterName, namespace string) *BackupManager {
+func NewBackupManagerFromWriter(kubecli kubernetes.Interface, bw writer.Writer, tls *tls.Config, clusterName, namespace string) *BackupManager {
 	return &BackupManager{
-		kubecli:     kubecli,
-		clusterName: clusterName,
-		namespace:   namespace,
-		bw:          bw,
+		kubecli:       kubecli,
+		clusterName:   clusterName,
+		namespace:     namespace,
+		etcdTLSConfig: tls,
+		bw:            bw,
 	}
 }
 

--- a/pkg/backup/backup_manager.go
+++ b/pkg/backup/backup_manager.go
@@ -45,12 +45,12 @@ type BackupManager struct {
 }
 
 // NewBackupManagerFromWriter creates a BackupManager with backup writer.
-func NewBackupManagerFromWriter(kubecli kubernetes.Interface, bw writer.Writer, tls *tls.Config, clusterName, namespace string) *BackupManager {
+func NewBackupManagerFromWriter(kubecli kubernetes.Interface, bw writer.Writer, tc *tls.Config, clusterName, namespace string) *BackupManager {
 	return &BackupManager{
 		kubecli:       kubecli,
 		clusterName:   clusterName,
 		namespace:     namespace,
-		etcdTLSConfig: tls,
+		etcdTLSConfig: tc,
 		bw:            bw,
 	}
 }

--- a/pkg/controller/backup-operator/s3_backup.go
+++ b/pkg/controller/backup-operator/s3_backup.go
@@ -15,6 +15,7 @@
 package controller
 
 import (
+	"crypto/tls"
 	"fmt"
 	"path"
 
@@ -23,20 +24,34 @@ import (
 	"github.com/coreos/etcd-operator/pkg/backup/backupapi"
 	"github.com/coreos/etcd-operator/pkg/backup/writer"
 	"github.com/coreos/etcd-operator/pkg/util/awsutil/s3factory"
+	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
+	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
 
 	"k8s.io/client-go/kubernetes"
 )
 
 // TODO: replace this with generic backend interface for other options (PV, Azure)
 // handleS3 backups up etcd cluster to s3 and return s3 path for the backup file.
-func handleS3(kubecli kubernetes.Interface, s3 *api.S3Source, namespace, clusterName string) (string, error) {
+func handleS3(kubecli kubernetes.Interface, s3 *api.S3Source, clientTLSSecret, namespace, clusterName string) (string, error) {
 	cli, err := s3factory.NewClientFromSecret(kubecli, namespace, s3.AWSSecret)
 	if err != nil {
 		return "", err
 	}
 	defer cli.Close()
-	// TODO: support TLS.
-	bm := backup.NewBackupManagerFromWriter(kubecli, writer.NewS3Writer(cli.S3), clusterName, namespace)
+
+	var tlsConfig *tls.Config
+	if len(clientTLSSecret) != 0 {
+		d, err := k8sutil.GetTLSDataFromSecret(kubecli, namespace, clientTLSSecret)
+		if err != nil {
+			return "", fmt.Errorf("failed to get TLS data from secret (%v): %v", clientTLSSecret, err)
+		}
+		tlsConfig, err = etcdutil.NewTLSConfig(d.CertData, d.KeyData, d.CAData)
+		if err != nil {
+			return "", fmt.Errorf("failed to constructs tls config: %v", err)
+		}
+	}
+
+	bm := backup.NewBackupManagerFromWriter(kubecli, writer.NewS3Writer(cli.S3), tlsConfig, clusterName, namespace)
 	s3Prefix := backupapi.ToS3Prefix(s3.Prefix, namespace, clusterName)
 	fullPath, err := bm.SaveSnapWithPrefix(path.Join(s3.S3Bucket, s3Prefix))
 	if err != nil {

--- a/pkg/controller/backup-operator/sync.go
+++ b/pkg/controller/backup-operator/sync.go
@@ -113,7 +113,7 @@ func (b *Backup) handleErr(err error, key interface{}) {
 func (b *Backup) handleBackup(spec *api.BackupSpec) (*api.BackupCRStatus, error) {
 	switch spec.StorageType {
 	case api.BackupStorageTypeS3:
-		s3path, err := handleS3(b.kubecli, spec.S3, b.namespace, spec.ClusterName)
+		s3path, err := handleS3(b.kubecli, spec.S3, spec.ClientTLSSecret, b.namespace, spec.ClusterName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/k8sutil/tls.go
+++ b/pkg/util/k8sutil/tls.go
@@ -27,6 +27,7 @@ type TLSData struct {
 	CAData   []byte
 }
 
+// GetTLSDataFromSecret retrives the kubernete secret that contain etcd tls certs and put them into TLSData.
 func GetTLSDataFromSecret(kubecli kubernetes.Interface, ns, se string) (*TLSData, error) {
 	secret, err := kubecli.CoreV1().Secrets(ns).Get(se, metav1.GetOptions{})
 	if err != nil {

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -36,7 +36,7 @@ func NewCluster(genName string, size int) *api.EtcdCluster {
 }
 
 // NewS3Backup creates a EtcdBackup object using clusterName.
-func NewS3Backup(clusterName, bucket, secret, PrepareTLS string) *api.EtcdBackup {
+func NewS3Backup(clusterName, bucket, secret, clientTLSSecret string) *api.EtcdBackup {
 	return &api.EtcdBackup{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       api.EtcdBackupResourceKind,

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -36,7 +36,7 @@ func NewCluster(genName string, size int) *api.EtcdCluster {
 }
 
 // NewS3Backup creates a EtcdBackup object using clusterName.
-func NewS3Backup(clusterName, bucket, secret string) *api.EtcdBackup {
+func NewS3Backup(clusterName, bucket, secret, PrepareTLS string) *api.EtcdBackup {
 	return &api.EtcdBackup{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       api.EtcdBackupResourceKind,
@@ -46,8 +46,9 @@ func NewS3Backup(clusterName, bucket, secret string) *api.EtcdBackup {
 			GenerateName: clusterName,
 		},
 		Spec: api.BackupSpec{
-			ClusterName: clusterName,
-			StorageType: api.BackupStorageTypeS3,
+			ClusterName:     clusterName,
+			StorageType:     api.BackupStorageTypeS3,
+			ClientTLSSecret: clientTLSSecret,
 			BackupStorageSource: api.BackupStorageSource{
 				S3: &api.S3Source{
 					S3Bucket:  bucket,
@@ -83,6 +84,19 @@ func NewEtcdRestore(restoreName, version string, size int, restoreSource api.Res
 				Version:   version,
 			},
 			RestoreSource: restoreSource,
+		},
+	}
+}
+
+// ClusterCRWithTLS adds TLSPolicy to the passing in cluster CR.
+func ClusterCRWithTLS(cl *api.EtcdCluster, memberPeerTLSSecret, memberServerTLSSecret, operatorClientTLSSecret string) {
+	cl.Spec.TLS = &api.TLSPolicy{
+		Static: &api.StaticTLS{
+			Member: &api.MemberSecret{
+				PeerSecret:   memberPeerTLSSecret,
+				ServerSecret: memberServerTLSSecret,
+			},
+			OperatorSecret: operatorClientTLSSecret,
 		},
 	}
 }

--- a/test/e2e/e2eutil/tls.go
+++ b/test/e2e/e2eutil/tls.go
@@ -25,6 +25,20 @@ import (
 	"time"
 )
 
+// PrepareTLS creates all the required tls certs for a given clusterName.
+func PrepareTLS(clusterName, namespace, memberPeerTLSSecret, memberClientTLSSecret, operatorClientTLSSecret string) error {
+	err := PreparePeerTLSSecret(clusterName, namespace, memberPeerTLSSecret)
+	if err != nil {
+		return err
+	}
+	certsDir, err := ioutil.TempDir("", "etcd-operator-tls-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(certsDir)
+	return PrepareClientTLSSecret(certsDir, clusterName, namespace, memberClientTLSSecret, operatorClientTLSSecret)
+}
+
 func PreparePeerTLSSecret(clusterName, ns, secretName string) error {
 	dir, err := ioutil.TempDir("", "etcd-operator-tls-")
 	if err != nil {


### PR DESCRIPTION
add ClientTLSSecret to backup spec; it is kubernete secret that contains client tls certs.
backup operator uses the ClientTLSSecret to  construct a TLS enabled 
etcd client for retrieving etcd snapshot.

ref: https://github.com/coreos/etcd-operator/issues/1495