### PR TITLE
e2e: fix tls secret creation and cleanup in tests

### DIFF
--- a/test/e2e/e2eslow/tls_test.go
+++ b/test/e2e/e2eslow/tls_test.go
@@ -18,10 +18,15 @@ import (
 	"fmt"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/coreos/etcd-operator/test/e2e/e2eutil"
 	"github.com/coreos/etcd-operator/test/e2e/framework"
 )
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
 
 func TestTLS(t *testing.T) {
 	f := framework.Global

--- a/test/e2e/e2eutil/tls.go
+++ b/test/e2e/e2eutil/tls.go
@@ -23,20 +23,26 @@ import (
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/sirupsen/logrus"
 )
 
 // PrepareTLS creates all the required tls certs for a given clusterName.
 func PrepareTLS(clusterName, namespace, memberPeerTLSSecret, memberClientTLSSecret, operatorClientTLSSecret string) error {
 	err := PreparePeerTLSSecret(clusterName, namespace, memberPeerTLSSecret)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to prepare peer TLS secret: %v", err)
 	}
 	certsDir, err := ioutil.TempDir("", "etcd-operator-tls-")
 	if err != nil {
 		return err
 	}
 	defer os.RemoveAll(certsDir)
-	return PrepareClientTLSSecret(certsDir, clusterName, namespace, memberClientTLSSecret, operatorClientTLSSecret)
+	err = PrepareClientTLSSecret(certsDir, clusterName, namespace, memberClientTLSSecret, operatorClientTLSSecret)
+	if err != nil {
+		return fmt.Errorf("failed to prepare client TLS secret: %v", err)
+	}
+	return nil
 }
 
 func PreparePeerTLSSecret(clusterName, ns, secretName string) error {
@@ -65,7 +71,12 @@ func PreparePeerTLSSecret(clusterName, ns, secretName string) error {
 		fmt.Sprintf("--from-file=%s", certPath),
 		fmt.Sprintf("--from-file=%s", keyPath),
 	)
-	return cmd.Run()
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		logrus.Errorf("failed to create tls secret. stdout/stderr: %s", stdoutStderr)
+		return fmt.Errorf("failed to create tls secret: %v", err)
+	}
+	return nil
 }
 
 func PrepareClientTLSSecret(dir, clusterName, ns, mSecret, oSecret string) error {
@@ -98,9 +109,10 @@ func PrepareClientTLSSecret(dir, clusterName, ns, mSecret, oSecret string) error
 		fmt.Sprintf("--from-file=%s", mCertPath),
 		fmt.Sprintf("--from-file=%s", mKeyPath),
 	)
-	err = cmd.Run()
+	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
-		return err
+		logrus.Errorf("failed to create tls secret. stdout/stderr: %s", stdoutStderr)
+		return fmt.Errorf("failed to create tls secret: %v", err)
 	}
 
 	cmd = exec.Command("kubectl", "-n", ns, "create", "secret", "generic", oSecret,
@@ -108,7 +120,12 @@ func PrepareClientTLSSecret(dir, clusterName, ns, mSecret, oSecret string) error
 		fmt.Sprintf("--from-file=%s", oCertPath),
 		fmt.Sprintf("--from-file=%s", oKeyPath),
 	)
-	return cmd.Run()
+	stdoutStderr, err = cmd.CombinedOutput()
+	if err != nil {
+		logrus.Errorf("failed to create tls secret. stdout/stderr: %s", stdoutStderr)
+		return fmt.Errorf("failed to create tls secret: %v", err)
+	}
+	return nil
 }
 
 func prepareTLSCerts(certPath, keyPath, caPath string, hosts []string) error {


### PR DESCRIPTION
fixes: #1700 

The framework now correctly seeds the random number generator.
The backup test cleans up its TLS secrets as well.
The error from executing commands is now wrapped as well in the tls util functions.