### PR TITLE
*: combine build steps for e2e

### DIFF
--- a/hack/build/e2e/build
+++ b/hack/build/e2e/build
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# This script builds and pushes the images and binaries needed for e2e testing: the operators, test-pod and logcollector
+
+if ! which docker > /dev/null; then
+	echo "docker needs to be installed"
+	exit 1
+fi
+
+mkdir -p _output
+
+DOCKER_REPO_ROOT="/go/src/github.com/coreos/etcd-operator"
+
+function build_binaries {
+	docker run --rm \
+		-v "$PWD":"$DOCKER_REPO_ROOT" \
+		-w "$DOCKER_REPO_ROOT" \
+		gcr.io/coreos-k8s-scale-testing/etcd-operator-builder \
+		/bin/bash -c "hack/update_vendor.sh && \
+			hack/build/operator/build -i && \
+			hack/build/backup-operator/build -i && \
+			hack/build/restore-operator/build -i && \
+			go build -i -o ${DOCKER_REPO_ROOT}/_output/bin/logcollector test/logcollector/main.go"
+}
+
+function build_and_push_images {
+	: ${TEST_IMAGE:?"Need to set TEST_IMAGE"}
+	: ${OPERATOR_IMAGE:?"Need to set OPERATOR_IMAGE"}
+	IMAGE=${OPERATOR_IMAGE} hack/build/docker_push
+	TEST_IMAGE=${TEST_IMAGE} test/pod/build
+}
+
+build_binaries
+build_and_push_images

--- a/hack/build/e2e/builder/Dockerfile
+++ b/hack/build/e2e/builder/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.9
+
+RUN curl -L https://github.com/golang/dep/releases/download/v0.3.2/dep-linux-amd64 -o /usr/local/bin/dep \
+    && chmod +x /usr/local/bin/dep

--- a/hack/build/e2e/builder/build
+++ b/hack/build/e2e/builder/build
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This script builds and pushes the builder image
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if ! which docker > /dev/null; then
+	echo "docker needs to be installed"
+	exit 1
+fi
+
+: ${IMAGE:?"Need to set IMAGE, e.g. gcr.io/coreos-k8s-scale-testing/etcd-operator-builder"}
+
+echo "building container..."
+docker build --tag "${IMAGE}" -f hack/build/e2e/builder/Dockerfile . 1>/dev/null
+
+# For gcr users, do "gcloud docker -a" to have access.
+echo "pushing container..."
+docker push "${IMAGE}"

--- a/hack/build/operator/build
+++ b/hack/build/operator/build
@@ -13,11 +13,6 @@ if ! which go > /dev/null; then
 	exit 1
 fi
 
-if ! which docker > /dev/null; then
-	echo "docker needs to be installed"
-	exit 1
-fi
-
 GIT_SHA=`git rev-parse --short HEAD || echo "GitNotFound"`
 
 bin_dir="$(pwd)/_output/bin"

--- a/test/pod/build
+++ b/test/pod/build
@@ -13,9 +13,9 @@ fi
 
 : ${TEST_IMAGE:?"Need to set TEST_IMAGE, e.g. gcr.io/coreos-k8s-scale-testing/etcd-operator-tests"}
 
-echo "building container..."
+echo "building test-pod container..."
 docker build --tag "${TEST_IMAGE}" -f test/pod/Dockerfile . 1>/dev/null
 
 # For gcr users, do "gcloud docker -a" to have access.
-echo "pushing container..."
+echo "pushing test-pod container..."
 docker push "${TEST_IMAGE}"

--- a/test/pod/run-test-pod
+++ b/test/pod/run-test-pod
@@ -82,8 +82,8 @@ cp $KUBECONFIG ./kubeconfig
 docker run --rm \
     -v "$PWD":"$DOCKER_REPO_ROOT" \
     -w "$DOCKER_REPO_ROOT" \
-    golang:1.9-alpine \
-    go run ./test/logcollector/main.go --kubeconfig=${DOCKER_REPO_ROOT}/kubeconfig --e2e-podname=${POD_NAME} \
+    golang:1.9 \
+    _output/bin/logcollector --kubeconfig=${DOCKER_REPO_ROOT}/kubeconfig --e2e-podname=${POD_NAME} \
     --namespace=${TEST_NAMESPACE} --logs-dir="_output/logs/"
 
 # Check for pod success or failure


### PR DESCRIPTION
[skip ci]

The script `hack/build/e2e/build` builds all the binaries and images needed for e2e testing.
- operator image
- test-pod image
- logcollector binary

The script builds all the binaries inside a container whose image is defined under `hack/build/e2e/operator-builder`. (go 1.9,bash,git and dep)
This removes the dependence on the `hack/ci/run` script during testing.

This script would be run as:
```
OPERATOR_IMAGE=<opeartor-image> TEST_IMAGE=<test-pod-image> hack/build/e2e/build
```