### PR TITLE
ClusterSpec: remove PodPolicy.AutomountServiceAccountToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 
 ### Removed
 
+- ClusterSpec: Remove `PodPolicy.AutomountServiceAccountToken` field.
+  No etcd pod will have service account token mounted.
+
 ### Fixed
 
 - Ignore Terminating pods when polling etcd pods.

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -141,10 +141,6 @@ type PodPolicy struct {
 	// bootstrap the cluster (for example `--initial-cluster` flag).
 	// This field cannot be updated.
 	EtcdEnv []v1.EnvVar `json:"etcdEnv,omitempty"`
-
-	// By default, kubernetes will mount a service account token into the etcd pods.
-	// AutomountServiceAccountToken indicates whether pods running with the service account should have an API token automatically mounted.
-	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty"`
 }
 
 func (c *ClusterSpec) Validate() error {

--- a/pkg/apis/etcd/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/etcd/v1beta2/zz_generated.deepcopy.go
@@ -538,15 +538,6 @@ func (in *PodPolicy) DeepCopyInto(out *PodPolicy) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.AutomountServiceAccountToken != nil {
-		in, out := &in.AutomountServiceAccountToken, &out.AutomountServiceAccountToken
-		if *in == nil {
-			*out = nil
-		} else {
-			*out = new(bool)
-			**out = **in
-		}
-	}
 	return
 }
 

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -309,8 +309,9 @@ func NewEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 			// DNS A record: `[m.Name].[clusterName].Namespace.svc`
 			// For example, etcd-0000 in default namesapce will have DNS name
 			// `etcd-0000.etcd.default.svc`.
-			Hostname:  m.Name,
-			Subdomain: clusterName,
+			Hostname:                     m.Name,
+			Subdomain:                    clusterName,
+			AutomountServiceAccountToken: func(b bool) *bool { return &b }(false),
 		},
 	}
 

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -102,9 +102,6 @@ func applyPodPolicy(clusterName string, pod *v1.Pod, policy *api.PodPolicy) {
 	if len(policy.Tolerations) != 0 {
 		pod.Spec.Tolerations = policy.Tolerations
 	}
-	if policy.AutomountServiceAccountToken != nil {
-		pod.Spec.AutomountServiceAccountToken = policy.AutomountServiceAccountToken
-	}
 
 	mergeLabels(pod.Labels, policy.Labels)
 

--- a/pkg/util/k8sutil/self_hosted.go
+++ b/pkg/util/k8sutil/self_hosted.go
@@ -141,13 +141,14 @@ done
 		Spec: v1.PodSpec{
 			// Self-hosted etcd pod need to endure node restart.
 			// If we set it to Never, the pod won't restart. If etcd won't come up, nor does other k8s API components.
-			RestartPolicy: v1.RestartPolicyAlways,
-			Containers:    []v1.Container{c},
-			Volumes:       volumes,
-			HostNetwork:   true,
-			DNSPolicy:     v1.DNSClusterFirstWithHostNet,
-			Hostname:      m.Name,
-			Subdomain:     clusterName,
+			RestartPolicy:                v1.RestartPolicyAlways,
+			Containers:                   []v1.Container{c},
+			Volumes:                      volumes,
+			HostNetwork:                  true,
+			DNSPolicy:                    v1.DNSClusterFirstWithHostNet,
+			Hostname:                     m.Name,
+			Subdomain:                    clusterName,
+			AutomountServiceAccountToken: func(b bool) *bool { return &b }(false),
 		},
 	}
 


### PR DESCRIPTION
No etcd pod will have service account token mounted by default.

ref: https://github.com/coreos/etcd-operator/issues/1719