### PR TITLE
*: bump default etcd version to 3.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- Default base image is changed to `gcr.io/etcd-development/etcd`, default etcd version is `3.2.10`.
+- Default base image is changed to `gcr.io/etcd-development/etcd`, default etcd version is `3.2.11`.
 - Migrate dependency management tooling from glide to dep.
 - Containerize e2e test in a pod instead of running on raw jenkin slave.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See the [Resources and Labels](./doc/user/resource_labels.md) doc for an overvie
 ## Requirements
 
 - Kubernetes 1.8+
-- etcd 3.2.10+
+- etcd 3.2.11+
 
 ## Demo
 
@@ -101,7 +101,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 5
-  version: "3.2.10"
+  version: "3.2.11"
 ```
 
 Apply the size change to the cluster CR:
@@ -129,7 +129,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "3.2.10"
+  version: "3.2.11"
 ```
 ```
 $ kubectl apply -f example/example-etcd-cluster.yaml
@@ -243,7 +243,7 @@ $ kubectl get pod example-etcd-cluster-0000 -o yaml | grep "image:" | uniq
     image: quay.io/coreos/etcd:v3.1.10
 ```
 
-Now modify the file `upgrade-example` and change the `version` from 3.1.10 to 3.2.10:
+Now modify the file `upgrade-example` and change the `version` from 3.1.10 to 3.2.11:
 
 ```
 $ cat upgrade-example
@@ -253,7 +253,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "3.2.10"
+  version: "3.2.11"
 ```
 
 Apply the version change to the cluster CR:
@@ -262,11 +262,11 @@ Apply the version change to the cluster CR:
 $ kubectl apply -f upgrade-example
 ```
 
-Wait ~30 seconds. The container image version should be updated to v3.2.10:
+Wait ~30 seconds. The container image version should be updated to v3.2.11:
 
 ```
 $ kubectl get pod example-etcd-cluster-0000 -o yaml | grep "image:" | uniq
-    image: gcr.io/etcd-development/etcd:v3.2.10
+    image: gcr.io/etcd-development/etcd:v3.2.11
 ```
 
 Check the other two pods and you should see the same result.

--- a/doc/user/spec_examples.md
+++ b/doc/user/spec_examples.md
@@ -14,7 +14,7 @@ This will use the default version chosen by the etcd-operator.
 ```yaml
 spec:
   size: 3
-  version: "3.2.10"
+  version: "3.2.11"
 ```
 
 ## Three member cluster with node selector and anti-affinity across nodes

--- a/doc/user/walkthrough/backup-operator.md
+++ b/doc/user/walkthrough/backup-operator.md
@@ -79,7 +79,7 @@ apiVersion: etcd.database.coreos.com/v1beta2
 kind: EtcdBackup
 ...
 status:
-  s3Path: mybucket/v1/default/example-etcd-cluster/3.2.10_0000000000000001_etcd.backup
+  s3Path: mybucket/v1/default/example-etcd-cluster/3.2.11_0000000000000001_etcd.backup
   succeeded: true
 ```
 

--- a/doc/user/walkthrough/restore-operator.md
+++ b/doc/user/walkthrough/restore-operator.md
@@ -77,10 +77,10 @@ Create a Kubernetes secret that contains AWS credentials and config. This is use
 
 Create the `EtcdRestore` CR:
 
->Note: This example uses k8s secret "aws" and S3 path "mybucket/v1/default/example-etcd-cluster/3.2.10_0000000000000001_etcd.backup"
+>Note: This example uses k8s secret "aws" and S3 path "mybucket/v1/default/example-etcd-cluster/3.2.11_0000000000000001_etcd.backup"
 
 ```sh
-sed -e 's|<full-s3-path>|mybucket/v1/default/example-etcd-cluster/3.2.10_0000000000000001_etcd.backup|g' \
+sed -e 's|<full-s3-path>|mybucket/v1/default/example-etcd-cluster/3.2.11_0000000000000001_etcd.backup|g' \
     -e 's|<aws-secret>|aws|g' \
     example/etcd-restore-operator/restore_cr.yaml \
     | kubectl create -f -

--- a/example/etcd-restore-operator/restore_cr.yaml
+++ b/example/etcd-restore-operator/restore_cr.yaml
@@ -6,10 +6,10 @@ metadata:
 spec:
   clusterSpec:
     size: 3
-    version: 3.2.10
+    version: 3.2.11
     repository: "gcr.io/etcd-development/etcd"
   s3:
     # The format of "path" must be: "<s3-bucket-name>/<path-to-backup-file>"
-    # e.g: "etcd-snapshot-bucket/v1/default/example-etcd-cluster/3.2.10_0000000000000001_etcd.backup"
+    # e.g: "etcd-snapshot-bucket/v1/default/example-etcd-cluster/3.2.11_0000000000000001_etcd.backup"
     path: <full-s3-path>
     awsSecret: <aws-secret>

--- a/example/example-etcd-cluster.yaml
+++ b/example/example-etcd-cluster.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "3.2.10"
+  version: "3.2.11"

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	defaultRepository = "gcr.io/etcd-development/etcd"
-	defaultVersion    = "3.2.10"
+	defaultVersion    = "3.2.11"
 )
 
 var (
@@ -86,10 +86,10 @@ type ClusterSpec struct {
 	// The etcd-operator will eventually make the etcd cluster version
 	// equal to the expected version.
 	//
-	// The version must follow the [semver]( http://semver.org) format, for example "3.2.10".
+	// The version must follow the [semver]( http://semver.org) format, for example "3.2.11".
 	// Only etcd released versions are supported: https://github.com/coreos/etcd/releases
 	//
-	// If version is not set, default is "3.2.10".
+	// If version is not set, default is "3.2.11".
 	Version string `json:"version,omitempty"`
 
 	// Paused is to pause the control of the operator for the etcd cluster.

--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -55,7 +55,7 @@ type RestoreSource struct {
 type S3RestoreSource struct {
 	// Path is the full s3 path where the backup is saved.
 	// The format of the path must be: "<s3-bucket-name>/<path-to-backup-file>"
-	// e.g: "etcd-backups/v1/default/example-etcd-cluster/3.2.10_0000000000000001_etcd.backup"
+	// e.g: "etcd-backups/v1/default/example-etcd-cluster/3.2.11_0000000000000001_etcd.backup"
 	Path string `json:"path"`
 
 	// The name of the secret object that stores the AWS credential and config files.

--- a/pkg/backup/backup_manager.go
+++ b/pkg/backup/backup_manager.go
@@ -59,8 +59,8 @@ func NewBackupManagerFromWriter(kubecli kubernetes.Interface, bw writer.Writer, 
 // and returns file size and full path.
 // the full path has the format of prefix/<etcd_version>_<snapshot_reversion>_etcd.backup
 // e.g prefix = etcd-backups/v1/default/example-etcd-cluster and
-// backup object name = 3.2.10_0000000000000001_etcd.backup
-// full path is "etcd-backups/v1/default/example-etcd-cluster/3.2.10_0000000000000001_etcd.backup".
+// backup object name = 3.2.11_0000000000000001_etcd.backup
+// full path is "etcd-backups/v1/default/example-etcd-cluster/3.2.11_0000000000000001_etcd.backup".
 func (bm *BackupManager) SaveSnapWithPrefix(prefix string) (string, error) {
 	etcdcli, rev, err := bm.etcdClientWithMaxRevision()
 	if err != nil {

--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -150,7 +150,7 @@ func testEtcdRestoreOperatorForS3Source(t *testing.T, s3Path string) {
 	f := framework.Global
 
 	restoreSource := api.RestoreSource{S3: e2eutil.NewS3RestoreSource(s3Path, os.Getenv("TEST_AWS_SECRET"))}
-	er := e2eutil.NewEtcdRestore("test-etcd-restore-", "3.2.10", 3, restoreSource)
+	er := e2eutil.NewEtcdRestore("test-etcd-restore-", "3.2.11", 3, restoreSource)
 	er, err := f.CRClient.EtcdV1beta2().EtcdRestores(f.Namespace).Create(er)
 	if err != nil {
 		t.Fatalf("failed to create etcd restore cr: %v", err)

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -125,7 +125,7 @@ func TestEtcdUpgrade(t *testing.T) {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 
-	targetVersion := "3.2.10"
+	targetVersion := "3.2.11"
 	updateFunc := func(cl *api.EtcdCluster) {
 		cl = e2eutil.ClusterWithVersion(cl, targetVersion)
 	}

--- a/test/e2e/e2esh/self_hosted_test.go
+++ b/test/e2e/e2esh/self_hosted_test.go
@@ -85,7 +85,7 @@ func startEtcd(f *framework.Framework) (*v1.Pod, error) {
 			Containers: []v1.Container{{
 				Command: []string{"/bin/sh", "-ec", etcdCmd},
 				Name:    "etcd",
-				Image:   "gcr.io/etcd-development/etcd:v3.2.10",
+				Image:   "gcr.io/etcd-development/etcd:v3.2.11",
 				Env: []v1.EnvVar{{
 					Name:      "POD_NAME",
 					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},


### PR DESCRIPTION
etcd 3.2.11 contains better TLS messages and bug fixes:
https://github.com/coreos/etcd/releases/tag/v3.2.11
Better update to it.