### PR TITLE
*: run logcollector in container from pre-built image

### DIFF
--- a/hack/build/e2e/build
+++ b/hack/build/e2e/build
@@ -17,5 +17,4 @@ docker run --rm \
 	/bin/bash -c "hack/update_vendor.sh && \
 		hack/build/operator/build -i && \
 		hack/build/backup-operator/build -i && \
-		hack/build/restore-operator/build -i && \
-		go build -i -o ${DOCKER_REPO_ROOT}/_output/bin/logcollector test/logcollector/main.go"
+		hack/build/restore-operator/build -i"

--- a/hack/build/logcollector/Dockerfile
+++ b/hack/build/logcollector/Dockerfile
@@ -1,0 +1,11 @@
+# Build step: docker build --tag gcr.io/coreos-k8s-scale-testing/logcollector -f hack/build/logcollector/Dockerfile .
+
+FROM golang:1.9
+
+ADD ./ /go/src/github.com/coreos/etcd-operator
+
+WORKDIR /go/src/github.com/coreos/etcd-operator
+
+RUN rm -rf _output _test .git .gitignore
+
+RUN go build -i -o /usr/local/bin/logcollector test/logcollector/main.go

--- a/test/pod/Dockerfile
+++ b/test/pod/Dockerfile
@@ -9,3 +9,5 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.8.2/bi
 ADD ./ /go/src/github.com/coreos/etcd-operator
 
 WORKDIR /go/src/github.com/coreos/etcd-operator
+
+RUN rm -rf _output _test .git .gitignore

--- a/test/pod/run-test-pod
+++ b/test/pod/run-test-pod
@@ -82,8 +82,8 @@ cp $KUBECONFIG ./kubeconfig
 docker run --rm \
     -v "$PWD":"$DOCKER_REPO_ROOT" \
     -w "$DOCKER_REPO_ROOT" \
-    golang:1.9 \
-    _output/bin/logcollector --kubeconfig=${DOCKER_REPO_ROOT}/kubeconfig --e2e-podname=${POD_NAME} \
+    gcr.io/coreos-k8s-scale-testing/logcollector \
+    logcollector --kubeconfig=${DOCKER_REPO_ROOT}/kubeconfig --e2e-podname=${POD_NAME} \
     --namespace=${TEST_NAMESPACE} --logs-dir="_output/logs/"
 
 # Check for pod success or failure


### PR DESCRIPTION
The logcollector is now pre-built as an image at `gcr.io/coreos-k8s-scale-testing/logcollector` and `run-test-pod` now runs the logcollector in container from that image.