### PR TITLE
*: change gcr.io images to quay.io

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	defaultRepository = "gcr.io/etcd-development/etcd"
+	defaultRepository = "quay.io/coreos/etcd"
 	defaultVersion    = "3.2.11"
 )
 
@@ -76,7 +76,7 @@ type ClusterSpec struct {
 	//   https://github.com/coreos/etcd/releases
 	// That means, it should have exact same tags and the same meaning for the tags.
 	//
-	// By default, it is `gcr.io/etcd-development/etcd`.
+	// By default, it is `quay.io/coreos/etcd`.
 	Repository string `json:"repository,omitempty"`
 	// **DEPRECATED**. Use Repository instead.
 	// TODO: remove this field in v0.7.2 .

--- a/test/e2e/e2esh/self_hosted_test.go
+++ b/test/e2e/e2esh/self_hosted_test.go
@@ -85,7 +85,7 @@ func startEtcd(f *framework.Framework) (*v1.Pod, error) {
 			Containers: []v1.Container{{
 				Command: []string{"/bin/sh", "-ec", etcdCmd},
 				Name:    "etcd",
-				Image:   "gcr.io/etcd-development/etcd:v3.2.11",
+				Image:   "quay.io/coreos/etcd:v3.2.11",
 				Env: []v1.EnvVar{{
 					Name:      "POD_NAME",
 					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -79,7 +79,7 @@ func NewEtcdRestore(restoreName, version string, size int, restoreSource api.Res
 		},
 		Spec: api.RestoreSpec{
 			ClusterSpec: api.ClusterSpec{
-				Repository: "gcr.io/etcd-development/etcd",
+				Repository: "quay.io/coreos/etcd",
 				Size:       size,
 				Version:    version,
 			},


### PR DESCRIPTION
When we bump the etcd version to 3.2, the images were only available on gcr.io . But now it is added on quay.io .

We should better use quay.io and do a bug-fix release for it. In this way we can keep it compatible to work for 3.1 versions etcd.