### PR TITLE
logcollector: stop when pod is terminated

### DIFF
--- a/test/logcollector/main.go
+++ b/test/logcollector/main.go
@@ -99,7 +99,7 @@ func main() {
 				return
 			}
 			// If e2e test pod runs to completion, then stops this program.
-			if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+			if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed || pod.DeletionTimestamp != nil {
 				close(stopCh)
 			}
 		},


### PR DESCRIPTION
[skip ci]

Already pushed and tested the new logcollector image at gcr.io/coreos-k8s-scale-testing/logcollector