### PR TITLE
test/pod: decouple pod template and run script

### DIFF
--- a/hack/build/e2e/docker_push
+++ b/hack/build/e2e/docker_push
@@ -12,8 +12,5 @@ if ! which docker > /dev/null; then
 	exit 1
 fi
 
-# Push operator images
-IMAGE=${OPERATOR_IMAGE} hack/build/docker_push
-
-# Push e2e images
+# Push test pod image
 TEST_IMAGE=${TEST_IMAGE} test/pod/docker_push

--- a/hack/ci/run2
+++ b/hack/ci/run2
@@ -10,10 +10,15 @@ export PATH=$GOROOT/bin:$PATH
 go version
 kubectl version
 
+: ${PASSES:?"Need to set PASSES"}
+: ${TEST_NAMESPACE:?"Need to set TEST_NAMESPACE"}
+: ${TEST_S3_BUCKET:?"Need to set TEST_S3_BUCKET"}
+: ${TEST_AWS_SECRET:?"Need to set TEST_AWS_SECRET"}
+
 # Set envs for build
 GIT_VERSION=$(git rev-parse HEAD)
-export OPERATOR_IMAGE="gcr.io/coreos-k8s-scale-testing/etcd-operator:${GIT_VERSION}"
-export TEST_IMAGE=gcr.io/coreos-k8s-scale-testing/etcd-operator-e2e:${GIT_VERSION}
+export OPERATOR_IMAGE=${OPERATOR_IMAGE:-"gcr.io/coreos-k8s-scale-testing/etcd-operator:${GIT_VERSION}"}
+export TEST_IMAGE=${TEST_IMAGE:-"gcr.io/coreos-k8s-scale-testing/etcd-operator-e2e:${GIT_VERSION}"}
 
 echo "TEST_NAMESPACE: ${TEST_NAMESPACE}"
 echo "OPERATOR_IMAGE: ${OPERATOR_IMAGE}"
@@ -21,16 +26,33 @@ echo "TEST_IMAGE: ${TEST_IMAGE}"
 
 hack/ci/get_dep
 
-BUILD_IMAGE=${BUILD_IMAGE:-false}
+BUILD_IMAGE=${BUILD_IMAGE:-true}
 if [[ ${BUILD_IMAGE} == "true" ]]; then
+  gcloud docker -a
   hack/build/build
+  IMAGE=${OPERATOR_IMAGE} hack/build/docker_push
 fi
 
-BUILD_E2E=${BUILD_E2E:-false}
+BUILD_E2E=${BUILD_E2E:-true}
 if [[ ${BUILD_E2E} == "true" ]]; then
   gcloud docker -a
   hack/build/e2e/docker_push
 fi
+
+
+# Generate test-pod spec
+export TEST_POD_SPEC=${PWD}/test/pod/test-pod-spec.yaml
+export POD_NAME=${POD_NAME:-"e2e-testing"}
+export E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-""}
+
+sed -e "s|<POD_NAME>|${POD_NAME}|g" \
+    -e "s|<TEST_IMAGE>|${TEST_IMAGE}|g" \
+    -e "s|<PASSES>|${PASSES}|g" \
+    -e "s|<OPERATOR_IMAGE>|${OPERATOR_IMAGE}|g" \
+    -e "s|<E2E_TEST_SELECTOR>|${E2E_TEST_SELECTOR}|g" \
+    -e "s|<TEST_S3_BUCKET>|${TEST_S3_BUCKET}|g" \
+    -e "s|<TEST_AWS_SECRET>|${TEST_AWS_SECRET}|g" \
+    test/pod/test-pod.yaml > ${TEST_POD_SPEC}
 
 # Run test-pod
 PASSES=${PASSES} \

--- a/test/pod/run-test-pod
+++ b/test/pod/run-test-pod
@@ -6,21 +6,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-: ${TEST_IMAGE:?"Need to set TEST_IMAGE, e.g. gcr.io/coreos-k8s-scale-testing/etcd-operator-tests"}
 : ${TEST_NAMESPACE:?"Need to set TEST_NAMESPACE"}
-: ${TEST_S3_BUCKET:?"Need to set TEST_S3_BUCKET"}
-: ${TEST_AWS_SECRET:?"Need to set TEST_AWS_SECRET"}
+: ${POD_NAME:?"Need to set POD_NAME"}
 : ${KUBECONFIG:?"Need to set KUBECONFIG"}
-
-
-PASSES=${PASSES:-"e2e e2eslow"}
-OPERATOR_IMAGE=${OPERATOR_IMAGE:-"quay.io/coreos/etcd-operator:dev"}
-
-# Leave blank to run all tests
-# To run a particular test set to test name e.g: E2E_TEST_SELECTOR="CreateCluster"
-E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-""}
-
-POD_NAME=${POD_NAME:-"e2e-testing"}
+: ${TEST_POD_SPEC:?"Need to set TEST_POD_SPEC"}
 
 # Setup RBAC for the e2e tests
 source hack/ci/rbac_utils.sh
@@ -37,17 +26,8 @@ else
     exit 1
 fi
 
-# Run the test-pod in the given namespace
-sed -e "s|<POD_NAME>|${POD_NAME}|g" \
-    -e "s|<TEST_IMAGE>|${TEST_IMAGE}|g" \
-    -e "s|<PASSES>|${PASSES}|g" \
-    -e "s|<OPERATOR_IMAGE>|${OPERATOR_IMAGE}|g" \
-    -e "s|<E2E_TEST_SELECTOR>|${E2E_TEST_SELECTOR}|g" \
-    -e "s|<TEST_S3_BUCKET>|${TEST_S3_BUCKET}|g" \
-    -e "s|<TEST_AWS_SECRET>|${TEST_AWS_SECRET}|g" \
-    test/pod/test-pod.yaml \
-    | kubectl -n ${TEST_NAMESPACE} create -f -
 
+kubectl -n ${TEST_NAMESPACE} create -f ${TEST_POD_SPEC}
 
 PHASE_RUNNING="Running"
 PHASE_SUCCEEDED="Succeeded"


### PR DESCRIPTION
The test-pod spec is now generated from the template in `hack/ci/run2` and passed to `run-test-pod` to use.