### PR TITLE
*: support running upgrade tests in test-pod

### DIFF
--- a/hack/ci/run_e2e
+++ b/hack/ci/run_e2e
@@ -43,6 +43,10 @@ export TEST_POD_SPEC=${PWD}/test/pod/test-pod-spec.yaml
 export POD_NAME=${POD_NAME:-"e2e-testing"}
 export E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-""}
 
+export UPGRADE_TEST_SELECTOR=${UPGRADE_TEST_SELECTOR:-""}
+export UPGRADE_FROM=${UPGRADE_FROM:-"quay.io/coreos/etcd-operator:latest"}
+export UPGRADE_TO=${UPGRADE_TO:-"quay.io/coreos/etcd-operator:dev"}
+
 sed -e "s|<POD_NAME>|${POD_NAME}|g" \
   -e "s|<TEST_IMAGE>|${TEST_IMAGE}|g" \
     -e "s|<PASSES>|${PASSES}|g" \
@@ -50,6 +54,9 @@ sed -e "s|<POD_NAME>|${POD_NAME}|g" \
     -e "s|<E2E_TEST_SELECTOR>|${E2E_TEST_SELECTOR}|g" \
     -e "s|<TEST_S3_BUCKET>|${TEST_S3_BUCKET}|g" \
     -e "s|<TEST_AWS_SECRET>|${TEST_AWS_SECRET}|g" \
+    -e "s|<UPGRADE_TEST_SELECTOR>|${UPGRADE_TEST_SELECTOR}|g" \
+    -e "s|<UPGRADE_FROM>|${UPGRADE_FROM}|g" \
+    -e "s|<UPGRADE_TO>|${UPGRADE_TO}|g" \
     test/pod/test-pod-templ.yaml > ${TEST_POD_SPEC}
 
 # Run test-pod

--- a/test/pod/README.md
+++ b/test/pod/README.md
@@ -35,6 +35,8 @@ sed -e "s|<POD_NAME>|e2e-testing|g" \
     test/pod/test-pod-templ.yaml > test-pod-spec.yaml
 ```
 
+// TODO: Update for upgrade test env variables
+
 ## Run the test-pod
 
 The `run-test-pod` script sets up RBAC for the namespace, runs the logcollector and then the test-pod. The script waits until the test-pod has run to completion.

--- a/test/pod/test-pod-templ.yaml
+++ b/test/pod/test-pod-templ.yaml
@@ -29,3 +29,9 @@ spec:
         value: <TEST_AWS_SECRET>
       - name: PARALLEL_TEST
         value: "true"
+      - name: UPGRADE_TEST_SELECTOR
+        value: <UPGRADE_TEST_SELECTOR>
+      - name: UPGRADE_FROM
+        value: <UPGRADE_FROM>
+      - name: UPGRADE_TO
+        value: <UPGRADE_TO>


### PR DESCRIPTION
@hongchaodeng PTAL

Already tested the upgrade tests against my own branch
https://jenkins-etcd.prod.coreos.systems/view/operator/job/etcd-operator-upgrade/243/console

Forgot to archive the logs for that run. Update the jenkins job to archive the logs now.