### PR TITLE
e2e: use default etcd version when creating NewEtcdRestore

### DIFF
--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -165,7 +165,7 @@ func testEtcdRestoreOperatorForS3Source(t *testing.T, s3Path string) {
 	}()
 
 	restoreSource := api.RestoreSource{S3: e2eutil.NewS3RestoreSource(s3Path, os.Getenv("TEST_AWS_SECRET"))}
-	er := e2eutil.NewEtcdRestore("", "3.2.11", 3, restoreSource)
+	er := e2eutil.NewEtcdRestore("", 3, restoreSource)
 	er.Name = clusterName
 	e2eutil.RestoreCRWithTLS(er, memberPeerTLSSecret, memberClientTLSSecret, operatorClientTLSSecret)
 	er, err = f.CRClient.EtcdV1beta2().EtcdRestores(f.Namespace).Create(er)

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -68,7 +68,7 @@ func NewS3RestoreSource(path, awsSecret string) *api.S3RestoreSource {
 }
 
 // NewEtcdRestore returns an EtcdRestore CR with the specified RestoreSource
-func NewEtcdRestore(restoreName, version string, size int, restoreSource api.RestoreSource) *api.EtcdRestore {
+func NewEtcdRestore(restoreName string, size int, restoreSource api.RestoreSource) *api.EtcdRestore {
 	return &api.EtcdRestore{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       api.EtcdRestoreResourceKind,
@@ -81,7 +81,6 @@ func NewEtcdRestore(restoreName, version string, size int, restoreSource api.Res
 			ClusterSpec: api.ClusterSpec{
 				Repository: "quay.io/coreos/etcd",
 				Size:       size,
-				Version:    version,
 			},
 			RestoreSource: restoreSource,
 		},


### PR DESCRIPTION
NewEtcdRestore now use a default etcd verison instead of having a parameter to indicate etcd version. 