### PR TITLE
*: use pod readiness check to update member status

### DIFF
--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -57,8 +57,9 @@ func etcdContainer(cmd []string, repo, version string) v1.Container {
 	return c
 }
 
-func containerWithLivenessProbe(c v1.Container, lp *v1.Probe) v1.Container {
+func containerWithProbes(c v1.Container, lp *v1.Probe, rp *v1.Probe) v1.Container {
 	c.LivenessProbe = lp
+	c.ReadinessProbe = rp
 	return c
 }
 
@@ -67,7 +68,7 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 	return c
 }
 
-func etcdLivenessProbe(isSecure bool) *v1.Probe {
+func newEtcdProbe(isSecure bool) *v1.Probe {
 	// etcd pod is alive only if a linearizable get succeeds.
 	cmd := "ETCDCTL_API=3 etcdctl get foo"
 	if isSecure {


### PR DESCRIPTION
ref #1320 

Added readiness probe to etcd pod. It's the same as the liveliness probe but the time period for readiness is 10s, shorter than the liveliness 60s.

The operator now checks if all member pods are Ready while updating the member status for ready/unready members.

