### PR TITLE
cmd: add parse() to parse flags in etcd backup operator

### DIFF
--- a/cmd/backup-operator/main.go
+++ b/cmd/backup-operator/main.go
@@ -42,6 +42,7 @@ var (
 
 func init() {
 	flag.BoolVar(&createCRD, "create-crd", true, "The backup operator will not create the EtcdBackup CRD when this flag is set to false.")
+	flag.Parse()
 }
 
 func main() {


### PR DESCRIPTION
add parse() to parse flags.