### PR TITLE
apis: add EtcdVersion and EtcdRevision to BackupCRStatus

### DIFF
--- a/pkg/apis/etcd/v1beta2/backup_types.go
+++ b/pkg/apis/etcd/v1beta2/backup_types.go
@@ -79,6 +79,10 @@ type BackupCRStatus struct {
 	Succeeded bool `json:"succeeded"`
 	// Reason indicates the reason for any backup related failures.
 	Reason string `json:"Reason,omitempty"`
+	// EtcdVersion is the version of the backup etcd server.
+	EtcdVersion string `json:"etcdVersion,omitempty"`
+	// EtcdRevision is the revision of etcd's KV store where the backup is performed on.
+	EtcdRevision string `json:"etcdRevision,omitempty"`
 }
 
 // S3BackupSource provides the spec how to store backups on S3.


### PR DESCRIPTION
add  EtcdVersion and EtcdRevision to BackupCRStatus to give the backup snapshot information
about the etcd server version that snapshot is based on and what revision of kv store that snapshot contains. 