### PR TITLE
*: remove namespace from EtcdClusterRef

### DIFF
--- a/example/etcd-restore-operator/restore_cr.yaml
+++ b/example/etcd-restore-operator/restore_cr.yaml
@@ -6,8 +6,7 @@ metadata:
 spec:
   etcdCluster:
     name: example-etcd-cluster
-    # Optional, defaults to the restore-operator namespace
-    namespace: <namespace>
+    # The namespace will be the same as the restore-operator namespace
   s3:
     # The format of "path" must be: "<s3-bucket-name>/<path-to-backup-file>"
     # e.g: "etcd-snapshot-bucket/v1/default/example-etcd-cluster/3.2.11_0000000000000001_etcd.backup"

--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -53,10 +53,8 @@ type RestoreSpec struct {
 // and to be restored.
 type EtcdClusterRef struct {
 	// Name is the EtcdCluster resource name.
+	// This reference EtcdCluster must be present in the same namespace as the restore-operator
 	Name string `json:"name"`
-	// Namespace is the EtcdCluster resource namespace.
-	// If not set, it defaults to the same namespace as the EtcdRestore resource.
-	Namespace string `json:"namespace,omitempty"`
 }
 
 type RestoreSource struct {

--- a/pkg/controller/restore-operator/sync.go
+++ b/pkg/controller/restore-operator/sync.go
@@ -148,22 +148,18 @@ func (r *Restore) prepareSeed(er *api.EtcdRestore) (err error) {
 
 	// Fetch the reference EtcdCluster
 	ecRef := er.Spec.EtcdCluster
-	// Default to using restore-operator namespace
-	if len(ecRef.Namespace) == 0 {
-		ecRef.Namespace = r.namespace
-	}
-	ec, err := r.etcdCRCli.EtcdV1beta2().EtcdClusters(ecRef.Namespace).Get(ecRef.Name, metav1.GetOptions{})
+	ec, err := r.etcdCRCli.EtcdV1beta2().EtcdClusters(r.namespace).Get(ecRef.Name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get reference EtcdCluster(%s/%s): %v", ecRef.Namespace, ecRef.Name, err)
+		return fmt.Errorf("failed to get reference EtcdCluster(%s/%s): %v", r.namespace, ecRef.Name, err)
 	}
 	if err := ec.Spec.Validate(); err != nil {
 		return fmt.Errorf("invalid cluster spec: %v", err)
 	}
 
 	// Delete reference EtcdCluster
-	err = r.etcdCRCli.EtcdV1beta2().EtcdClusters(ecRef.Namespace).Delete(ecRef.Name, &metav1.DeleteOptions{})
+	err = r.etcdCRCli.EtcdV1beta2().EtcdClusters(r.namespace).Delete(ecRef.Name, &metav1.DeleteOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to delete reference EtcdCluster (%s/%s): %v", ecRef.Namespace, ecRef.Name, err)
+		return fmt.Errorf("failed to delete reference EtcdCluster (%s/%s): %v", r.namespace, ecRef.Name, err)
 	}
 	// TODO: Find a better way to ensure all pods and services from reference EtcdCluster are completely deleted
 	time.Sleep(10 * time.Second)

--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -179,8 +179,7 @@ func testEtcdRestoreOperatorForS3Source(t *testing.T, clusterName, s3Path string
 	f := framework.Global
 
 	restoreSource := api.RestoreSource{S3: e2eutil.NewS3RestoreSource(s3Path, os.Getenv("TEST_AWS_SECRET"))}
-	er := e2eutil.NewEtcdRestore(clusterName, f.Namespace, 3, restoreSource)
-	er.Name = clusterName
+	er := e2eutil.NewEtcdRestore(clusterName, 3, restoreSource)
 	er, err := f.CRClient.EtcdV1beta2().EtcdRestores(f.Namespace).Create(er)
 	if err != nil {
 		t.Fatalf("failed to create etcd restore cr: %v", err)

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -68,7 +68,7 @@ func NewS3RestoreSource(path, awsSecret string) *api.S3RestoreSource {
 }
 
 // NewEtcdRestore returns an EtcdRestore CR with the specified RestoreSource
-func NewEtcdRestore(clusterName, clusterNamespace string, size int, restoreSource api.RestoreSource) *api.EtcdRestore {
+func NewEtcdRestore(clusterName string, size int, restoreSource api.RestoreSource) *api.EtcdRestore {
 	return &api.EtcdRestore{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       api.EtcdRestoreResourceKind,
@@ -80,8 +80,7 @@ func NewEtcdRestore(clusterName, clusterNamespace string, size int, restoreSourc
 		},
 		Spec: api.RestoreSpec{
 			EtcdCluster: api.EtcdClusterRef{
-				Name:      clusterName,
-				Namespace: clusterNamespace,
+				Name: clusterName,
 			},
 			RestoreSource: restoreSource,
 		},


### PR DESCRIPTION
ref: #1770 

Part 1/2 of #1785 

`EtcdClusterRef` has been simplified by removing the namespace field. The namespace for the reference cluster is always assumed to be the same namespace as the restore-operator.

Support for restoring from an EtcdCluster in a different namespace can be added later.

/cc @hongchaodeng 