### PR TITLE
*: restore-operator deletes EtcdClusterRef completely

### DIFF
--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -44,13 +44,17 @@ type RestoreSpec struct {
 	BackupStorageType string `json:"backupStorageType"`
 	// RestoreSource tells the where to get the backup and restore from.
 	RestoreSource `json:",inline"`
-	// EtcdCluster references an EtcdCluster resource which should have "Failed" status.phase
-	// and to be restored.
+	// EtcdCluster references an EtcdCluster resource whose metadata and spec
+	// will be used to create the new restored EtcdCluster CR.
+	// This reference EtcdCluster CR and all its resources will be deleted before the
+	// restored EtcdCluster CR is created.
 	EtcdCluster EtcdClusterRef `json:"etcdCluster"`
 }
 
-// EtcdClusterRef references the EtcdCluster which should have "Failed" status.phase
-// and to be restored.
+// EtcdCluster references an EtcdCluster resource whose metadata and spec
+// will be used to create the new restored EtcdCluster CR.
+// This reference EtcdCluster CR and all its resources will be deleted before the
+// restored EtcdCluster CR is created.
 type EtcdClusterRef struct {
 	// Name is the EtcdCluster resource name.
 	// This reference EtcdCluster must be present in the same namespace as the restore-operator

--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -82,9 +82,6 @@ func TestBackupAndRestore(t *testing.T) {
 	s3Path := path.Join(os.Getenv("TEST_S3_BUCKET"), "jenkins", suffix, time.Now().Format(time.RFC3339), "etcd.backup")
 
 	testEtcdBackupOperatorForS3Backup(t, clusterName, operatorClientTLSSecret, s3Path)
-	// Delete the cluster pods so that the restore-operator can create a seed member with the same name
-	// The services need to be deleted as well to avoid relying on GC to delete them in time
-	deleteClusterPodsAndService(t, clusterName)
 	testEtcdRestoreOperatorForS3Source(t, clusterName, s3Path)
 }
 
@@ -191,8 +188,8 @@ func testEtcdRestoreOperatorForS3Source(t *testing.T, clusterName, s3Path string
 	}()
 
 	// Verify the EtcdRestore CR status "succeeded=true". In practice the time taken to update is 1 second.
-	// Note: The restore-operator currently waits 10 seconds after deleting the EtcdClusterRef so the timeout should account for that
-	err = retryutil.Retry(10*time.Second, 3, func() (bool, error) {
+	// Note: The restore-operator currently waits 60 seconds after deleting the EtcdClusterRef so the timeout should account for that
+	err = retryutil.Retry(10*time.Second, 7, func() (bool, error) {
 		er, err := f.CRClient.EtcdV1beta2().EtcdRestores(f.Namespace).Get(er.Name, metav1.GetOptions{})
 		if err != nil {
 			return false, fmt.Errorf("failed to retrieve restore CR: %v", err)
@@ -220,39 +217,5 @@ func testEtcdRestoreOperatorForS3Source(t *testing.T, clusterName, s3Path string
 	}
 	if _, err := e2eutil.WaitUntilSizeReached(t, f.CRClient, 3, 6, restoredCluster); err != nil {
 		t.Fatalf("failed to see restored etcd cluster(%v) reach 3 members: %v", restoredCluster.Name, err)
-	}
-}
-
-func deleteClusterPodsAndService(t *testing.T, clusterName string) {
-	f := framework.Global
-
-	// Delete etcd pods
-	err := f.KubeClient.Core().Pods(f.Namespace).DeleteCollection(metav1.NewDeleteOptions(1), k8sutil.ClusterListOpt(clusterName))
-	if err != nil {
-		t.Fatalf("failed to delete cluster pods: %v", err)
-	}
-
-	// Delete services
-	srvs, err := f.KubeClient.Core().Services(f.Namespace).List(k8sutil.ClusterListOpt(clusterName))
-	if err != nil {
-		t.Fatalf("failed to list cluster services: %v", err)
-	}
-	for _, srv := range srvs.Items {
-		err = f.KubeClient.Core().Services(f.Namespace).Delete(srv.GetName(), nil)
-		if err != nil {
-			t.Fatalf("failed to delete cluster service(%v): %v", srv.GetName(), err)
-		}
-	}
-
-	// Wait until pods are completely removed
-	err = retryutil.Retry(10*time.Second, 6, func() (bool, error) {
-		podList, err := f.KubeClient.Core().Pods(f.Namespace).List(k8sutil.ClusterListOpt(clusterName))
-		if err != nil {
-			return false, fmt.Errorf("failed to list running pods: %v", err)
-		}
-		return len(podList.Items) == 0, nil
-	})
-	if err != nil {
-		t.Fatalf("failed to see all etcd pods deleted for cluster(%v): %v", clusterName, err)
 	}
 }


### PR DESCRIPTION
ref: #1770

Part 2/2 of #1785

The restore-operator will now delete the reference EtcdCluster and its pods and services completely before creating the restored EtcdCluster.
With this change, the e2e test no longer needs to clean up the pods and services of the reference cluster first.

/cc @hongchaodeng 