### PR TITLE
*: etcd backup operator updates EtcdVersion and EtcdRevision in BackupStatus

### DIFF
--- a/pkg/apis/etcd/v1beta2/backup_types.go
+++ b/pkg/apis/etcd/v1beta2/backup_types.go
@@ -82,7 +82,7 @@ type BackupStatus struct {
 	// EtcdVersion is the version of the backup etcd server.
 	EtcdVersion string `json:"etcdVersion,omitempty"`
 	// EtcdRevision is the revision of etcd's KV store where the backup is performed on.
-	EtcdRevision string `json:"etcdRevision,omitempty"`
+	EtcdRevision int64 `json:"etcdRevision,omitempty"`
 }
 
 // S3BackupSource provides the spec how to store backups on S3.

--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -159,7 +159,10 @@ func testEtcdBackupOperatorForS3Backup(t *testing.T, clusterName, operatorClient
 			return false, fmt.Errorf("failed to retrieve backup CR: %v", err)
 		}
 		if reb.Status.Succeeded {
-			return true, nil
+			if reb.Status.EtcdVersion == "3.2.11" && reb.Status.EtcdRevision == 1 {
+				return true, nil
+			}
+			return false, fmt.Errorf("expect EtcdVersion==3.2.11 and EtcdRevision==1, but got EtcdVersion==%v and EtcdRevision==%v", reb.Status.EtcdVersion, reb.Status.EtcdRevision)
 		}
 		if len(reb.Status.Reason) != 0 {
 			return false, fmt.Errorf("backup failed with reason: %v ", reb.Status.Reason)


### PR DESCRIPTION
ref: https://github.com/coreos/etcd-operator/issues/1763

etcd backup operator now writes EtcdVersion and EtcdRevision into BackupStatus when performing an successful backup. 