### PR TITLE
*: validate BackupStorageType in restore operator

### DIFF
--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -40,8 +40,7 @@ type EtcdRestore struct {
 // RestoreSpec defines how to restore an etcd cluster from existing backup.
 type RestoreSpec struct {
 	// BackupStorageType is the type of the backup storage which is used as RestoreSource.
-	// TODO: implement me.
-	BackupStorageType string `json:"backupStorageType"`
+	BackupStorageType BackupStorageType `json:"backupStorageType"`
 	// RestoreSource tells the where to get the backup and restore from.
 	RestoreSource `json:",inline"`
 	// EtcdCluster references an EtcdCluster resource whose metadata and spec

--- a/test/e2e/backup_test.go
+++ b/test/e2e/backup_test.go
@@ -179,7 +179,7 @@ func testEtcdRestoreOperatorForS3Source(t *testing.T, clusterName, s3Path string
 	f := framework.Global
 
 	restoreSource := api.RestoreSource{S3: e2eutil.NewS3RestoreSource(s3Path, os.Getenv("TEST_AWS_SECRET"))}
-	er := e2eutil.NewEtcdRestore(clusterName, 3, restoreSource)
+	er := e2eutil.NewEtcdRestore(clusterName, 3, restoreSource, api.BackupStorageTypeS3)
 	er, err := f.CRClient.EtcdV1beta2().EtcdRestores(f.Namespace).Create(er)
 	if err != nil {
 		t.Fatalf("failed to create etcd restore cr: %v", err)

--- a/test/e2e/e2eutil/spec_util.go
+++ b/test/e2e/e2eutil/spec_util.go
@@ -68,7 +68,7 @@ func NewS3RestoreSource(path, awsSecret string) *api.S3RestoreSource {
 }
 
 // NewEtcdRestore returns an EtcdRestore CR with the specified RestoreSource
-func NewEtcdRestore(clusterName string, size int, restoreSource api.RestoreSource) *api.EtcdRestore {
+func NewEtcdRestore(clusterName string, size int, restoreSource api.RestoreSource, backupStorageType api.BackupStorageType) *api.EtcdRestore {
 	return &api.EtcdRestore{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       api.EtcdRestoreResourceKind,
@@ -82,7 +82,8 @@ func NewEtcdRestore(clusterName string, size int, restoreSource api.RestoreSourc
 			EtcdCluster: api.EtcdClusterRef{
 				Name: clusterName,
 			},
-			RestoreSource: restoreSource,
+			BackupStorageType: backupStorageType,
+			RestoreSource:     restoreSource,
 		},
 	}
 }


### PR DESCRIPTION
ref: https://github.com/coreos/etcd-operator/issues/1763

When RestoreSpec specifies  backupStorageType, restore operator needs to check if backupStorageType matches the RestoreSource.