### PR TITLE
test/container: run e2e tests from container

### DIFF
--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,0 +1,17 @@
+# golang:1.9-alpine can't be used since it does not support the race detector flag which assumes a glibc based system, whereas alpine linux uses musl libc
+# https://github.com/golang/go/issues/14481
+FROM golang:1.9
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.8.2/bin/linux/amd64/kubectl \
+    && chmod +x ./kubectl \
+    && mv ./kubectl /usr/local/bin/kubectl
+
+ADD ./ /go/src/github.com/coreos/etcd-operator
+
+ADD ./_test/aws /aws
+
+WORKDIR /go/src/github.com/coreos/etcd-operator
+
+RUN rm -rf _output _test .git .gitignore
+
+ENTRYPOINT ["./test/container/run"]

--- a/test/container/docker_push
+++ b/test/container/docker_push
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This script builds and pushes the test-container image
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if ! which docker > /dev/null; then
+	echo "docker needs to be installed"
+	exit 1
+fi
+
+: ${TEST_IMAGE:?"Need to set TEST_IMAGE"}
+
+echo "building test-container image..."
+docker build --tag "${TEST_IMAGE}" -f test/container/Dockerfile . 1>/dev/null
+
+# For gcr users, do "gcloud docker -a" to have access.
+echo "pushing test-container image..."
+docker push "${TEST_IMAGE}" 1>/dev/null

--- a/test/container/run
+++ b/test/container/run
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+
+: ${KUBECONFIG:?"Need to set KUBECONFIG"}
+
+export OPERATOR_IMAGE="quay.io/coreos/etcd-operator:dev"
+
+# Create test namespace
+export TEST_NAMESPACE=$(cat <<EOF | kubectl create -f - | awk '{print $2}' | tr -d '"'
+apiVersion: v1
+kind: Namespace
+metadata:
+  generateName: etcd-operator-test-
+EOF
+)
+
+echo "TEST_NAMESPACE: ${TEST_NAMESPACE}"
+echo "OPERATOR_IMAGE: ${OPERATOR_IMAGE}"
+
+export TEST_AWS_SECRET="aws"
+AWS_DIR=${AWS_DIR:-"/aws"}
+
+source hack/ci/rbac_utils.sh
+# Cleanup namespace and rbac
+function finish {
+	kubectl delete namespace $TEST_NAMESPACE || :
+	rbac_cleanup || :
+}
+trap finish EXIT
+
+# Setup rbac
+if rbac_setup ; then
+    echo "RBAC setup success! ==="
+else
+    echo "RBAC setup fail! ==="
+    exit 1
+fi
+
+# Create aws secret
+kubectl -n $TEST_NAMESPACE create secret generic $TEST_AWS_SECRET --from-file=$AWS_DIR/credentials --from-file=$AWS_DIR/config
+
+# Run e2e tests
+export PASSES="e2e e2eslow"
+export TEST_S3_BUCKET="jenkins-testing-operator"
+
+# TODO: stdout not being redirected to file
+# hack/test >/out/e2e-testing.log 2>&1
+hack/test


### PR DESCRIPTION
[skip ci]

The test-container minimizes the dependencies needed to run the e2e tests.

After building the image `TEST_IMAGE` the test-container can be run as:

```sh
docker run -e "KUBECONFIG=/kubeconfig" \
-v "/path/to/local/kubeconfig:/kubeconfig" \
$TEST_IMAGE
```

There is some issue with redirecting the stdout/stderr to a file that can be resolved later.