### PR TITLE
test: reorg test suites

### DIFF
--- a/test/container/run
+++ b/test/container/run
@@ -3,7 +3,7 @@
 set -o errexit
 set -o pipefail
 
-: ${KUBECONFIG:?"Need to set KUBECONFIG"}
+KUBECONFIG=${KUBECONFIG:-"/kubeconfig"}
 
 export OPERATOR_IMAGE="quay.io/coreos/etcd-operator:dev"
 


### PR DESCRIPTION
- move tls_test to parallel e2e
- move backup_test.go to e2eslow/backup_restore_test.go

Discussed this with @hasbro17 before.