### PR TITLE
test: reorg test suites

### DIFF
--- a/test/e2e/e2eslow/backup_restore_test.go
+++ b/test/e2e/e2eslow/backup_restore_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package e2e
+package e2eslow
 
 import (
 	"errors"
@@ -42,9 +42,6 @@ func init() {
 
 // TestBackupAndRestore runs the backup test first, and only runs the restore test after if the backup test succeeds and sets the S3 path
 func TestBackupAndRestore(t *testing.T) {
-	if os.Getenv(envParallelTest) == envParallelTestTrue {
-		t.Parallel()
-	}
 	if err := verifyAWSEnvVars(); err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package e2eslow
+package e2e
 
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"testing"
 	"time"
 
@@ -29,6 +30,9 @@ func init() {
 }
 
 func TestTLS(t *testing.T) {
+	if os.Getenv(envParallelTest) == envParallelTestTrue {
+		t.Parallel()
+	}
 	f := framework.Global
 	suffix := fmt.Sprintf("-%d", rand.Uint64())
 	clusterName := "tls-test" + suffix


### PR DESCRIPTION
- move tls_test to parallel e2e
- move backup_test.go to e2eslow/backup_restore_test.go