### PR TITLE
hack/run_e2e: support skipping tests

### DIFF
--- a/hack/ci/run_e2e
+++ b/hack/ci/run_e2e
@@ -10,7 +10,6 @@ export PATH=$GOROOT/bin:$PATH
 go version
 kubectl version
 
-: ${PASSES:?"Need to set PASSES"}
 : ${TEST_NAMESPACE:?"Need to set TEST_NAMESPACE"}
 : ${TEST_S3_BUCKET:?"Need to set TEST_S3_BUCKET"}
 : ${TEST_AWS_SECRET:?"Need to set TEST_AWS_SECRET"}
@@ -38,6 +37,11 @@ if [[ ${BUILD_E2E} == "true" ]]; then
   TEST_IMAGE=${TEST_IMAGE:-"gcr.io/coreos-k8s-scale-testing/etcd-operator-e2e:${GIT_VERSION}"}
   gcloud docker -a
   TEST_IMAGE=${TEST_IMAGE} hack/build/e2e/docker_push
+fi
+
+if [ -z "${PASSES-}" ]; then
+  echo "No PASSES specified. Skipping tests"
+  exit 0
 fi
 
 echo "TEST_NAMESPACE: ${TEST_NAMESPACE}"

--- a/hack/test
+++ b/hack/test
@@ -10,7 +10,7 @@ source "hack/lib/test_lib.sh"
 KUBECONFIG=${KUBECONFIG:-""}
 
 if [ -z "${PASSES-}" ]; then
-	PASSES="fmt build e2e e2eslow unit"
+	PASSES="fmt e2e e2eslow unit"
 fi
 
 function fmt_pass {


### PR DESCRIPTION
With `PASSES=""` hack/run_e2e can be used to skip tests and only build images.