### PR TITLE
*: bump etcd verison to 3.2.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+- Default base image is changed to `gcr.io/etcd-development/etcd`, default etcd version is `3.2.13`.
+
 ### Removed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ See the [Resources and Labels](./doc/user/resource_labels.md) doc for an overvie
 ## Requirements
 
 - Kubernetes 1.8+
-- etcd 3.2.11+
+- etcd 3.2.13+
 
 ## Demo
 
@@ -101,7 +101,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 5
-  version: "3.2.11"
+  version: "3.2.13"
 ```
 
 Apply the size change to the cluster CR:
@@ -129,7 +129,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "3.2.11"
+  version: "3.2.13"
 ```
 ```
 $ kubectl apply -f example/example-etcd-cluster.yaml
@@ -243,7 +243,7 @@ $ kubectl get pod example-etcd-cluster-0000 -o yaml | grep "image:" | uniq
     image: quay.io/coreos/etcd:v3.1.10
 ```
 
-Now modify the file `upgrade-example` and change the `version` from 3.1.10 to 3.2.11:
+Now modify the file `upgrade-example` and change the `version` from 3.1.10 to 3.2.13:
 
 ```
 $ cat upgrade-example
@@ -253,7 +253,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "3.2.11"
+  version: "3.2.13"
 ```
 
 Apply the version change to the cluster CR:
@@ -262,11 +262,11 @@ Apply the version change to the cluster CR:
 $ kubectl apply -f upgrade-example
 ```
 
-Wait ~30 seconds. The container image version should be updated to v3.2.11:
+Wait ~30 seconds. The container image version should be updated to v3.2.13:
 
 ```
 $ kubectl get pod example-etcd-cluster-0000 -o yaml | grep "image:" | uniq
-    image: gcr.io/etcd-development/etcd:v3.2.11
+    image: gcr.io/etcd-development/etcd:v3.2.13
 ```
 
 Check the other two pods and you should see the same result.

--- a/doc/user/spec_examples.md
+++ b/doc/user/spec_examples.md
@@ -14,7 +14,7 @@ This will use the default version chosen by the etcd-operator.
 ```yaml
 spec:
   size: 3
-  version: "3.2.11"
+  version: "3.2.13"
 ```
 
 ## Three member cluster with node selector and anti-affinity across nodes

--- a/doc/user/walkthrough/backup-operator.md
+++ b/doc/user/walkthrough/backup-operator.md
@@ -81,7 +81,7 @@ kind: EtcdBackup
 ...
 status:
   etcdRevision: 1
-  etcdVersion: 3.2.11
+  etcdVersion: 3.2.13
   succeeded: true
 ```
 

--- a/example/example-etcd-cluster.yaml
+++ b/example/example-etcd-cluster.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "3.2.11"
+  version: "3.2.13"

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	defaultRepository = "quay.io/coreos/etcd"
-	defaultVersion    = "3.2.11"
+	defaultRepository  = "quay.io/coreos/etcd"
+	DefaultEtcdVersion = "3.2.13"
 )
 
 var (
@@ -89,7 +89,7 @@ type ClusterSpec struct {
 	// The version must follow the [semver]( http://semver.org) format, for example "3.2.11".
 	// Only etcd released versions are supported: https://github.com/coreos/etcd/releases
 	//
-	// If version is not set, default is "3.2.11".
+	// If version is not set, default is "3.2.13".
 	Version string `json:"version,omitempty"`
 
 	// Paused is to pause the control of the operator for the etcd cluster.
@@ -173,7 +173,7 @@ func (e *EtcdCluster) SetDefaults() {
 	}
 
 	if len(c.Version) == 0 {
-		c.Version = defaultVersion
+		c.Version = DefaultEtcdVersion
 	}
 
 	c.Version = strings.TrimLeft(c.Version, "v")

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -86,7 +86,7 @@ type ClusterSpec struct {
 	// The etcd-operator will eventually make the etcd cluster version
 	// equal to the expected version.
 	//
-	// The version must follow the [semver]( http://semver.org) format, for example "3.2.11".
+	// The version must follow the [semver]( http://semver.org) format, for example "3.2.13".
 	// Only etcd released versions are supported: https://github.com/coreos/etcd/releases
 	//
 	// If version is not set, default is "3.2.13".

--- a/test/e2e/basic_test.go
+++ b/test/e2e/basic_test.go
@@ -125,7 +125,7 @@ func TestEtcdUpgrade(t *testing.T) {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
 
-	targetVersion := "3.2.11"
+	targetVersion := "3.2.13"
 	updateFunc := func(cl *api.EtcdCluster) {
 		cl = e2eutil.ClusterWithVersion(cl, targetVersion)
 	}

--- a/test/e2e/e2esh/self_hosted_test.go
+++ b/test/e2e/e2esh/self_hosted_test.go
@@ -85,7 +85,7 @@ func startEtcd(f *framework.Framework) (*v1.Pod, error) {
 			Containers: []v1.Container{{
 				Command: []string{"/bin/sh", "-ec", etcdCmd},
 				Name:    "etcd",
-				Image:   "quay.io/coreos/etcd:v3.2.11",
+				Image:   "quay.io/coreos/etcd:v3.2.13",
 				Env: []v1.EnvVar{{
 					Name:      "POD_NAME",
 					ValueFrom: &v1.EnvVarSource{FieldRef: &v1.ObjectFieldSelector{FieldPath: "metadata.name"}},

--- a/test/e2e/e2eslow/backup_restore_test.go
+++ b/test/e2e/e2eslow/backup_restore_test.go
@@ -156,10 +156,10 @@ func testEtcdBackupOperatorForS3Backup(t *testing.T, clusterName, operatorClient
 			return false, fmt.Errorf("failed to retrieve backup CR: %v", err)
 		}
 		if reb.Status.Succeeded {
-			if reb.Status.EtcdVersion == "3.2.11" && reb.Status.EtcdRevision == 1 {
+			if reb.Status.EtcdVersion == api.DefaultEtcdVersion && reb.Status.EtcdRevision == 1 {
 				return true, nil
 			}
-			return false, fmt.Errorf("expect EtcdVersion==3.2.11 and EtcdRevision==1, but got EtcdVersion==%v and EtcdRevision==%v", reb.Status.EtcdVersion, reb.Status.EtcdRevision)
+			return false, fmt.Errorf("expect EtcdVersion==%v and EtcdRevision==1, but got EtcdVersion==%v and EtcdRevision==%v", api.DefaultEtcdVersion, reb.Status.EtcdVersion, reb.Status.EtcdRevision)
 		}
 		if len(reb.Status.Reason) != 0 {
 			return false, fmt.Errorf("backup failed with reason: %v ", reb.Status.Reason)


### PR DESCRIPTION
bump etcd version to 3.2.13 in many places.
exposed DefaultVersion allowing backup_restore_test.go to use it to compare 
backup status with the default etcd version.

fixes #1813