### PR TITLE
[WIP] e2e: increase wait retries for etcd restore cluster

### DIFF
--- a/test/e2e/e2eslow/backup_restore_test.go
+++ b/test/e2e/e2eslow/backup_restore_test.go
@@ -216,7 +216,7 @@ func testEtcdRestoreOperatorForS3Source(t *testing.T, clusterName, s3Path string
 			Size: 3,
 		},
 	}
-	if _, err := e2eutil.WaitUntilSizeReached(t, f.CRClient, 3, 6, restoredCluster); err != nil {
+	if _, err := e2eutil.WaitUntilSizeReached(t, f.CRClient, 3, 12, restoredCluster); err != nil {
 		t.Fatalf("failed to see restored etcd cluster(%v) reach 3 members: %v", restoredCluster.Name, err)
 	}
 }


### PR DESCRIPTION
local testing show that's restoring cluster came up too slowly. so the retry failed before cluster was able to complete. Increase the retry rate gives restoring etcd cluster more time to come up.
 
fixes #1825
  