### PR TITLE
*DON'T MERGE* e2e: don't delete resource

### DIFF
--- a/test/e2e/e2eslow/backup_restore_test.go
+++ b/test/e2e/e2eslow/backup_restore_test.go
@@ -67,11 +67,11 @@ func TestBackupAndRestore(t *testing.T) {
 	c.Name = clusterName
 	e2eutil.ClusterCRWithTLS(c, memberPeerTLSSecret, memberClientTLSSecret, operatorClientTLSSecret)
 	testEtcd, err := e2eutil.CreateCluster(t, f.CRClient, f.Namespace, c)
-	defer func() {
-		if err := e2eutil.DeleteCluster(t, f.CRClient, f.KubeClient, testEtcd); err != nil {
-			t.Fatal(err)
-		}
-	}()
+	// defer func() {
+	// 	if err := e2eutil.DeleteCluster(t, f.CRClient, f.KubeClient, testEtcd); err != nil {
+	// 		t.Fatal(err)
+	// 	}
+	// }()
 	if _, err := e2eutil.WaitUntilSizeReached(t, f.CRClient, 3, 6, testEtcd); err != nil {
 		t.Fatalf("failed to create 3 members etcd cluster: %v", err)
 	}
@@ -182,11 +182,11 @@ func testEtcdRestoreOperatorForS3Source(t *testing.T, clusterName, s3Path string
 	if err != nil {
 		t.Fatalf("failed to create etcd restore cr: %v", err)
 	}
-	defer func() {
-		if err := f.CRClient.EtcdV1beta2().EtcdRestores(f.Namespace).Delete(er.Name, nil); err != nil {
-			t.Fatalf("failed to delete etcd restore cr: %v", err)
-		}
-	}()
+	// defer func() {
+	// 	if err := f.CRClient.EtcdV1beta2().EtcdRestores(f.Namespace).Delete(er.Name, nil); err != nil {
+	// 		t.Fatalf("failed to delete etcd restore cr: %v", err)
+	// 	}
+	// }()
 
 	// Verify the EtcdRestore CR status "succeeded=true". In practice the time taken to update is 1 second.
 	// Note: The restore-operator currently waits 60 seconds after deleting the EtcdClusterRef so the timeout should account for that

--- a/test/e2e/framework/main_entry.go
+++ b/test/e2e/framework/main_entry.go
@@ -29,9 +29,9 @@ func MainEntry(m *testing.M) {
 
 	code := m.Run()
 
-	if err := teardown(); err != nil {
-		logrus.Errorf("fail to teardown framework: %v", err)
-		os.Exit(1)
-	}
+	// if err := teardown(); err != nil {
+	// 	logrus.Errorf("fail to teardown framework: %v", err)
+	// 	os.Exit(1)
+	// }
 	os.Exit(code)
 }


### PR DESCRIPTION
debugging TestBackupAndRestore flake.

Currently, with this change, local test always fail due to second member can't verify seed member's ip. Error:
```
2018-01-12 23:13:04.413761 I | etcdmain: rejected connection from "172.17.0.5:56888" (error "tls: \"172.17.0.5\" does not match any of DNSNames [\"*.test-etcd-backup-restore-7029314227233146219.e2e-1.svc\" \"*.test-etcd-backup-restore-7029314227233146219.e2e-1.svc.cluster.local\"] (lookup 5.0.17.172.in-addr.arpa. on 10.96.0.10:53: no such host)", ServerName "test-etcd-backup-restore-7029314227233146219-0001.test-etcd-backup-restore-7029314227233146219.e2e-1.svc", IPAddresses [], DNSNames ["*.test-etcd-backup-restore-7029314227233146219.e2e-1.svc" "*.test-etcd-backup-restore-7029314227233146219.e2e-1.svc.cluster.local"])
```

[skip ci]