### PR TITLE
k8sutil: run etcd pods as non-root user

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -292,6 +292,9 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 		}})
 	}
 
+	runAsNonRoot := true
+	podUID := int64(9000)
+	fsGroup := podUID
 	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        m.Name,
@@ -319,6 +322,11 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 			Hostname:                     m.Name,
 			Subdomain:                    clusterName,
 			AutomountServiceAccountToken: func(b bool) *bool { return &b }(false),
+			SecurityContext: &v1.PodSecurityContext{
+				RunAsUser:    &podUID,
+				RunAsNonRoot: &runAsNonRoot,
+				FSGroup:      &fsGroup,
+			},
 		},
 	}
 	SetEtcdVersion(pod, cs.Version)


### PR DESCRIPTION
ref: #806 

With the given pod security context, the etcd containers will run as the non-root user 9000, and any volumes will have permissions for the group 9000 allowing the etcd process to read/write to them.