### PR TITLE
Enable users to specify a ServiceAccount for their etcd pods

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -132,6 +132,9 @@ type PodPolicy struct {
 	// Tolerations specifies the pod's tolerations.
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 
+	// ServiceAccountName specifies the pod's ServiceAccount.
+	ServiceAccountName string
+
 	// List of environment variables to set in the etcd container.
 	// This is used to configure etcd process. etcd cluster cannot be created, when
 	// bad environement variables are provided. Do not overwrite any flags used to

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -93,6 +93,8 @@ func applyPodPolicy(clusterName string, pod *v1.Pod, policy *api.PodPolicy) {
 		return
 	}
 
+	pod.Spec.ServiceAccountName = policy.ServiceAccountName
+
 	if policy.Affinity != nil {
 		pod.Spec.Affinity = policy.Affinity
 	}


### PR DESCRIPTION
Clusters with locked down default service accounts are unable to
mount secrets into the etcd pods. Allow users to specify a
service account to use for the etcd pods.