### PR TITLE
*: improve restore init container error message

### DIFF
--- a/pkg/cluster/reconcile.go
+++ b/pkg/cluster/reconcile.go
@@ -93,7 +93,6 @@ func (c *Cluster) reconcileMembers(running etcdutil.MemberSet) error {
 	}
 
 	if L.Size() < c.members.Size()/2+1 {
-		c.logger.Infof("lost quorum")
 		return ErrLostQuorum
 	}
 

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -84,8 +84,15 @@ func makeRestoreInitContainers(backupURL *url.URL, token, repo, version string, 
 			Name:  "fetch-backup",
 			Image: "tutum/curl",
 			Command: []string{
-				"/bin/sh", "-ec",
-				fmt.Sprintf("curl -o %s %s", backupFile, backupURL.String()),
+				"/bin/bash", "-ec",
+				fmt.Sprintf(`
+httpcode=$(curl --write-out %%\{http_code\} --silent --output %[1]s %[2]s)
+if [[ "$httpcode" != "200" ]]; then
+	echo "http status code: ${httpcode}" >> /dev/termination-log
+	cat %[1]s >> /dev/termination-log
+	exit 1
+fi
+					`, backupFile, backupURL.String()),
 			},
 			VolumeMounts: etcdVolumeMounts(),
 		},
@@ -99,7 +106,7 @@ func makeRestoreInitContainers(backupURL *url.URL, token, repo, version string, 
 					" --initial-cluster %[2]s=%[3]s"+
 					" --initial-cluster-token %[4]s"+
 					" --initial-advertise-peer-urls %[3]s"+
-					" --data-dir %[5]s", backupFile, m.Name, m.PeerURL(), token, dataDir),
+					" --data-dir %[5]s 2>/dev/termination-log", backupFile, m.Name, m.PeerURL(), token, dataDir),
 			},
 			VolumeMounts: etcdVolumeMounts(),
 		},


### PR DESCRIPTION
Sort out serror case and put error message into termination log.

ref: https://github.com/coreos/etcd-operator/issues/1860
ref: https://github.com/coreos/etcd-operator/issues/1825