### PR TITLE
Add tag to initContainer to enable offline deploys

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -346,8 +346,7 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 		},
 		Spec: v1.PodSpec{
 			InitContainers: []v1.Container{{
-				Image: "busybox",
-                                ImagePullPolicy: "IfNotPresent",
+				Image: "busybox:1.28.0",
 				Name:  "check-dns",
 				// In etcd 3.2, TLS listener will do a reverse-DNS lookup for pod IP -> hostname.
 				// If DNS entry is not warmed up, it will return empty result and peer connection will be rejected.

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -347,6 +347,7 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 		Spec: v1.PodSpec{
 			InitContainers: []v1.Container{{
 				Image: "busybox",
+                                ImagePullPolicy: "IfNotPresent",
 				Name:  "check-dns",
 				// In etcd 3.2, TLS listener will do a reverse-DNS lookup for pod IP -> hostname.
 				// If DNS entry is not warmed up, it will return empty result and peer connection will be rejected.


### PR DESCRIPTION
Rather than specify an ImagePullPolicy, specify a tag for
initContainer image.  This addresses disconnected installs without
changing podspec default settings.

Fixes #1894