### PR TITLE
k8sutil: make pod annotations configurable

### DIFF
--- a/doc/user/spec_examples.md
+++ b/doc/user/spec_examples.md
@@ -72,5 +72,16 @@ spec:
 
 For more information on working with TLS, see [Cluster TLS policy][cluster-tls].
 
+## Custom pod annotations
+
+```yaml
+spec:
+  size: 3
+  pod:
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "2379"
+```
+
 
 [cluster-tls]: cluster_tls.md

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -138,6 +138,11 @@ type PodPolicy struct {
 	// Note. This feature is in alpha stage. It is currently only used as non-stable storage,
 	// not the stable storage. Future work need to make it used as stable storage.
 	PersistentVolumeClaimSpec *v1.PersistentVolumeClaimSpec `json:"persistentVolumeClaimSpec,omitempty"`
+
+	// Annotations specifies the annotations to attach to pods the operator creates for the
+	// etcd cluster.
+	// The "etcd.version" annotation is reserved for the internal use of the etcd operator.
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 func (c *ClusterSpec) Validate() error {

--- a/pkg/apis/etcd/v1beta2/zz_generated.deepcopy.go
+++ b/pkg/apis/etcd/v1beta2/zz_generated.deepcopy.go
@@ -608,6 +608,13 @@ func (in *PodPolicy) DeepCopyInto(out *PodPolicy) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -372,7 +372,6 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 			},
 		},
 	}
-	setAnnotations(pod, cs.Pod.Annotations)
 	SetEtcdVersion(pod, cs.Version)
 	return pod
 }
@@ -483,10 +482,4 @@ func UniqueMemberName(clusterName string) string {
 		clusterName = clusterName[:maxNameLength]
 	}
 	return clusterName + "-" + suffix
-}
-
-func setAnnotations(pod *v1.Pod, annotations map[string]string) {
-	for key, value := range annotations {
-		pod.ObjectMeta.Annotations[key] = value
-	}
 }

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -372,6 +372,7 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 			},
 		},
 	}
+	setAnnotations(pod, cs.Pod.Annotations)
 	SetEtcdVersion(pod, cs.Version)
 	return pod
 }
@@ -482,4 +483,10 @@ func UniqueMemberName(clusterName string) string {
 		clusterName = clusterName[:maxNameLength]
 	}
 	return clusterName + "-" + suffix
+}
+
+func setAnnotations(pod *v1.Pod, annotations map[string]string) {
+	for key, value := range annotations {
+		pod.ObjectMeta.Annotations[key] = value
+	}
 }

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -116,6 +116,10 @@ func applyPodPolicy(clusterName string, pod *v1.Pod, policy *api.PodPolicy) {
 	for i := range pod.Spec.InitContainers {
 		pod.Spec.InitContainers[i] = containerWithRequirements(pod.Spec.InitContainers[i], policy.Resources)
 	}
+
+	for key, value := range policy.Annotations {
+		pod.ObjectMeta.Annotations[key] = value
+	}
 }
 
 // IsPodReady returns false if the Pod Status is nil


### PR DESCRIPTION
Annotations are a way to attach metadata to Kubernetes objects. This PR extends the operator configuration with an option to attach annotations to pods that the operator creates for the cluster. A
use case for this is prometheus using annotations to identify pods from which metrics can be scraped, including pod-specific scraping configuration. The changes in this PR would enable users to configure
etcd pods created by the operator to be annotated for scraping by prometheus.