### PR TITLE
cmd: do not receive signal

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/signal"
 	"runtime"
 	"time"
 
@@ -79,13 +78,6 @@ func main() {
 	if len(name) == 0 {
 		logrus.Fatalf("must set env (%s)", constants.EnvOperatorPodName)
 	}
-
-	c := make(chan os.Signal, 1)
-	signal.Notify(c)
-	go func() {
-		logrus.Infof("received signal: %v", <-c)
-		os.Exit(1)
-	}()
 
 	if printVersion {
 		fmt.Println("etcd-operator Version:", version.Version)


### PR DESCRIPTION

Usually signal.Notify() is used for the main thread to wait for children
threads to complete for graceful shutdown. We aren't doing any of this.
This part of code was added as a way to print SIGTERM. Not needed anyway.

Original PR: https://github.com/coreos/etcd-operator/pull/750

fix https://github.com/coreos/etcd-operator/issues/1892