### PR TITLE
*: reject empty endpoints in EtcdBackup CR

### DIFF
--- a/pkg/backup/backup_manager.go
+++ b/pkg/backup/backup_manager.go
@@ -131,6 +131,10 @@ func getClientWithMaxRev(endpoints []string, tc *tls.Config) (*clientv3.Client, 
 		cli.Close()
 	}
 
+	if maxClient == nil {
+		return nil, 0, fmt.Errorf("could not create an etcd client for the max revision purpose from given endpoints (%v)", endpoints)
+	}
+
 	var err error
 	if len(errors) > 0 {
 		errorStr := ""

--- a/pkg/controller/backup-operator/sync_test.go
+++ b/pkg/controller/backup-operator/sync_test.go
@@ -1,0 +1,46 @@
+// Copyright 2018 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"testing"
+
+	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		spec      *api.BackupSpec
+		expectErr bool
+	}{{
+		spec: &api.BackupSpec{
+			EtcdEndpoints: []string{"http://localhost:2379"},
+		},
+		expectErr: false,
+	}, { // fail due to empty etcd endpoints
+		spec:      &api.BackupSpec{},
+		expectErr: true,
+	}}
+
+	for i, tt := range tests {
+		err := validate(tt.spec)
+		if err != nil && !tt.expectErr {
+			t.Errorf("#%d: validate failed: %v", i, err)
+		}
+		if err == nil && tt.expectErr {
+			t.Errorf("#%d: expect error, but got nil", i)
+		}
+	}
+}


### PR DESCRIPTION
fix https://github.com/coreos/etcd-operator/issues/1893

Tested with empty endpoints:
```
  status:
    Reason: spec.etcdEndpoints could not be empty
    succeeded: false
```

Should be better handled by initializer/admission plugin: https://github.com/coreos/etcd-operator/issues/1392