### PR TITLE
*: support Writer with context

### DIFF
--- a/pkg/backup/backup_manager.go
+++ b/pkg/backup/backup_manager.go
@@ -69,7 +69,7 @@ func (bm *BackupManager) SaveSnap(ctx context.Context, s3Path string) (int64, st
 	}
 	defer rc.Close()
 
-	_, err = bm.bw.Write(s3Path, rc)
+	_, err = bm.bw.Write(ctx, s3Path, rc)
 	if err != nil {
 		return 0, "", fmt.Errorf("failed to write snapshot (%v)", err)
 	}

--- a/pkg/backup/writer/abs_writer.go
+++ b/pkg/backup/writer/abs_writer.go
@@ -16,6 +16,7 @@ package writer
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -43,7 +44,8 @@ const (
 )
 
 // Write writes the backup file to the given abs path, "<abs-container-name>/<key>".
-func (absw *absWriter) Write(path string, r io.Reader) (int64, error) {
+func (absw *absWriter) Write(ctx context.Context, path string, r io.Reader) (int64, error) {
+	// TODO: support context.
 	container, key, err := util.ParseBucketAndKey(path)
 	if err != nil {
 		return 0, err

--- a/pkg/backup/writer/s3_writer.go
+++ b/pkg/backup/writer/s3_writer.go
@@ -15,6 +15,7 @@
 package writer
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -35,13 +36,13 @@ func NewS3Writer(s3 *s3.S3) Writer {
 }
 
 // Write writes the backup file to the given s3 path, "<s3-bucket-name>/<key>".
-func (s3w *s3Writer) Write(path string, r io.Reader) (int64, error) {
+func (s3w *s3Writer) Write(ctx context.Context, path string, r io.Reader) (int64, error) {
 	bk, key, err := util.ParseBucketAndKey(path)
 	if err != nil {
 		return 0, err
 	}
 
-	_, err = s3manager.NewUploaderWithClient(s3w.s3).Upload(
+	_, err = s3manager.NewUploaderWithClient(s3w.s3).UploadWithContext(ctx,
 		&s3manager.UploadInput{
 			Bucket: aws.String(bk),
 			Key:    aws.String(key),

--- a/pkg/backup/writer/writer.go
+++ b/pkg/backup/writer/writer.go
@@ -14,10 +14,13 @@
 
 package writer
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 // Writer defines the required writer operations.
 type Writer interface {
 	// Write writes a backup file to the given path and returns size of written file.
-	Write(path string, r io.Reader) (int64, error)
+	Write(ctx context.Context, path string, r io.Reader) (int64, error)
 }


### PR DESCRIPTION
backup/writer interface now reasons about input context. The context controls the writer.Write operation.

ref: https://github.com/coreos/etcd-operator/issues/1906