### PR TITLE
 k8sutil: set 30s default request timeout for kube client

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -145,6 +145,7 @@ type PodPolicy struct {
 	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
+// TODO: move this to initializer
 func (c *ClusterSpec) Validate() error {
 	if c.TLS != nil {
 		if err := c.TLS.Validate(); err != nil {
@@ -163,7 +164,7 @@ func (c *ClusterSpec) Validate() error {
 }
 
 // SetDefaults cleans up user passed spec, e.g. defaulting, transforming fields.
-// TODO: move this to admission controller
+// TODO: move this to initializer
 func (e *EtcdCluster) SetDefaults() {
 	c := &e.Spec
 	if len(c.Repository) == 0 {

--- a/pkg/controller/backup-operator/sync.go
+++ b/pkg/controller/backup-operator/sync.go
@@ -149,6 +149,7 @@ func (b *Backup) handleBackup(spec *api.BackupSpec) (*api.BackupStatus, error) {
 	return nil, nil
 }
 
+// TODO: move this to initializer
 func validate(spec *api.BackupSpec) error {
 	if len(spec.EtcdEndpoints) == 0 {
 		return errors.New("spec.etcdEndpoints should not be empty")

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -60,6 +60,8 @@ const (
 	randomSuffixLength = 10
 	// k8s object name has a maximum length
 	maxNameLength = 63 - randomSuffixLength - 1
+
+	defaultKubeAPIRequestTimeout = 30 * time.Second
 )
 
 const TolerateUnreadyEndpointsAnnotation = "service.alpha.kubernetes.io/tolerate-unready-endpoints"
@@ -404,7 +406,13 @@ func InClusterConfig() (*rest.Config, error) {
 	if len(os.Getenv("KUBERNETES_SERVICE_PORT")) == 0 {
 		os.Setenv("KUBERNETES_SERVICE_PORT", "443")
 	}
-	return rest.InClusterConfig()
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+	// Set a reasonable default request timeout
+	cfg.Timeout = defaultKubeAPIRequestTimeout
+	return cfg, nil
 }
 
 func IsKubernetesResourceAlreadyExistError(err error) bool {


### PR DESCRIPTION
fix https://github.com/coreos/etcd-operator/issues/1909