### PR TITLE
pkg/util: Change check-dns init container image

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -346,7 +346,7 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 		},
 		Spec: v1.PodSpec{
 			InitContainers: []v1.Container{{
-				Image: "busybox:1.28.0",
+				Image: "busybox:1.28.0-glibc",
 				Name:  "check-dns",
 				// In etcd 3.2, TLS listener will do a reverse-DNS lookup for pod IP -> hostname.
 				// If DNS entry is not warmed up, it will return empty result and peer connection will be rejected.


### PR DESCRIPTION
The image currently used is busybox:1.28.0 which uses uclibc.  This is
causing nslookup to fail name resolution when it shouldn't in some
environments.  The version of busybox that uses glibc does not suffer the
same problem.

Related:
https://github.com/docker-library/busybox/issues/9
https://github.com/docker-library/busybox/issues/27