### PR TITLE
release: bump version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Security
 
+## [Release 0.9.0]
+
+Same as v0.8.4. The version is bumping to 0.9.0 due to adding a new ABS backup API into etcd-backup-operator.
+
 ## [Release 0.8.4]
 
 ### Added

--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: etcd-operator
-        image: quay.io/coreos/etcd-operator:v0.8.4
+        image: quay.io/coreos/etcd-operator:v0.9.0
         command:
         - etcd-operator
         env:

--- a/example/etcd-backup-operator/deployment.yaml
+++ b/example/etcd-backup-operator/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: etcd-backup-operator
-        image: quay.io/coreos/etcd-operator:v0.8.4
+        image: quay.io/coreos/etcd-operator:v0.9.0
         command:
         - etcd-backup-operator
         env:

--- a/example/etcd-restore-operator/deployment.yaml
+++ b/example/etcd-restore-operator/deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: etcd-restore-operator
-        image: quay.io/coreos/etcd-operator:v0.8.4
+        image: quay.io/coreos/etcd-operator:v0.9.0
         command:
         - etcd-restore-operator
         env:

--- a/version/version.go
+++ b/version/version.go
@@ -15,6 +15,6 @@
 package version
 
 var (
-	Version = "0.8.4"
+	Version = "0.9.0"
 	GitSHA  = "Not provided (use ./build instead of go build)"
 )


### PR DESCRIPTION
same as 0.8.4. bump to 0.9.0 due to adding a new abs backup api.

[skip ci]