### PR TITLE
cluster: add option to specify busybox repository

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -25,6 +25,8 @@ import (
 const (
 	defaultRepository  = "quay.io/coreos/etcd"
 	DefaultEtcdVersion = "3.2.13"
+	defaultBusyboxRepository = "busybox"
+	defaultBusyboxVersion = "1.28.0-glibc"
 )
 
 var (
@@ -99,6 +101,15 @@ type ClusterSpec struct {
 
 	// etcd cluster TLS configuration
 	TLS *TLSPolicy `json:"TLS,omitempty"`
+
+	// busybox:latest uses uclibc which contains a bug that sometimes prevents name resolution
+	// More info: https://github.com/docker-library/busybox/issues/27
+	// busybox init container repository. default is busybox
+	BusyboxRepository string `json:"busyboxRepository,omitempty"`
+
+	// busybox init container version. defaults to 1.28.0-glibc
+	BusyboxVersion string `json:"busyboxVersion,omitempty"`
+
 }
 
 // PodPolicy defines the policy to create pod for the etcd container.
@@ -176,6 +187,15 @@ func (e *EtcdCluster) SetDefaults() {
 	}
 
 	c.Version = strings.TrimLeft(c.Version, "v")
+
+	// set defaults for busybox init container
+	if len(c.BusyboxRepository) == 0 {
+		c.BusyboxRepository = defaultBusyboxRepository
+	}
+
+	if len(c.BusyboxVersion) == 0 {
+		c.BusyboxVersion = defaultBusyboxVersion
+	}
 
 	// convert PodPolicy.AntiAffinity to Pod.Affinity.PodAntiAffinity
 	// TODO: Remove this once PodPolicy.AntiAffinity is removed

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -25,8 +25,6 @@ import (
 const (
 	defaultRepository  = "quay.io/coreos/etcd"
 	DefaultEtcdVersion = "3.2.13"
-	defaultBusyboxRepository = "busybox"
-	defaultBusyboxVersion = "1.28.0-glibc"
 )
 
 var (
@@ -101,15 +99,6 @@ type ClusterSpec struct {
 
 	// etcd cluster TLS configuration
 	TLS *TLSPolicy `json:"TLS,omitempty"`
-
-	// busybox:latest uses uclibc which contains a bug that sometimes prevents name resolution
-	// More info: https://github.com/docker-library/busybox/issues/27
-	// busybox init container repository. default is busybox
-	BusyboxRepository string `json:"busyboxRepository,omitempty"`
-
-	// busybox init container version. defaults to 1.28.0-glibc
-	BusyboxVersion string `json:"busyboxVersion,omitempty"`
-
 }
 
 // PodPolicy defines the policy to create pod for the etcd container.
@@ -154,6 +143,14 @@ type PodPolicy struct {
 	// etcd cluster.
 	// The "etcd.version" annotation is reserved for the internal use of the etcd operator.
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// busybox:latest uses uclibc which contains a bug that sometimes prevents name resolution
+	// More info: https://github.com/docker-library/busybox/issues/27
+	// busybox init container repository. default is busybox
+	BusyboxRepository string `json:"busyboxRepository,omitempty"`
+
+	// busybox init container version. defaults to 1.28.0-glibc
+	BusyboxVersion string `json:"busyboxVersion,omitempty"`
 }
 
 // TODO: move this to initializer
@@ -187,15 +184,6 @@ func (e *EtcdCluster) SetDefaults() {
 	}
 
 	c.Version = strings.TrimLeft(c.Version, "v")
-
-	// set defaults for busybox init container
-	if len(c.BusyboxRepository) == 0 {
-		c.BusyboxRepository = defaultBusyboxRepository
-	}
-
-	if len(c.BusyboxVersion) == 0 {
-		c.BusyboxVersion = defaultBusyboxVersion
-	}
 
 	// convert PodPolicy.AntiAffinity to Pod.Affinity.PodAntiAffinity
 	// TODO: Remove this once PodPolicy.AntiAffinity is removed

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -144,12 +144,12 @@ type PodPolicy struct {
 	// The "etcd.version" annotation is reserved for the internal use of the etcd operator.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	// busybox:latest uses uclibc which contains a bug that sometimes prevents name resolution
-	// More info: https://github.com/docker-library/busybox/issues/27
 	// busybox init container repository. default is busybox
 	BusyboxRepository string `json:"busyboxRepository,omitempty"`
 
 	// busybox init container version. defaults to 1.28.0-glibc
+	// busybox:latest uses uclibc which contains a bug that sometimes prevents name resolution
+	// More info: https://github.com/docker-library/busybox/issues/27
 	BusyboxVersion string `json:"busyboxVersion,omitempty"`
 }
 

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -144,13 +144,10 @@ type PodPolicy struct {
 	// The "etcd.version" annotation is reserved for the internal use of the etcd operator.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	// busybox init container repository. default is busybox
-	BusyboxRepository string `json:"busyboxRepository,omitempty"`
-
-	// busybox init container version. defaults to 1.28.0-glibc
+	// busybox init container image. default is busybox:1.28.0-glibc
 	// busybox:latest uses uclibc which contains a bug that sometimes prevents name resolution
 	// More info: https://github.com/docker-library/busybox/issues/27
-	BusyboxVersion string `json:"busyboxVersion,omitempty"`
+	BusyboxImage string `json:"busyboxImage,omitempty"`
 }
 
 // TODO: move this to initializer

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -134,6 +134,11 @@ func ImageName(repo, version string) string {
 	return fmt.Sprintf("%s:v%v", repo, version)
 }
 
+func ImageNameBusybox(repo, version string) string {
+	return fmt.Sprintf("%s:%v", repo, version)
+}
+
+
 func PodWithNodeSelector(p *v1.Pod, ns map[string]string) *v1.Pod {
 	p.Spec.NodeSelector = ns
 	return p
@@ -355,7 +360,8 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 			InitContainers: []v1.Container{{
 				// busybox:latest uses uclibc which contains a bug that sometimes prevents name resolution
 				// More info: https://github.com/docker-library/busybox/issues/27
-				Image: "busybox:1.28.0-glibc",
+				//Image default: "busybox:1.28.0-glibc",
+				Image: ImageNameBusybox(cs.BusyboxRepository,cs.BusyboxVersion),
 				Name:  "check-dns",
 				// In etcd 3.2, TLS listener will do a reverse-DNS lookup for pod IP -> hostname.
 				// If DNS entry is not warmed up, it will return empty result and peer connection will be rejected.

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -136,14 +136,12 @@ func ImageName(repo, version string) string {
 	return fmt.Sprintf("%s:v%v", repo, version)
 }
 
+// imageNameBusybox returns the default image for busybox init container, or the image specified in the PodPolicy
 func imageNameBusybox(policy *api.PodPolicy) string {
-	// set defaults for busybox init container
-	image := defaultBusyboxImage
-
 	if policy != nil && len(policy.BusyboxImage) > 0 {
-		image = policy.BusyboxImage
+		return policy.BusyboxImage
 	}
-	return image
+	return defaultBusyboxImage
 }
 
 func PodWithNodeSelector(p *v1.Pod, ns map[string]string) *v1.Pod {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -66,9 +66,9 @@ const (
 	// AnnotationScope annotation name for defining instance scope. Used for specifing cluster wide clusters.
 	AnnotationScope = "etcd.database.coreos.com/scope"
 	//AnnotationClusterWide annotation value for cluster wide clusters.
-	AnnotationClusterWide = "clusterwide"
+	AnnotationClusterWide    = "clusterwide"
 	defaultBusyboxRepository = "busybox"
-	defaultBusyboxVersion = "1.28.0-glibc"
+	defaultBusyboxVersion    = "1.28.0-glibc"
 )
 
 const TolerateUnreadyEndpointsAnnotation = "service.alpha.kubernetes.io/tolerate-unready-endpoints"
@@ -138,8 +138,8 @@ func ImageName(repo, version string) string {
 
 func ImageNameBusybox(policy *api.PodPolicy) string {
 	// set defaults for busybox init container
-	repo:= defaultBusyboxRepository
-	version:= defaultBusyboxVersion
+	repo := defaultBusyboxRepository
+	version := defaultBusyboxVersion
 
 	if policy != nil && len(policy.BusyboxRepository) > 0 {
 		repo = policy.BusyboxRepository
@@ -150,7 +150,6 @@ func ImageNameBusybox(policy *api.PodPolicy) string {
 	}
 	return fmt.Sprintf("%s:%v", repo, version)
 }
-
 
 func PodWithNodeSelector(p *v1.Pod, ns map[string]string) *v1.Pod {
 	p.Spec.NodeSelector = ns

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -63,12 +63,13 @@ const (
 
 	defaultKubeAPIRequestTimeout = 30 * time.Second
 
+	defaultBusyboxRepository = "busybox"
+	defaultBusyboxVersion    = "1.28.0-glibc"
+
 	// AnnotationScope annotation name for defining instance scope. Used for specifing cluster wide clusters.
 	AnnotationScope = "etcd.database.coreos.com/scope"
 	//AnnotationClusterWide annotation value for cluster wide clusters.
-	AnnotationClusterWide    = "clusterwide"
-	defaultBusyboxRepository = "busybox"
-	defaultBusyboxVersion    = "1.28.0-glibc"
+	AnnotationClusterWide = "clusterwide"
 )
 
 const TolerateUnreadyEndpointsAnnotation = "service.alpha.kubernetes.io/tolerate-unready-endpoints"
@@ -136,7 +137,7 @@ func ImageName(repo, version string) string {
 	return fmt.Sprintf("%s:v%v", repo, version)
 }
 
-func ImageNameBusybox(policy *api.PodPolicy) string {
+func imageNameBusybox(policy *api.PodPolicy) string {
 	// set defaults for busybox init container
 	repo := defaultBusyboxRepository
 	version := defaultBusyboxVersion
@@ -373,7 +374,7 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 				// busybox:latest uses uclibc which contains a bug that sometimes prevents name resolution
 				// More info: https://github.com/docker-library/busybox/issues/27
 				//Image default: "busybox:1.28.0-glibc",
-				Image: ImageNameBusybox(cs.Pod),
+				Image: imageNameBusybox(cs.Pod),
 				Name:  "check-dns",
 				// In etcd 3.2, TLS listener will do a reverse-DNS lookup for pod IP -> hostname.
 				// If DNS entry is not warmed up, it will return empty result and peer connection will be rejected.

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -63,8 +63,7 @@ const (
 
 	defaultKubeAPIRequestTimeout = 30 * time.Second
 
-	defaultBusyboxRepository = "busybox"
-	defaultBusyboxVersion    = "1.28.0-glibc"
+	defaultBusyboxImage = "busybox:1.28.0-glibc"
 
 	// AnnotationScope annotation name for defining instance scope. Used for specifing cluster wide clusters.
 	AnnotationScope = "etcd.database.coreos.com/scope"
@@ -139,17 +138,12 @@ func ImageName(repo, version string) string {
 
 func imageNameBusybox(policy *api.PodPolicy) string {
 	// set defaults for busybox init container
-	repo := defaultBusyboxRepository
-	version := defaultBusyboxVersion
+	image := defaultBusyboxImage
 
-	if policy != nil && len(policy.BusyboxRepository) > 0 {
-		repo = policy.BusyboxRepository
+	if policy != nil && len(policy.BusyboxImage) > 0 {
+		image = policy.BusyboxImage
 	}
-
-	if policy != nil && len(policy.BusyboxVersion) > 0 {
-		version = policy.BusyboxVersion
-	}
-	return fmt.Sprintf("%s:%v", repo, version)
+	return image
 }
 
 func PodWithNodeSelector(p *v1.Pod, ns map[string]string) *v1.Pod {

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -15,7 +15,6 @@
 package k8sutil
 
 import (
-	"fmt"
 	"testing"
 
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
@@ -24,7 +23,7 @@ import (
 func TestDefaultBusyboxImageName(t *testing.T) {
 	policy := &api.PodPolicy{}
 	image := imageNameBusybox(policy)
-	expected := fmt.Sprintf("%s:%v", defaultBusyboxRepository, defaultBusyboxVersion)
+	expected := defaultBusyboxImage
 	if image != expected {
 		t.Errorf("expect image=%s, get=%s", expected, image)
 	}
@@ -32,7 +31,7 @@ func TestDefaultBusyboxImageName(t *testing.T) {
 
 func TestDefaultNilBusyboxImageName(t *testing.T) {
 	image := imageNameBusybox(nil)
-	expected := fmt.Sprintf("%s:%v", defaultBusyboxRepository, defaultBusyboxVersion)
+	expected := defaultBusyboxImage
 	if image != expected {
 		t.Errorf("expect image=%s, get=%s", expected, image)
 	}
@@ -40,11 +39,10 @@ func TestDefaultNilBusyboxImageName(t *testing.T) {
 
 func TestSetBusyboxImageName(t *testing.T) {
 	policy := &api.PodPolicy{
-		BusyboxVersion:    "1.3.2",
-		BusyboxRepository: "myRepo/busybox",
+		BusyboxImage: "myRepo/busybox:1.3.2",
 	}
 	image := imageNameBusybox(policy)
-	expected := fmt.Sprintf("%s:%v", "myRepo/busybox", "1.3.2")
+	expected := "myRepo/busybox:1.3.2"
 	if image != expected {
 		t.Errorf("expect image=%s, get=%s", expected, image)
 	}

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -1,23 +1,38 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package k8sutil
 
 import (
-	"testing"
 	"fmt"
+	"testing"
+
 	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
 )
 
 func TestDefaultBusyboxImageName(t *testing.T) {
 	policy := &api.PodPolicy{}
-	image:=ImageNameBusybox(policy)
-	expected:= fmt.Sprintf("%s:%v",defaultBusyboxRepository , defaultBusyboxVersion)
+	image := ImageNameBusybox(policy)
+	expected := fmt.Sprintf("%s:%v", defaultBusyboxRepository, defaultBusyboxVersion)
 	if image != expected {
 		t.Errorf("expect image=%s, get=%s", expected, image)
 	}
 }
 
 func TestDefaultNilBusyboxImageName(t *testing.T) {
-	image:=ImageNameBusybox(nil)
-	expected:= fmt.Sprintf("%s:%v",defaultBusyboxRepository , defaultBusyboxVersion)
+	image := ImageNameBusybox(nil)
+	expected := fmt.Sprintf("%s:%v", defaultBusyboxRepository, defaultBusyboxVersion)
 	if image != expected {
 		t.Errorf("expect image=%s, get=%s", expected, image)
 	}
@@ -25,11 +40,11 @@ func TestDefaultNilBusyboxImageName(t *testing.T) {
 
 func TestSetBusyboxImageName(t *testing.T) {
 	policy := &api.PodPolicy{
-		BusyboxVersion:"1.3.2",
-		BusyboxRepository:"myRepo/busybox",
+		BusyboxVersion:    "1.3.2",
+		BusyboxRepository: "myRepo/busybox",
 	}
-	image:=ImageNameBusybox(policy)
-	expected:= fmt.Sprintf("%s:%v","myRepo/busybox" , "1.3.2")
+	image := ImageNameBusybox(policy)
+	expected := fmt.Sprintf("%s:%v", "myRepo/busybox", "1.3.2")
 	if image != expected {
 		t.Errorf("expect image=%s, get=%s", expected, image)
 	}

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -1,0 +1,36 @@
+package k8sutil
+
+import (
+	"testing"
+	"fmt"
+	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
+)
+
+func TestDefaultBusyboxImageName(t *testing.T) {
+	policy := &api.PodPolicy{}
+	image:=ImageNameBusybox(policy)
+	expected:= fmt.Sprintf("%s:%v",defaultBusyboxRepository , defaultBusyboxVersion)
+	if image != expected {
+		t.Errorf("expect image=%s, get=%s", expected, image)
+	}
+}
+
+func TestDefaultNilBusyboxImageName(t *testing.T) {
+	image:=ImageNameBusybox(nil)
+	expected:= fmt.Sprintf("%s:%v",defaultBusyboxRepository , defaultBusyboxVersion)
+	if image != expected {
+		t.Errorf("expect image=%s, get=%s", expected, image)
+	}
+}
+
+func TestSetBusyboxImageName(t *testing.T) {
+	policy := &api.PodPolicy{
+		BusyboxVersion:"1.3.2",
+		BusyboxRepository:"myRepo/busybox",
+	}
+	image:=ImageNameBusybox(policy)
+	expected:= fmt.Sprintf("%s:%v","myRepo/busybox" , "1.3.2")
+	if image != expected {
+		t.Errorf("expect image=%s, get=%s", expected, image)
+	}
+}

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestDefaultBusyboxImageName(t *testing.T) {
 	policy := &api.PodPolicy{}
-	image := ImageNameBusybox(policy)
+	image := imageNameBusybox(policy)
 	expected := fmt.Sprintf("%s:%v", defaultBusyboxRepository, defaultBusyboxVersion)
 	if image != expected {
 		t.Errorf("expect image=%s, get=%s", expected, image)
@@ -31,7 +31,7 @@ func TestDefaultBusyboxImageName(t *testing.T) {
 }
 
 func TestDefaultNilBusyboxImageName(t *testing.T) {
-	image := ImageNameBusybox(nil)
+	image := imageNameBusybox(nil)
 	expected := fmt.Sprintf("%s:%v", defaultBusyboxRepository, defaultBusyboxVersion)
 	if image != expected {
 		t.Errorf("expect image=%s, get=%s", expected, image)
@@ -43,7 +43,7 @@ func TestSetBusyboxImageName(t *testing.T) {
 		BusyboxVersion:    "1.3.2",
 		BusyboxRepository: "myRepo/busybox",
 	}
-	image := ImageNameBusybox(policy)
+	image := imageNameBusybox(policy)
 	expected := fmt.Sprintf("%s:%v", "myRepo/busybox", "1.3.2")
 	if image != expected {
 		t.Errorf("expect image=%s, get=%s", expected, image)


### PR DESCRIPTION
cluster: add option to specify busybox repository 
add 2 options in EtcdCluster.spec:
busyboxRepository. Defaults to "busybox"
busyboxVersion. Defaults to "1.28.0-glibc"

for #1927 