### PR TITLE
k8sutil: remove global defaultKubeAPIRequestTimeout

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -61,8 +61,6 @@ const (
 	// k8s object name has a maximum length
 	maxNameLength = 63 - randomSuffixLength - 1
 
-	defaultKubeAPIRequestTimeout = 30 * time.Second
-
 	defaultBusyboxImage = "busybox:1.28.0-glibc"
 
 	// AnnotationScope annotation name for defining instance scope. Used for specifing cluster wide clusters.
@@ -428,8 +426,6 @@ func InClusterConfig() (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Set a reasonable default request timeout
-	cfg.Timeout = defaultKubeAPIRequestTimeout
 	return cfg, nil
 }
 


### PR DESCRIPTION
The watch stream in informer will break after 30s:

```
E0306 20:38:49.476999       1 streamwatcher.go:109] Unable to decode an event from the watch stream: net/http: request canceled (Client.Timeout exceeded while reading body)
```