### PR TITLE
*: update go version to 1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- Update Go version to 1.10
+- Build `gcr.io/coreos-k8s-scale-testing/etcd-operator-builder:0.4.1-2` container
+  with Go 1.10 and dep 0.4.1
+
 ### Removed
 
 ### Fixed

--- a/doc/dev/developer_guide.md
+++ b/doc/dev/developer_guide.md
@@ -14,7 +14,7 @@ Install dependency if you haven't:
 ## How to build
 
 Requirement:
-- Go 1.9+
+- Go 1.10+
 
 Build in project root dir:
 

--- a/hack/build/backup-operator/build
+++ b/hack/build/backup-operator/build
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# Note: add `-i` to enable build with caching. e.g ./hack/backup-operator/build -i
-
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/build/build
+++ b/hack/build/build
@@ -13,7 +13,7 @@ DOCKER_REPO_ROOT="/go/src/github.com/coreos/etcd-operator"
 docker run --rm \
 	-v "$PWD":"$DOCKER_REPO_ROOT" \
 	-w "$DOCKER_REPO_ROOT" \
-	gcr.io/coreos-k8s-scale-testing/etcd-operator-builder:0.4.1 \
-	/bin/bash -c "hack/build/operator/build -i && \
-		hack/build/backup-operator/build -i && \
-		hack/build/restore-operator/build -i"
+	gcr.io/coreos-k8s-scale-testing/etcd-operator-builder:0.4.1-2 \
+	/bin/bash -c "hack/build/operator/build && \
+		hack/build/backup-operator/build && \
+		hack/build/restore-operator/build"

--- a/hack/build/e2e/builder/Dockerfile
+++ b/hack/build/e2e/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9
+FROM golang:1.10
 
 RUN curl -L https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 -o /usr/local/bin/dep \
     && chmod +x /usr/local/bin/dep \

--- a/hack/build/logcollector/Dockerfile
+++ b/hack/build/logcollector/Dockerfile
@@ -1,6 +1,6 @@
 # Build step: docker build --tag gcr.io/coreos-k8s-scale-testing/logcollector -f hack/build/logcollector/Dockerfile .
 
-FROM golang:1.9
+FROM golang:1.10
 
 ADD ./ /go/src/github.com/coreos/etcd-operator
 
@@ -8,4 +8,4 @@ WORKDIR /go/src/github.com/coreos/etcd-operator
 
 RUN rm -rf _output _test .git .gitignore
 
-RUN go build -i -o /usr/local/bin/logcollector test/logcollector/main.go
+RUN go build -o /usr/local/bin/logcollector test/logcollector/main.go

--- a/hack/build/operator/build
+++ b/hack/build/operator/build
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# Note: add `-i` to` enable build with caching. e.g ./hack/operator/build -i
-
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/build/restore-operator/build
+++ b/hack/build/restore-operator/build
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-# Note: add `-i` to enable build with caching. e.g ./hack/restore-operator/build -i
-
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/ci/get_dep
+++ b/hack/ci/get_dep
@@ -7,5 +7,5 @@ DOCKER_REPO_ROOT="/go/src/github.com/coreos/etcd-operator"
 docker run --rm \
 	-v "$PWD":"$DOCKER_REPO_ROOT" \
 	-w "$DOCKER_REPO_ROOT" \
-	gcr.io/coreos-k8s-scale-testing/etcd-operator-builder:0.4.1 \
+	gcr.io/coreos-k8s-scale-testing/etcd-operator-builder:0.4.1-2 \
 	hack/update_vendor.sh

--- a/hack/ci/run_e2e
+++ b/hack/ci/run_e2e
@@ -4,10 +4,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GOROOT="/usr/local/go"
-export PATH=$GOROOT/bin:$PATH
-
-go version
 kubectl version
 
 : ${TEST_NAMESPACE:?"Need to set TEST_NAMESPACE"}

--- a/hack/ci/run_unit
+++ b/hack/ci/run_unit
@@ -6,11 +6,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-export GOROOT="/usr/local/go"
-export PATH=$GOROOT/bin:$PATH
 export CODECOV_TOKEN=$(cat $CODECOV_TOKEN_FILE)
-
-go version
 
 function finish {
   sudo chown -R "$(whoami)" ./

--- a/hack/fmt_pass
+++ b/hack/fmt_pass
@@ -17,15 +17,6 @@ for file in $allfiles; do
   fi
 done
 
-echo "Checking govet..."
-for file in $allfiles; do
-  checkRes=$(go vet $file)
-  if [ -n "${checkRes}" ]; then
-    echo -e "go vet checking failed:\n${checkRes}"
-    exit 255
-  fi
-done
-
 if which gosimple >/dev/null; then
   echo "Checking gosimple..."
   # Generated deepcopy code failed checking... Ignore it at the moment

--- a/hack/test
+++ b/hack/test
@@ -22,7 +22,7 @@ function fmt_pass {
 	docker run --rm \
 		-v "${PWD}":"${DOCKER_REPO_ROOT}" \
 		-w "${DOCKER_REPO_ROOT}" \
-		gcr.io/coreos-k8s-scale-testing/etcd-operator-builder:0.4.1 \
+		gcr.io/coreos-k8s-scale-testing/etcd-operator-builder:0.4.1-2 \
 		"./hack/fmt_pass"
 }
 
@@ -35,7 +35,7 @@ function e2e_pass {
 
 	build_flags=("-i") # cache package compilation data for faster repeated builds
 	for i in {1..2}; do
-		go test -parallel=4 "./test/e2e/" ${build_flags[@]} -run "$E2E_TEST_SELECTOR" -timeout 30m --race \
+		go test -failfast -parallel=4 "./test/e2e/" ${build_flags[@]} -run "$E2E_TEST_SELECTOR" -timeout 30m --race \
 			--kubeconfig=$KUBECONFIG --operator-image=$OPERATOR_IMAGE --namespace=${TEST_NAMESPACE}
 		build_flags=("")
 	done
@@ -45,7 +45,7 @@ function e2eslow_pass {
 	E2E_TEST_SELECTOR=${E2E_TEST_SELECTOR:-.*}
 	build_flags=("-i") # cache package compilation data for faster repeated builds
 	for i in {1..2}; do
-		go test "./test/e2e/e2eslow" ${build_flags[@]} -run "$E2E_TEST_SELECTOR" -timeout 30m --race \
+		go test -failfast "./test/e2e/e2eslow" ${build_flags[@]} -run "$E2E_TEST_SELECTOR" -timeout 30m --race \
 			--kubeconfig=$KUBECONFIG --operator-image=$OPERATOR_IMAGE --namespace=${TEST_NAMESPACE}
 		build_flags=("")
 	done
@@ -54,7 +54,7 @@ function e2eslow_pass {
 function upgrade_pass {
 	# Run all the tests by default
 	UPGRADE_TEST_SELECTOR=${UPGRADE_TEST_SELECTOR:-.*}
-	go test ./test/e2e/upgradetest/ -run "$UPGRADE_TEST_SELECTOR" --race -timeout 30m \
+	go test -failfast ./test/e2e/upgradetest/ -run "$UPGRADE_TEST_SELECTOR" --race -timeout 30m \
 		--kubeconfig=$KUBECONFIG --kube-ns=$TEST_NAMESPACE \
 		--old-image=$UPGRADE_FROM \
 		--new-image=$UPGRADE_TO
@@ -66,7 +66,7 @@ function unit_pass {
 		-v "${PWD}":"${DOCKER_REPO_ROOT}" \
 		-w "${DOCKER_REPO_ROOT}" \
 		-e "CODECOV_TOKEN" \
-		golang:1.9 \
+		golang:1.10 \
 		"./hack/unit_test"
 }
 

--- a/hack/unit_test
+++ b/hack/unit_test
@@ -14,7 +14,7 @@ for pkg in $TEST_PKGS
 do
   build_flags=("-i") # cache package compilation data for faster repeated builds
   for i in {1..2}; do
-    go test ${build_flags[@]} -race -covermode=atomic -coverprofile=profile.out $pkg
+    go test -failfast ${build_flags[@]} -race -covermode=atomic -coverprofile=profile.out $pkg
     # Expand empty array would cause "unbound variable".
     # Expand one empty string array is equal to nothing.
     build_flags=("")

--- a/test/container/Dockerfile
+++ b/test/container/Dockerfile
@@ -1,6 +1,6 @@
-# golang:1.9-alpine can't be used since it does not support the race detector flag which assumes a glibc based system, whereas alpine linux uses musl libc
+# golang:X-alpine can't be used since it does not support the race detector flag which assumes a glibc based system, whereas alpine linux uses musl libc
 # https://github.com/golang/go/issues/14481
-FROM golang:1.9
+FROM golang:1.10
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.8.2/bin/linux/amd64/kubectl \
     && chmod +x ./kubectl \

--- a/test/pod/Dockerfile
+++ b/test/pod/Dockerfile
@@ -1,6 +1,6 @@
-# golang:1.9-alpine can't be used since it does not support the race detector flag which assumes a glibc based system, whereas alpine linux uses musl libc
+# golang:X-alpine can't be used since it does not support the race detector flag which assumes a glibc based system, whereas alpine linux uses musl libc
 # https://github.com/golang/go/issues/14481
-FROM golang:1.9
+FROM golang:1.10
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.8.2/bin/linux/amd64/kubectl \
     && chmod +x ./kubectl \


### PR DESCRIPTION
Go version is defined in
- build
- test script

This PR updates them. Also some cleanup.

fix https://github.com/coreos/etcd-operator/issues/1752