### PR TITLE
doc: fix misspelling of Kubernetes

### DIFF
--- a/doc/best_practices.md
+++ b/doc/best_practices.md
@@ -2,16 +2,16 @@
 
 ## Large-scale deployment
 
-To run etcd cluster at large-scale, it is important to assign etcd pods to nodes with desired resources, such as SSD, high performance network. 
+To run etcd cluster at large-scale, it is important to assign etcd pods to nodes with desired resources, such as SSD, high performance network.
 
 ### Assign to nodes with desired resources
 
-Kuberentes nodes can be attached with labels. Users can [assign pods to nodes with given labels](http://kubernetes.io/docs/user-guide/node-selection/). Similarly for the etcd-operator, users can specify `Node Selector` in the pod policy to select nodes for etcd pods. For example, users can label a set of nodes with SSD with label `"disk"="SSD"`. To assign etcd pods to these node, users can specify `"disk"="SSD"` node selector in the cluster spec.
+Kubernetes nodes can be attached with labels. Users can [assign pods to nodes with given labels](http://kubernetes.io/docs/user-guide/node-selection/). Similarly for the etcd-operator, users can specify `Node Selector` in the pod policy to select nodes for etcd pods. For example, users can label a set of nodes with SSD with label `"disk"="SSD"`. To assign etcd pods to these node, users can specify `"disk"="SSD"` node selector in the cluster spec.
 
 ### Assign to dedicated node
 
 Even with container isolation, not all resources are isolated. Thus, performance interference can still affect etcd clusters' performance unexpectedly. We recommend dedicating nodes for each etcd pod to achieve predictable performance.
 
-Kuberentes node can be [tainted](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/taint-toleration-dedicated.md) with keys. Together with node selector feature, users can create nodes that are dedicated for only running etcd clusters. This is the **suggested way** to run high performance large scale etcd clusters.
+Kubernetes node can be [tainted](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/taint-toleration-dedicated.md) with keys. Together with node selector feature, users can create nodes that are dedicated for only running etcd clusters. This is the **suggested way** to run high performance large scale etcd clusters.
 
 Use kubectl to taint the node with kubectl taint nodes etcd dedicated. Then only etcd pods, which tolerate this taint will be assigned to the nodes.

--- a/doc/design/cluster_status.md
+++ b/doc/design/cluster_status.md
@@ -2,14 +2,14 @@
 
 An etcd cluster permanently fails when all its members are dead and no backup is available. A user might update etcd cluster TPR with invalid input or format. The operator needs to notify users about these bad events.
 
-A common way to do this in the Kuberentes world is through status field, like pod.status. The etcd operator will write out cluster status similar to pod status.
+A common way to do this in the Kubernetes world is through status field, like pod.status. The etcd operator will write out cluster status similar to pod status.
 
 ```go
 type EtcdCluster struct {
     unversioned.TypeMeta `json:",inline"`
     api.ObjectMeta       `json:"metadata,omitempty"`
     Spec                 ClusterSpec `json:"spec"`
-    Status               ClusterStatus `json:"status"`   
+    Status               ClusterStatus `json:"status"`
 }
 
 Type ClusterStatus struct {
@@ -20,7 +20,7 @@ Type ClusterStatus struct {
 
 The etcd operator keeps the truth of the cluster status, and update the TPR item after each cluster reconciliation atomically. Note that users can:
 
- - modify TPR item concurrently with the operator. 
+ - modify TPR item concurrently with the operator.
  - update TPR and overwrite the status filed with empty or bad input
 
  The operator MUST handle these two cases gracefully. Thus, the operator MUST NOT overwrite the user input on spec field. The operator CANNOT trust the existing status filed in TPR.


### PR DESCRIPTION
Fixes misspellings of Kubernetes and removes some extraneous whitespace