### PR TITLE
Add support for specifying etcd pod probe config & changing reconcile loop timer

### DIFF
--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -59,6 +59,8 @@ var (
 	createCRD bool
 
 	clusterWide bool
+
+	reconcileInterval time.Duration
 )
 
 func init() {
@@ -69,6 +71,7 @@ func init() {
 	flag.BoolVar(&createCRD, "create-crd", true, "The operator will not create the EtcdCluster CRD when this flag is set to false.")
 	flag.DurationVar(&gcInterval, "gc-interval", 10*time.Minute, "GC interval")
 	flag.BoolVar(&clusterWide, "cluster-wide", false, "Enable operator to watch clusters in all namespaces")
+	flag.DurationVar(&reconcileInterval, "re-interval", 8*time.Second, "Cluster reconcile interval")
 	flag.Parse()
 }
 
@@ -153,13 +156,14 @@ func newControllerConfig() controller.Config {
 	}
 
 	cfg := controller.Config{
-		Namespace:      namespace,
-		ClusterWide:    clusterWide,
-		ServiceAccount: serviceAccount,
-		KubeCli:        kubecli,
-		KubeExtCli:     k8sutil.MustNewKubeExtClient(),
-		EtcdCRCli:      client.MustNewInCluster(),
-		CreateCRD:      createCRD,
+		Namespace:         namespace,
+		ClusterWide:       clusterWide,
+		ServiceAccount:    serviceAccount,
+		KubeCli:           kubecli,
+		KubeExtCli:        k8sutil.MustNewKubeExtClient(),
+		EtcdCRCli:         client.MustNewInCluster(),
+		CreateCRD:         createCRD,
+		ReconcileInterval: reconcileInterval,
 	}
 
 	return cfg

--- a/doc/user/spec_examples.md
+++ b/doc/user/spec_examples.md
@@ -83,5 +83,25 @@ spec:
       prometheus.io/port: "2379"
 ```
 
+## Custom pod probe configuration
+
+```yaml
+spec:
+  size: 3
+  pod:
+    livenessProbe:
+      failureThreshold: 3
+      initialDelaySeconds: 300
+      periodSeconds: 60
+      successThreshold: 1
+      timeoutSeconds: 10
+    readinessProbe:
+      failureThreshold: 3
+      initialDelaySeconds: 1
+      periodSeconds: 5
+      successThreshold: 1
+      timeoutSeconds: 5
+```
+
 
 [cluster-tls]: cluster_tls.md

--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -16,6 +16,8 @@ spec:
         - etcd-operator
         # Uncomment to act for resources in all namespaces. More information in doc/clusterwide.md
         #- -cluster-wide
+        # Uncomment to set the cluster reconcile interval (default 8 sec) to reduce monitoring overhead.
+        #- -re-interval=15s
         env:
         - name: MY_POD_NAMESPACE
           valueFrom:

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -148,6 +148,14 @@ type PodPolicy struct {
 	// busybox:latest uses uclibc which contains a bug that sometimes prevents name resolution
 	// More info: https://github.com/docker-library/busybox/issues/27
 	BusyboxImage string `json:"busyboxImage,omitempty"`
+
+	// LivenessProbe specifies the parameters for the probe.
+	// The "livenessprobe.handler" will be set by etcd operator and shouldn't be defined"
+	LivenessProbe *v1.Probe `json:"livenessProbe,omitempty"`
+
+	// ReadinessProbe specifies the parameters for the probe.
+	// The "readinessprobe.handler" will be set by etcd operator and shouldn't be defined"
+	ReadinessProbe *v1.Probe `json:"readinessProbe,omitempty"`
 }
 
 // TODO: move this to initializer

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -39,7 +39,6 @@ import (
 )
 
 var (
-	reconcileInterval         = 8 * time.Second
 	podTerminationGracePeriod = int64(5)
 )
 
@@ -59,6 +58,8 @@ type Config struct {
 
 	KubeCli   kubernetes.Interface
 	EtcdCRCli versioned.Interface
+
+	ReconcileInterval time.Duration
 }
 
 type Cluster struct {
@@ -218,7 +219,7 @@ func (c *Cluster) run() {
 				panic("unknown event type" + event.typ)
 			}
 
-		case <-time.After(reconcileInterval):
+		case <-time.After(c.config.ReconcileInterval):
 			start := time.Now()
 
 			if c.cluster.Spec.Paused {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -44,13 +44,14 @@ type Controller struct {
 }
 
 type Config struct {
-	Namespace      string
-	ClusterWide    bool
-	ServiceAccount string
-	KubeCli        kubernetes.Interface
-	KubeExtCli     apiextensionsclient.Interface
-	EtcdCRCli      versioned.Interface
-	CreateCRD      bool
+	Namespace         string
+	ClusterWide       bool
+	ServiceAccount    string
+	KubeCli           kubernetes.Interface
+	KubeExtCli        apiextensionsclient.Interface
+	EtcdCRCli         versioned.Interface
+	CreateCRD         bool
+	ReconcileInterval time.Duration
 }
 
 func New(cfg Config) *Controller {
@@ -119,9 +120,10 @@ func (c *Controller) handleClusterEvent(event *Event) (bool, error) {
 
 func (c *Controller) makeClusterConfig() cluster.Config {
 	return cluster.Config{
-		ServiceAccount: c.Config.ServiceAccount,
-		KubeCli:        c.Config.KubeCli,
-		EtcdCRCli:      c.Config.EtcdCRCli,
+		ServiceAccount:    c.Config.ServiceAccount,
+		KubeCli:           c.Config.KubeCli,
+		EtcdCRCli:         c.Config.EtcdCRCli,
+		ReconcileInterval: c.Config.ReconcileInterval,
 	}
 }
 

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -312,12 +312,14 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 		"etcd_cluster": clusterName,
 	}
 
-	livenessProbe := newEtcdProbe(cs.TLS.IsSecureClient())
-	readinessProbe := newEtcdProbe(cs.TLS.IsSecureClient())
-	readinessProbe.InitialDelaySeconds = 1
-	readinessProbe.TimeoutSeconds = 5
-	readinessProbe.PeriodSeconds = 5
-	readinessProbe.FailureThreshold = 3
+	livenessProbe := newEtcdProbe(cs.TLS.IsSecureClient(), cs.Pod.LivenessProbe)
+	readinessProbe := newEtcdProbe(cs.TLS.IsSecureClient(), cs.Pod.ReadinessProbe)
+	if cs.Pod.ReadinessProbe == nil {
+		readinessProbe.InitialDelaySeconds = 1
+		readinessProbe.TimeoutSeconds = 5
+		readinessProbe.PeriodSeconds = 5
+		readinessProbe.FailureThreshold = 3
+	}
 
 	container := containerWithProbes(
 		etcdContainer(strings.Split(commands, " "), cs.Repository, cs.Version),


### PR DESCRIPTION
Both these changes allow modification of the fixed settings in today's code to deal conditions that either prevent etcd clusters from being created (probe configs) or overload monitoring of clusters (reconcile timer).