### PR TITLE
Avoid probe failure from auth enable

### DIFF
--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -69,7 +69,7 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 }
 
 func newEtcdProbe(isSecure bool) *v1.Probe {
-	// etcd pod is alive only if a linearizable get succeeds.
+	// etcd pod is healthy only if it can participate in consensus
 	cmd := "ETCDCTL_API=3 etcdctl endpoint health"
 	if isSecure {
 		tlsFlags := fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, etcdutil.CliCertFile, etcdutil.CliKeyFile, etcdutil.CliCAFile)

--- a/pkg/util/k8sutil/pod_util.go
+++ b/pkg/util/k8sutil/pod_util.go
@@ -70,10 +70,10 @@ func containerWithRequirements(c v1.Container, r v1.ResourceRequirements) v1.Con
 
 func newEtcdProbe(isSecure bool) *v1.Probe {
 	// etcd pod is alive only if a linearizable get succeeds.
-	cmd := "ETCDCTL_API=3 etcdctl get foo"
+	cmd := "ETCDCTL_API=3 etcdctl endpoint health"
 	if isSecure {
 		tlsFlags := fmt.Sprintf("--cert=%[1]s/%[2]s --key=%[1]s/%[3]s --cacert=%[1]s/%[4]s", operatorEtcdTLSDir, etcdutil.CliCertFile, etcdutil.CliKeyFile, etcdutil.CliCAFile)
-		cmd = fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=https://localhost:%d %s get foo", EtcdClientPort, tlsFlags)
+		cmd = fmt.Sprintf("ETCDCTL_API=3 etcdctl --endpoints=https://localhost:%d %s endpoint health", EtcdClientPort, tlsFlags)
 	}
 	return &v1.Probe{
 		Handler: v1.Handler{


### PR DESCRIPTION
Change the probe to check `endpoint health` instead of `get foo` so that enabling authorization does not take down the cluster.