### PR TITLE
Add a time-out for waiting on DNS

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -152,6 +152,11 @@ type PodPolicy struct {
 	// SecurityContext specifies the security context for the entire pod
 	// More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context
 	SecurityContext *v1.PodSecurityContext `json:"securityContext,omitempty"`
+
+	// DNSTimeoutInSecond is the maximum allowed time for the init container of the etcd pod to
+	// reverse DNS lookup its IP given the hostname.
+	// The default is to wait indefinitely and has a vaule of 0.
+	DNSTimeoutInSecond int64 `json:"DNSTimeoutInSecond,omitempty"`
 }
 
 // TODO: move this to initializer

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -365,11 +365,20 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 				Name:  "check-dns",
 				// In etcd 3.2, TLS listener will do a reverse-DNS lookup for pod IP -> hostname.
 				// If DNS entry is not warmed up, it will return empty result and peer connection will be rejected.
+				// In some cases the DNS is not created correctly so we need to time out after a given period.
 				Command: []string{"/bin/sh", "-c", fmt.Sprintf(`
+					TIMEOUT_READY=%d
 					while ( ! nslookup %s )
 					do
-						sleep 2
-					done`, m.Addr())},
+						# If TIMEOUT_READY is 0 we should never time out and exit 
+						TIMEOUT_READY=$(( TIMEOUT_READY-1 ))
+                        if [ $TIMEOUT_READY -eq 0 ];
+				        then
+				            echo "Timed out waiting for DNS entry"
+				            exit 1
+				        fi
+						sleep 1
+					done`, cs.Pod.DNSTimeoutInSecond, m.Addr())},
 			}},
 			Containers:    []v1.Container{container},
 			RestartPolicy: v1.RestartPolicyNever,


### PR DESCRIPTION
Adding a timeout for waiting on the DNS entry to exists. This prevents the init container to be in an inifinite loop in case of a failure of registering the DNS on startup

We have seen this happening on GKE with preemptive nodes where the pod got created before the network was able to assign it an IP causing the init container to be stuck forever in this loop.