### PR TITLE
e2e/framework: support on-cluster as well as kubeconfig

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -61,7 +62,14 @@ func setup() error {
 	ns := flag.String("namespace", "default", "e2e test namespace")
 	flag.Parse()
 
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	var config *rest.Config
+	var err error
+	if *kubeconfig == "" {
+		//on-cluster mode
+		config, err = rest.InClusterConfig()
+	} else {
+		config, err = clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
If kubeconfig is not provided to e2e framwork binary, assume that the framework is running on-cluster

\cc @hasbro17 