### PR TITLE
test: run e2e test pod without framework setup

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -76,10 +76,21 @@ func setup() error {
 		Namespace:  *ns,
 		opImage:    *opImage,
 	}
+
+	// Skip the etcd-operator deployment setup if the operator image was not specified
+	if len(Global.opImage) == 0 {
+		return nil
+	}
+
 	return Global.setup()
 }
 
 func teardown() error {
+	// Skip the etcd-operator teardown if the operator image was not specified
+	if len(Global.opImage) == 0 {
+		return nil
+	}
+
 	err := Global.deleteOperatorCompletely("etcd-operator")
 	if err != nil {
 		return err

--- a/test/pod/simple/Dockerfile
+++ b/test/pod/simple/Dockerfile
@@ -1,0 +1,21 @@
+# golang:X-alpine can't be used since it does not support the race detector flag which assumes a glibc based system, whereas alpine linux uses musl libc
+# https://github.com/golang/go/issues/14481
+FROM golang:1.10.2 as builder
+
+RUN wget -nv -O /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.2/bin/linux/amd64/kubectl
+
+RUN chmod a+x /bin/kubectl
+
+ADD ./ /go/src/github.com/coreos/etcd-operator
+
+WORKDIR /go/src/github.com/coreos/etcd-operator
+
+RUN go test ./test/e2e/ -c -o /bin/etcd-operator-e2e --race
+
+FROM busybox:1.28.3-glibc
+
+COPY --from=builder /bin/etcd-operator-e2e /bin
+COPY --from=builder /bin/kubectl /bin
+COPY --from=builder /go/src/github.com/coreos/etcd-operator/test/pod/simple/run-e2e /bin/run-e2e
+
+CMD ["/bin/run-e2e"]

--- a/test/pod/simple/run-e2e
+++ b/test/pod/simple/run-e2e
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+: ${TEST_NAMESPACE:?"Need to set TEST_NAMESPACE"}
+
+# Run e2e tests 
+/bin/etcd-operator-e2e -test.timeout 30m -test.failfast -test.parallel 4 --namespace=${TEST_NAMESPACE}

--- a/test/pod/simple/simple-pod-templ.yaml
+++ b/test/pod/simple/simple-pod-templ.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: etcd-operator-e2e-tests
+spec:
+  restartPolicy: Never
+  containers:
+  - name: etcd-operator-e2e-tests
+    image: <TEST_IMAGE>
+    imagePullPolicy: Always
+    env:
+      - name: TEST_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace


### PR DESCRIPTION
Added a simplified version of the current [test/pod](https://github.com/coreos/etcd-operator/blob/master/test/pod/test-pod-templ.yaml) to reduce the number of configurations.

Modified the e2e test framework to skip the operator setup if no test image is provided.

This way the test-pod can be used to run e2e tests in a namespace with an already deployed etcd-operator.

The default cmd is set to `run-e2e` which only runs the e2e tests for now.
The [e2e-slow](https://github.com/coreos/etcd-operator/tree/master/test/e2e/e2eslow) tests are not run for now because they require aws creds or modify the deployed operator which requires the operator image env.

The Dockerfile for the simplified test pod is 2 staged. The first stage builds the test binary and the second stage adds the test binary to be run inside a smaller image.

/cc @colhom @fanminshi 