### PR TITLE
Use 'kubectl apply' instead of 'create' to allow subsequent changes via apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ See [instructions on how to install/uninstall etcd operator](doc/user/install_gu
 ### Create and destroy an etcd cluster
 
 ```bash
-$ kubectl create -f example/example-etcd-cluster.yaml
+$ kubectl apply -f example/example-etcd-cluster.yaml
 ```
 
 A 3 member etcd cluster will be created.


### PR DESCRIPTION
In the example, `kubectl create` is used.  But later when you want to scale up the etcd cluster and use `kubectl apply`, you get "Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply"

