### PR TITLE
README: update URL to unit test badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # etcd operator
 unit/integration:
-[![Build Status](https://jenkins-etcd-public.prod.coreos.systems/view/operator/job/etcd-operator-unit-master/badge/icon)](https://jenkins-etcd-public.prod.coreos.systems/view/operator/job/etcd-operator-unit-master/)
+[![Build Status](https://jenkins-etcd-public.prod.coreos.systems/job/etcd-operator-unit-master/badge/icon)](https://jenkins-etcd-public.prod.coreos.systems/job/etcd-operator-unit-master/lastBuild/)
 e2e (Kubernetes stable):
 [![Build Status](https://jenkins-etcd-public.prod.coreos.systems/buildStatus/icon?job=etcd-operator-master)](https://jenkins-etcd-public.prod.coreos.systems/job/etcd-operator-master/)
 e2e (upgrade):


### PR DESCRIPTION
Due to a Jenkins upgrade (I think?) the URL for the unit test badge
changed. Fix this.