### PR TITLE
Add cloud environment support for ABS backup

### DIFF
--- a/pkg/apis/etcd/v1beta2/backup_types.go
+++ b/pkg/apis/etcd/v1beta2/backup_types.go
@@ -26,6 +26,7 @@ const (
 	BackupStorageTypeABS      BackupStorageType = "ABS"
 	AzureSecretStorageAccount                   = "storage-account"
 	AzureSecretStorageKey                       = "storage-key"
+	AzureCloudKey                               = "cloud"
 )
 
 type BackupStorageType string


### PR DESCRIPTION
PR #1842 adds support for ABS (Azure Blob Service) backup. But it always using AzurePublicCloud, so that other sovereign clouds (e.g. mooncake) won't work.

This PR adds an extra option `cloud` to ABS credential and use `storage.NewBasicClientOnSovereignCloud()`  to fix the issue. If `cloud` is not set, then AzurePublicCloud is used (same as before).

Example ABS credential now is

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: abs-credentials
type: Opaque
stringData:
  storage-account: <storage-account-name>
  storage-key: <storage-key>
  cloud: AzurePublicCloud
```