### PR TITLE
etcd-backup: support for google cloud storage

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,9 +3,23 @@
 
 [[projects]]
   name = "cloud.google.com/go"
-  packages = ["compute/metadata"]
-  revision = "20d4028b8a750c2aca76bf9fefa8ed2d0109b573"
-  version = "v0.19.0"
+  packages = [
+    "compute/metadata",
+    "iam",
+    "internal",
+    "internal/optional",
+    "internal/trace",
+    "internal/version",
+    "storage"
+  ]
+  revision = "aad3f485ee528456e0768f20397b4d9dd941e755"
+  version = "v0.25.0"
+
+[[projects]]
+  name = "contrib.go.opencensus.io/exporter/stackdriver"
+  packages = ["propagation"]
+  revision = "37aa2801fbf0205003e15636096ebf0373510288"
+  version = "v0.5.0"
 
 [[projects]]
   name = "github.com/Azure/azure-sdk-for-go"
@@ -145,6 +159,12 @@
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  name = "github.com/googleapis/gax-go"
+  packages = ["."]
+  revision = "317e0006254c44a0ac427cc52a0e083ff0b9622f"
+  version = "v2.0.0"
+
+[[projects]]
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
@@ -268,6 +288,25 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "internal",
+    "internal/tagencoding",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/propagation"
+  ]
+  revision = "e262766cd0d230a1bb7c37281e345e465f19b41b"
+  version = "v0.14.0"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
   packages = ["ssh/terminal"]
@@ -298,7 +337,7 @@
     "jws",
     "jwt"
   ]
-  revision = "2f32c3ac0fa4fb807a0fcefb0b6f2468a0d99bd0"
+  revision = "3d292e4d0cdc3a0113e6d207bb137145ef1de42f"
 
 [[projects]]
   branch = "master"
@@ -337,6 +376,23 @@
   revision = "6dc17368e09b0e8634d71cac8168d853e869a0c7"
 
 [[projects]]
+  branch = "master"
+  name = "google.golang.org/api"
+  packages = [
+    "cloudkms/v1",
+    "gensupport",
+    "googleapi",
+    "googleapi/internal/uritemplates",
+    "googleapi/transport",
+    "internal",
+    "iterator",
+    "option",
+    "storage/v1",
+    "transport/http"
+  ]
+  revision = "f6d94689cbd71030af1108ddac733886fcae1d75"
+
+[[projects]]
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -358,6 +414,8 @@
   name = "google.golang.org/genproto"
   packages = [
     "googleapis/api/annotations",
+    "googleapis/iam/v1",
+    "googleapis/rpc/code",
     "googleapis/rpc/status"
   ]
   revision = "df60624c1e9b9d2973e889c7a1cff73155da81c4"
@@ -602,6 +660,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "39eb18288d85b8046b11837309b8fb215359ca43e163bbb8f88721d1bc42616e"
+  inputs-digest = "e51612faed48eec703227f20471aa576dfd9f5e761758f91f9ad6b1759095097"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,5 @@
+required = ["golang.org/x/oauth2"]
+
 [[constraint]]
   name = "k8s.io/api"
   version = "kubernetes-1.10.0-beta.2"
@@ -44,7 +46,16 @@
 
 [[constraint]]
   name = "golang.org/x/time"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/Azure/azure-sdk-for-go"
   version = "=11.3.0-beta"
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/oauth2"
+
+[[constraint]]
+  version = "v0.25.0"
+  name = "cloud.google.com/go"

--- a/pkg/apis/etcd/v1beta2/backup_types.go
+++ b/pkg/apis/etcd/v1beta2/backup_types.go
@@ -26,6 +26,9 @@ const (
 	BackupStorageTypeABS      BackupStorageType = "ABS"
 	AzureSecretStorageAccount                   = "storage-account"
 	AzureSecretStorageKey                       = "storage-key"
+
+	// Google GCS related consts
+	BackupStorageTypeGCS BackupStorageType = "GCS"
 )
 
 type BackupStorageType string
@@ -80,6 +83,8 @@ type BackupSource struct {
 	S3 *S3BackupSource `json:"s3,omitempty"`
 	// ABS defines the ABS backup source spec.
 	ABS *ABSBackupSource `json:"abs,omitempty"`
+	// GCS defines the ABS backup source spec.
+	GCS *GCSBackupSource `json:"gcs,omitempty"`
 }
 
 // BackupPolicy defines backup policy.
@@ -129,4 +134,15 @@ type ABSBackupSource struct {
 
 	// The name of the secret object that stores the Azure storage credential
 	ABSSecret string `json:"absSecret"`
+}
+
+// GCSBackupSource provides the spec how to store backups on GCS.
+type GCSBackupSource struct {
+	// Path is the full abs path where the backup is saved.
+	// The format of the path must be: "<gcs-container-name>/<path-to-backup-file>"
+	// e.g: "mygcscontainer/etcd.backup"
+	Path string `json:"path"`
+
+	// The name of the secret object that stores the Google storage credential
+	GCSSecret string `json:"gcsSecret"`
 }

--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -66,6 +66,9 @@ type RestoreSource struct {
 
 	// ABS tells where on ABS the backup is saved and how to fetch the backup.
 	ABS *ABSRestoreSource `json:"abs,omitempty"`
+
+	// GCS tells where on GCS the backup is saved and how to fetch the backup.
+	GCS *GCSRestoreSource `json:"gcs,omitempty"`
 }
 
 type S3RestoreSource struct {
@@ -95,6 +98,16 @@ type ABSRestoreSource struct {
 
 	// The name of the secret object that stores the Azure Blob Storage credential.
 	ABSSecret string `json:"absSecret"`
+}
+
+type GCSRestoreSource struct {
+	// Path is the full gcs path where the backup is saved.
+	// The format of the path must be: "<gcs-container-name>/<path-to-backup-file>"
+	// e.g: "mygcscontainer/etcd.backup"
+	Path string `json:"path"`
+
+	// The name of the secret object that stores the Google Cloud Storage credential.
+	GCSSecret string `json:"gcsSecret"`
 }
 
 // RestoreStatus reports the status of this restore operation.

--- a/pkg/backup/backup_manager.go
+++ b/pkg/backup/backup_manager.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"strings"
 
 	"github.com/coreos/etcd-operator/pkg/backup/writer"
 	"github.com/coreos/etcd-operator/pkg/util/constants"
@@ -129,15 +130,8 @@ func getClientWithMaxRev(ctx context.Context, endpoints []string, tc *tls.Config
 	if maxClient == nil {
 		return nil, 0, fmt.Errorf("could not create an etcd client for the max revision purpose from given endpoints (%v)", endpoints)
 	}
-
-	var err error
 	if len(errors) > 0 {
-		errorStr := ""
-		for _, errStr := range errors {
-			errorStr += errStr + "\n"
-		}
-		err = fmt.Errorf(errorStr)
+		return maxClient, maxRev, fmt.Errorf(strings.Join(errors, "\n"))
 	}
-
-	return maxClient, maxRev, err
+	return maxClient, maxRev, nil
 }

--- a/pkg/backup/reader/gcs_reader.go
+++ b/pkg/backup/reader/gcs_reader.go
@@ -1,0 +1,46 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reader
+
+import (
+	"context"
+	"io"
+
+	"cloud.google.com/go/storage"
+	"github.com/coreos/etcd-operator/pkg/backup/util"
+)
+
+// ensure gcsReader satisfies reader interface.
+var _ Reader = &gcsReader{}
+
+type gcsReader struct {
+	gcs *storage.Client
+}
+
+// NewS3Writer creates a s3 writer.
+func NewGCSReader(gcs *storage.Client) Reader {
+	return &gcsReader{
+		gcs: gcs,
+	}
+}
+
+// Write writes the backup file to the given gcs path, "<gcs-bucket-name>/<key>".
+func (g *gcsReader) Open(path string) (io.ReadCloser, error) {
+	bucketName, keyPath, err := util.ParseBucketAndKey(path)
+	if err != nil {
+		return nil, err
+	}
+	return g.gcs.Bucket(bucketName).Object(keyPath).NewReader(context.Background())
+}

--- a/pkg/backup/writer/gcs_writer.go
+++ b/pkg/backup/writer/gcs_writer.go
@@ -1,0 +1,60 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package writer
+
+import (
+	"context"
+	"io"
+
+	"cloud.google.com/go/storage"
+
+	"github.com/coreos/etcd-operator/pkg/backup/util"
+	log "github.com/sirupsen/logrus"
+)
+
+type gcsWriter struct {
+	gcs *storage.Client
+}
+
+// NewS3Writer creates a s3 writer.
+func NewGCSWriter(gcs *storage.Client) Writer {
+	return &gcsWriter{
+		gcs: gcs,
+	}
+}
+
+// Write writes the backup file to the given gcs path, "<gcs-bucket-name>/<key>".
+func (g *gcsWriter) Write(ctx context.Context, path string, r io.Reader) (int64, error) {
+	bucketName, keyPath, err := util.ParseBucketAndKey(path)
+	if err != nil {
+		return 0, err
+	}
+
+	bucketWriter := g.gcs.Bucket(bucketName).Object(keyPath).NewWriter(ctx)
+	log.Infof("Writing etcd snapshot in bucket %s as object name %s", bucketName, keyPath)
+	n, err := io.Copy(bucketWriter, r)
+	if err != nil {
+		log.Errorf("Failed to write the etcd backup to the bucket %s at the key %s: %v", bucketName, keyPath, err)
+		return 0, err
+	}
+	// GCS actually sync data to the bucket on close
+	err = bucketWriter.Close()
+	if err != nil {
+		log.Errorf("Unexpected error while writing %d bytes to the bucket %s as object name %s", n, bucketName, keyPath, err)
+		return 0, err
+	}
+	log.Infof("Wrote %d bytes to the bucket %s at the key %s", n, bucketName, keyPath)
+	return int64(n), nil
+}

--- a/pkg/controller/backup-operator/gcs_backup.go
+++ b/pkg/controller/backup-operator/gcs_backup.go
@@ -1,0 +1,54 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+
+	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
+	"github.com/coreos/etcd-operator/pkg/backup"
+	"github.com/coreos/etcd-operator/pkg/backup/writer"
+	"github.com/coreos/etcd-operator/pkg/util/gcsutil/gcsfactory"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/client-go/kubernetes"
+)
+
+// handleGCS saves etcd cluster's backup to specificed GCS path.
+func handleGCS(ctx context.Context, kubecli kubernetes.Interface, s *api.GCSBackupSource, endpoints []string, clientTLSSecret, namespace string) (*api.BackupStatus, error) {
+	log.Infof("Starting a GCS backup on %s", s.Path)
+	// TODO: controls NewClientFromSecret with ctx. This depends on upstream kubernetes to support API calls with ctx.
+	cli, err := gcsfactory.NewClientFromSecret(kubecli, namespace, s.GCSSecret)
+	if err != nil {
+		return nil, err
+	}
+	defer cli.GCS.Close()
+
+	var tlsConfig *tls.Config
+	if tlsConfig, err = generateTLSConfig(kubecli, clientTLSSecret, namespace); err != nil {
+		return nil, err
+	}
+
+	w := writer.NewGCSWriter(cli.GCS)
+	bm := backup.NewBackupManagerFromWriter(kubecli, w, tlsConfig, endpoints, namespace)
+
+	rev, etcdVersion, err := bm.SaveSnap(ctx, s.Path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to save snapshot (%v)", err)
+	}
+	log.Infof("Successfully handled the backup operation")
+	return &api.BackupStatus{EtcdVersion: etcdVersion, EtcdRevision: rev}, nil
+}

--- a/pkg/controller/backup-operator/sync.go
+++ b/pkg/controller/backup-operator/sync.go
@@ -143,6 +143,12 @@ func (b *Backup) handleBackup(spec *api.BackupSpec) (*api.BackupStatus, error) {
 			return nil, err
 		}
 		return bs, nil
+	case api.BackupStorageTypeGCS:
+		bs, err := handleGCS(ctx, b.kubecli, spec.GCS, spec.EtcdEndpoints, spec.ClientTLSSecret, b.namespace)
+		if err != nil {
+			return nil, err
+		}
+		return bs, nil
 	default:
 		logrus.Fatalf("unknown StorageType: %v", spec.StorageType)
 	}

--- a/pkg/controller/backup-operator/util.go
+++ b/pkg/controller/backup-operator/util.go
@@ -20,13 +20,14 @@ import (
 
 	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
 	"github.com/coreos/etcd-operator/pkg/util/k8sutil"
-
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 )
 
 func generateTLSConfig(kubecli kubernetes.Interface, clientTLSSecret, namespace string) (*tls.Config, error) {
 	var tlsConfig *tls.Config
 	if len(clientTLSSecret) != 0 {
+		log.Infof("Creating etcd TLS config from secret/%s in namespace %s", clientTLSSecret, namespace)
 		d, err := k8sutil.GetTLSDataFromSecret(kubecli, namespace, clientTLSSecret)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get TLS data from secret (%v): %v", clientTLSSecret, err)
@@ -35,6 +36,8 @@ func generateTLSConfig(kubecli kubernetes.Interface, clientTLSSecret, namespace 
 		if err != nil {
 			return nil, fmt.Errorf("failed to constructs tls config: %v", err)
 		}
+		return tlsConfig, nil
 	}
+	log.Infof("Skipping the etcd TLS config, no secret provided")
 	return tlsConfig, nil
 }

--- a/pkg/util/gcsutil/gcsfactory/client.go
+++ b/pkg/util/gcsutil/gcsfactory/client.go
@@ -1,0 +1,47 @@
+// Copyright 2017 The etcd-operator Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcsfactory
+
+import (
+	"fmt"
+
+	gcs "cloud.google.com/go/storage"
+	"context"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/cloudkms/v1"
+	"google.golang.org/api/option"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GCSClient is a wrapper of GCS client that provides cleanup functionality.
+type GCSClient struct {
+	GCS *gcs.Client
+}
+
+// NewClientFromSecret returns a GCS client based on given k8s secret containing gcs credentials.
+func NewClientFromSecret(_ kubernetes.Interface, _, _ string) (*GCSClient, error) {
+	// implicit client
+	httpClient, err := google.DefaultClient(context.Background(), cloudkms.CloudPlatformScope)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create google cloud platform client: %v", err)
+	}
+	c, err := gcs.NewClient(context.Background(), option.WithHTTPClient(httpClient))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create gcs client with: %v", err)
+	}
+	log.Infof("Created an implicit GCS client")
+	return &GCSClient{c}, nil
+}


### PR DESCRIPTION
### What does this PR do?

Extend **etcd-backup-operator** to store etcd backups in Google Cloud Storage.

### Motivation

Support an additional cloud storage backend.

### Additional Notes

It uses google implicit client as the official documentation suggested [see](https://github.com/GoogleCloudPlatform/golang-samples/blob/71b2d51aafc87f99f79d671a9cc0a6df02522fc6/auth/snippets.go#L23).

```text
INFO[1433] Starting a GCS backup on k8s-etcd-backup-julien/etcd-backup/2018-08-06-17-07-10 
INFO[1433] Created an implicit GCS client               
INFO[1433] Skipping the etcd TLS config, no secret provided 
INFO[1433] getMaxRev: endpoint http://127.0.0.1:9379 revision (844407) 
INFO[1433] Writing etcd snapshot in bucket k8s-etcd-backup-julien as object name etcd-backup/2018-08-06-17-07-10 
INFO[1433] Wrote 4882464 bytes to the bucket k8s-etcd-backup-julien at the key etcd-backup/2018-08-06-17-07-10 
INFO[1433] Successfully handled the backup operation
```
```bash
gsutil ls gs://k8s-etcd-backup-julien/etcd-backup/2018-08-06-17-07-10 
gs://k8s-etcd-backup-julien/etcd-backup/2018-08-06-17-07-10
```