### PR TITLE
s3: add option to force path style addressing

### DIFF
--- a/example/etcd-backup-operator/backup_cr.yaml
+++ b/example/etcd-backup-operator/backup_cr.yaml
@@ -10,3 +10,8 @@ spec:
     # e.g: "mybucket/etcd.backup"
     path: <full-s3-path>
     awsSecret: <aws-secret>
+    ## endpoint configures custom (non-aws) s3 endpoint
+    #endpoint: https://play.minio.io:9000
+    ## forcePathStyle, if set to true, forces s3 requests to use path style addressing
+    ## (host/bucket instead of bucket.host)
+    #forcePathStyle: true

--- a/pkg/apis/etcd/v1beta2/backup_types.go
+++ b/pkg/apis/etcd/v1beta2/backup_types.go
@@ -119,6 +119,10 @@ type S3BackupSource struct {
 	// Endpoint if blank points to aws. If specified, can point to s3 compatible object
 	// stores.
 	Endpoint string `json:"endpoint,omitempty"`
+
+	// ForcePathStyle, if set to true, forces s3 requests to use path style addressing
+	// (host/bucket instead of bucket.host)
+	ForcePathStyle *bool `json:"forcePathStyle"`
 }
 
 // ABSBackupSource provides the spec how to store backups on ABS.

--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -85,6 +85,10 @@ type S3RestoreSource struct {
 	// Endpoint if blank points to aws. If specified, can point to s3 compatible object
 	// stores.
 	Endpoint string `json:"endpoint"`
+
+	// ForcePathStyle, if set to true, forces s3 requests to use path style addressing
+	// (host/bucket instead of bucket.host)
+	ForcePathStyle *bool `json:"forcePathStyle"`
 }
 
 type ABSRestoreSource struct {

--- a/pkg/controller/backup-operator/s3_backup.go
+++ b/pkg/controller/backup-operator/s3_backup.go
@@ -31,7 +31,7 @@ import (
 // handleS3 saves etcd cluster's backup to specificed S3 path.
 func handleS3(ctx context.Context, kubecli kubernetes.Interface, s *api.S3BackupSource, endpoints []string, clientTLSSecret, namespace string) (*api.BackupStatus, error) {
 	// TODO: controls NewClientFromSecret with ctx. This depends on upstream kubernetes to support API calls with ctx.
-	cli, err := s3factory.NewClientFromSecret(kubecli, namespace, s.Endpoint, s.AWSSecret)
+	cli, err := s3factory.NewClientFromSecret(kubecli, namespace, s.Endpoint, s.ForcePathStyle, s.AWSSecret)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/restore-operator/http.go
+++ b/pkg/controller/restore-operator/http.go
@@ -91,7 +91,7 @@ func (r *Restore) serveBackup(w http.ResponseWriter, req *http.Request) error {
 			return errors.New("invalid s3 restore source field (spec.s3), must specify all required subfields")
 		}
 
-		s3Cli, err := s3factory.NewClientFromSecret(r.kubecli, r.namespace, s3RestoreSource.Endpoint, s3RestoreSource.AWSSecret)
+		s3Cli, err := s3factory.NewClientFromSecret(r.kubecli, r.namespace, s3RestoreSource.Endpoint, s3RestoreSource.ForcePathStyle, s3RestoreSource.AWSSecret)
 		if err != nil {
 			return fmt.Errorf("failed to create S3 client: %v", err)
 		}

--- a/pkg/util/awsutil/s3factory/client.go
+++ b/pkg/util/awsutil/s3factory/client.go
@@ -39,7 +39,7 @@ type S3Client struct {
 }
 
 // NewClientFromSecret returns a S3 client based on given k8s secret containing aws credentials.
-func NewClientFromSecret(kubecli kubernetes.Interface, namespace, endpoint, awsSecret string) (w *S3Client, err error) {
+func NewClientFromSecret(kubecli kubernetes.Interface, namespace, endpoint string, forcePathStyle *bool, awsSecret string) (w *S3Client, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("new S3 client failed: %v", err)
@@ -50,7 +50,7 @@ func NewClientFromSecret(kubecli kubernetes.Interface, namespace, endpoint, awsS
 	if err != nil {
 		return nil, fmt.Errorf("failed to create aws config dir: (%v)", err)
 	}
-	so, err := setupAWSConfig(kubecli, namespace, awsSecret, endpoint, w.configDir)
+	so, err := setupAWSConfig(kubecli, namespace, awsSecret, endpoint, forcePathStyle, w.configDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to setup aws config: (%v)", err)
 	}
@@ -68,12 +68,13 @@ func (w *S3Client) Close() {
 }
 
 // setupAWSConfig setup local AWS config/credential files from Kubernetes aws secret.
-func setupAWSConfig(kubecli kubernetes.Interface, ns, secret, endpoint, configDir string) (*session.Options, error) {
+func setupAWSConfig(kubecli kubernetes.Interface, ns, secret, endpoint string, forcePathStyle *bool, configDir string) (*session.Options, error) {
 	options := &session.Options{}
 	options.SharedConfigState = session.SharedConfigEnable
 
 	// empty string defaults to aws
 	options.Config.Endpoint = &endpoint
+	options.Config.S3ForcePathStyle = forcePathStyle
 
 	se, err := kubecli.CoreV1().Secrets(ns).Get(secret, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/util/awsutil/s3factory/client_test.go
+++ b/pkg/util/awsutil/s3factory/client_test.go
@@ -15,6 +15,7 @@
 package s3factory
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -29,12 +30,16 @@ func TestSetupAWSConfig(t *testing.T) {
 	client := fake.NewSimpleClientset(sec)
 
 	e := "example.com"
-	opts, err := setupAWSConfig(client, "", "", e, "")
+	opts, err := setupAWSConfig(client, "", "", e, aws.Bool(true),"")
 	if err != nil {
 		t.Error(err)
 	}
 
 	if e != *opts.Config.Endpoint {
 		t.Errorf("got: %s wanted: %s", *opts.Config.Endpoint, e)
+	}
+
+	if !aws.BoolValue(opts.Config.S3ForcePathStyle) {
+		t.Error("forcePathStyle should have set Config.S3ForcePathStyle in the Config")
 	}
 }


### PR DESCRIPTION
Not all custom S3 endpoints support the virtual hosted bucket addressing that is by default
used in the AWS SDK and the SDK does not honor the `s3.addressing_style` if set in the AWS config file
So add an optional property in the backup and restore CRs that configure the S3 client to use path style addressing

Fixes #1980