### PR TITLE
Bubble all errors from getClientWithMaxRev()

### DIFF
--- a/pkg/backup/backup_manager.go
+++ b/pkg/backup/backup_manager.go
@@ -127,7 +127,7 @@ func getClientWithMaxRev(ctx context.Context, endpoints []string, tc *tls.Config
 	}
 
 	if maxClient == nil {
-		return nil, 0, fmt.Errorf("could not create an etcd client for the max revision purpose from given endpoints (%v)", endpoints)
+		errors = append(errors, fmt.Sprintf("could not create an etcd client for the max revision purpose from given endpoints (%v)", endpoints))
 	}
 
 	var err error


### PR DESCRIPTION
Hi,

I miss-configured the etcd endpoints for my backup cr. The error was getting swallowed.

This change makes sure the error gets added to the list, instead of returning straight away 

Before this change:
```
Status:
  Reason:  failed to save snapshot (create etcd client failed: failed to get etcd client
with maximum kv store revision: could not create an etcd client for the max revision
purpose from given endpoints ([https://localhost:4000]))
```
Error message after:
```
Status:
  Reason:  failed to save snapshot (create etcd client failed: failed to get etcd client
with maximum kv store revision: failed to create etcd client for endpoint
(https://localhost:4000): dial tcp [::1]:4000: connect: connection refused could not
create an etcd client for the max revision purpose from given endpoints
([https://localhost:4000]))
```

Now I have my error :).

I'm note sure of the impact of not returning `nil`, and `0`, One of the maintainers might be able to clear that up.

Thanks,

Henry