### PR TITLE
Add support to use IAM roles without credentials on s3 backup and restore

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -64,7 +64,7 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  digest = "1:1e47beabb90c1e4cc35a3b9ee2d43c191930940363d6c02d2c59acd38c07cef6"
+  digest = "1:53d8a9b02327cd7990062d6c1a3f64b8d2e34ccf07dcb459144728481c5feeac"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -77,15 +77,22 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/ini",
+    "internal/s3err",
+    "internal/sdkio",
     "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
@@ -97,8 +104,8 @@
     "service/sts",
   ]
   pruneopts = "NT"
-  revision = "aace5875a5c3b85a3902c6d72b9caed301d64cce"
-  version = "v1.13.8"
+  revision = "ddc06f9fad886ea5daa5f828f3ca094084f8c2a7"
+  version = "v1.15.90"
 
 [[projects]]
   branch = "master"
@@ -171,14 +178,6 @@
   pruneopts = "NT"
   revision = "0ca9ea5df5451ffdf184b4428c902747c2c11cd7"
   version = "v1.0.0"
-
-[[projects]]
-  digest = "1:c204ec81f754234f2c3c4093cc8cc42151aadedd1129b32539a472fd7881e689"
-  name = "github.com/go-ini/ini"
-  packages = ["."]
-  pruneopts = "NT"
-  revision = "9c8236e659b76e87bf02044d06fde8683008ff3e"
-  version = "v1.39.0"
 
 [[projects]]
   digest = "1:260f7ebefc63024c8dfe2c9f1a2935a89fa4213637a1f522f592f80c001cc441"
@@ -355,6 +354,14 @@
   pruneopts = "NT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
+
+[[projects]]
+  digest = "1:6ccd7a26be12d175a7f5c6fad5b63b57a3a278437dfbd4afe909b8f700fc049e"
+  name = "github.com/minio/minio-go"
+  packages = ["pkg/s3utils"]
+  pruneopts = "NT"
+  revision = "c6108c47ba5d86548404ebf9e51c5ca18769fe79"
+  version = "6.0.1"
 
 [[projects]]
   digest = "1:2f42fa12d6911c7b7659738758631bec870b7e9b4c6be5444f963cdcfccc191f"
@@ -989,6 +996,7 @@
     "github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes",
     "github.com/coreos/etcd/etcdserver/etcdserverpb",
     "github.com/coreos/etcd/pkg/transport",
+    "github.com/minio/minio-go/pkg/s3utils",
     "github.com/pborman/uuid",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,7 +45,11 @@ required = [
 
 [[constraint]]
   name = "github.com/aws/aws-sdk-go"
-  version = "=1.13.8"
+  version = "=1.15.90"
+
+[[constraint]]
+  name = "github.com/minio/minio-go"
+  version = "=6.0.1"
 
 [[constraint]]
   name = "github.com/pborman/uuid"

--- a/doc/user/walkthrough/backup-operator.md
+++ b/doc/user/walkthrough/backup-operator.md
@@ -2,20 +2,23 @@
 
 ## Overview
 
-etcd backup operator backups the data of a etcd cluster running on [Kubernetes][Kube] to a remote storage such as AWS [S3][s3].
+etcd backup operator backups the data of a etcd cluster running on [Kubernetes][kube] to a remote storage such as AWS [S3][s3].
 
 ## Getting Started
 
 Try out etcd backup operator by running it on Kubernetes and then create a `EtcdBackup` Custom Resource which contains the targeting etcd cluster and S3 backup config; the etcd backup operator automatically picks up the `EtcdBackup` Custom Resource, retrieves etcd snapshot, and then saves it to S3.
->Note: The demo uses the `default` namespace.
 
-Prerequisites: 
-* Setup RBAC and deploy an etcd operator. See [Install Guide][install_guide]
-* A running etcd cluster named `example-etcd-cluster`. See [instructions][etcd_cluster_deploy] to deploy it.
+> Note: The demo uses the `default` namespace.
+
+Prerequisites:
+
+- Setup RBAC and deploy an etcd operator. See [Install Guide][install_guide]
+- A running etcd cluster named `example-etcd-cluster`. See [instructions][etcd_cluster_deploy] to deploy it.
 
 ### Deploy etcd backup operator
 
 Create a deployment of etcd backup operator:
+
 > Note: etcd backup operator creates EtcdBackup CRD automatically
 
 ```sh
@@ -33,34 +36,56 @@ NAME                                    KIND
 etcdbackups.etcd.database.coreos.com    CustomResourceDefinition.v1beta1.apiextensions.k8s.io
 ```
 
-### Setup AWS Secret
+### AWS
+
+#### Without AWS Secret (with IAM roles)
+
+If you are using node IAM roles or applications like [Kiam] or [Kube2iam] to auth the requests to AWS resources without using credentials, you need to set the `spec.s3.endpoint` field (including the region in the url) and `spec.s3.endpoint` to the `bucket/file` (leave `spec.s3.awsSecret` empty). Example:
+
+```yaml
+apiVersion: "etcd.database.coreos.com/v1beta2"
+kind: "EtcdBackup"
+metadata:
+  name: example-etcd-cluster-backup
+spec:
+  etcdEndpoints: [<etcd-cluster-endpoints>]
+  storageType: S3
+  s3:
+    # The format of "path" must be: "<s3-bucket-name>/<path-to-backup-file>"
+    # e.g: "mybucket/etcd.backup"
+    path: <full-s3-path>
+    endpoint: s3.us-east-1.amazonaws.com
+```
+
+#### With AWS Secret
 
 Create a Kubernetes secret that contains aws config/credential;
 the secret will be used later to save etcd backup into S3.
 
 1. Verify that the local aws config and credentials files exist:
 
-    ```sh
-    $ cat $AWS_DIR/credentials
-    [default]
-    aws_access_key_id = XXX
-    aws_secret_access_key = XXX
+```sh
+$ cat $AWS_DIR/credentials
+[default]
+aws_access_key_id = XXX
+aws_secret_access_key = XXX
 
-    $ cat $AWS_DIR/config
-    [default]
-    region = <region>
-    ```
+$ cat $AWS_DIR/config
+[default]
+region = <region>
+```
 
 2. Create secret `aws`:
 
-    ```
-    kubectl create secret generic aws --from-file=$AWS_DIR/credentials --from-file=$AWS_DIR/config
-    ```
+```sh
+kubectl create secret generic aws --from-file=$AWS_DIR/credentials --from-file=$AWS_DIR/config
+```
 
 ### Create EtcdBackup CR
 
 Create EtcdBackup CR:
->Note: this example uses S3 Bucket "mybucket" and k8s secret "aws"
+
+> Note: this example uses S3 Bucket "mybucket" and k8s secret "aws"
 
 ```sh
 sed -e 's|<full-s3-path>|mybucket/etcd.backup|g' \
@@ -74,7 +99,7 @@ sed -e 's|<full-s3-path>|mybucket/etcd.backup|g' \
 
 Check the `status` section of the `EtcdBackup` CR:
 
-```
+```sh
 $ kubectl get EtcdBackup example-etcd-cluster-backup -o yaml
 apiVersion: etcd.database.coreos.com/v1beta2
 kind: EtcdBackup
@@ -90,6 +115,7 @@ This demonstrates etcd backup operator's basic one time backup functionality.
 ### Cleanup
 
 Delete the etcd-backup-operator deployment and the `EtcdBackup` CR.
+
 > Note: Deleting the `EtcdBackup` CR won't delete the backup in S3.
 
 ```sh
@@ -97,8 +123,10 @@ kubectl delete etcdbackup example-etcd-cluster-backup
 kubectl delete -f example/etcd-backup-operator/deployment.yaml
 ```
 
-[Kube]:https://github.com/kubernetes/kubernetes
-[s3]:https://aws.amazon.com/s3/
-[etcd_cluster_deploy]:https://github.com/coreos/etcd-operator#create-and-destroy-an-etcd-cluster
-[minikube]:https://github.com/kubernetes/minikube
-[install_guide]:../install_guide.md
+[kube]: https://github.com/kubernetes/kubernetes
+[s3]: https://aws.amazon.com/s3/
+[etcd_cluster_deploy]: https://github.com/coreos/etcd-operator#create-and-destroy-an-etcd-cluster
+[minikube]: https://github.com/kubernetes/minikube
+[install_guide]: ../install_guide.md
+[kiam]: https://github.com/uswitch/kiam
+[kube2iam]: https://github.com/jtblin/kube2iam

--- a/pkg/controller/backup-operator/s3_backup.go
+++ b/pkg/controller/backup-operator/s3_backup.go
@@ -31,10 +31,16 @@ import (
 // handleS3 saves etcd cluster's backup to specificed S3 path.
 func handleS3(ctx context.Context, kubecli kubernetes.Interface, s *api.S3BackupSource, endpoints []string, clientTLSSecret, namespace string) (*api.BackupStatus, error) {
 	// TODO: controls NewClientFromSecret with ctx. This depends on upstream kubernetes to support API calls with ctx.
-	cli, err := s3factory.NewClientFromSecret(kubecli, namespace, s.Endpoint, s.AWSSecret)
+	cfg := s3factory.ClientConfig{
+		Endpoint:  s.Endpoint,
+		Namespace: namespace,
+		AWSSecret: s.AWSSecret,
+	}
+	cli, err := s3factory.NewClient(cfg, kubecli)
 	if err != nil {
 		return nil, err
 	}
+
 	defer cli.Close()
 
 	var tlsConfig *tls.Config

--- a/pkg/controller/restore-operator/http.go
+++ b/pkg/controller/restore-operator/http.go
@@ -89,11 +89,16 @@ func (r *Restore) serveBackup(w http.ResponseWriter, req *http.Request) error {
 			return errors.New("empty s3 restore source")
 		}
 		s3RestoreSource := restoreSource.S3
-		if len(s3RestoreSource.AWSSecret) == 0 || len(s3RestoreSource.Path) == 0 {
-			return errors.New("invalid s3 restore source field (spec.s3), must specify all required subfields")
+		if len(s3RestoreSource.Path) == 0 {
+			return errors.New("invalid s3 restore source field (spec.s3), must specify s3 restore path")
 		}
 
-		s3Cli, err := s3factory.NewClientFromSecret(r.kubecli, r.namespace, s3RestoreSource.Endpoint, s3RestoreSource.AWSSecret)
+		cfg := s3factory.ClientConfig{
+			Endpoint:  s3RestoreSource.Endpoint,
+			Namespace: r.namespace,
+			AWSSecret: s3RestoreSource.AWSSecret,
+		}
+		s3Cli, err := s3factory.NewClient(cfg, r.kubecli)
 		if err != nil {
 			return fmt.Errorf("failed to create S3 client: %v", err)
 		}

--- a/pkg/util/awsutil/s3factory/client.go
+++ b/pkg/util/awsutil/s3factory/client.go
@@ -17,15 +17,18 @@ package s3factory
 import (
 	"fmt"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path"
 
-	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
-
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/minio/minio-go/pkg/s3utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+
+	api "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
 )
 
 const (
@@ -38,8 +41,61 @@ type S3Client struct {
 	configDir string
 }
 
-// NewClientFromSecret returns a S3 client based on given k8s secret containing aws credentials.
-func NewClientFromSecret(kubecli kubernetes.Interface, namespace, endpoint, awsSecret string) (w *S3Client, err error) {
+// ClientConfig is the configuration for a S3 client.
+type ClientConfig struct {
+	Endpoint  string
+	Namespace string
+	AWSSecret string
+}
+
+// NewClient returns a new S3Client. This client can be based on profiles, keys...
+// (from secret), or IAM Role based (nodes, Kube2iam, Kiam...), the client
+// type will be infered based on the missing (or not missing) data in the
+// client configuration.
+func NewClient(cfg ClientConfig, kubecli kubernetes.Interface) (*S3Client, error) {
+	// If credentials not required then use the S3 client based on IAM roles.
+	if cfg.AWSSecret == "" {
+		return newClientForIAMRole(cfg.Endpoint)
+	}
+
+	return newClientFromSecret(kubecli, cfg.Namespace, cfg.Endpoint, cfg.AWSSecret)
+}
+
+// newClientForIAMRole returns a S3 client that doesn't have credentials set and will do that
+// AWS S3 client fallback to machines assigned IAM role (or in case of using Kube2iam, Kiam...,
+// use the methods used to act on befhalf of the assumed roles given by these systems).
+func newClientForIAMRole(endpoint string) (w *S3Client, err error) {
+	defer func() {
+		if err != nil {
+			err = fmt.Errorf("new S3 client failed: %v", err)
+		}
+	}()
+
+	// Get the region based on the endpoint.
+	region := s3utils.GetRegionFromURL(url.URL{
+		Host: endpoint,
+	})
+
+	if region == "" {
+		return nil, fmt.Errorf("could not infer region from '%s' s3 endpoint, use an endpoint with region like `s3.us-east-1.amazonaws.com`", endpoint)
+	}
+
+	// Create AWS session default the config files, profile...
+	sess, err := session.NewSession(&aws.Config{
+		Endpoint: aws.String(endpoint),
+		Region:   aws.String(region),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &S3Client{
+		S3: s3.New(sess),
+	}, nil
+}
+
+// newClientFromSecret returns a S3 client based on given k8s secret containing aws credentials.
+func newClientFromSecret(kubecli kubernetes.Interface, namespace, endpoint, awsSecret string) (w *S3Client, err error) {
 	defer func() {
 		if err != nil {
 			err = fmt.Errorf("new S3 client failed: %v", err)
@@ -73,7 +129,7 @@ func setupAWSConfig(kubecli kubernetes.Interface, ns, secret, endpoint, configDi
 	options.SharedConfigState = session.SharedConfigEnable
 
 	// empty string defaults to aws
-	options.Config.Endpoint = &endpoint
+	options.Config.Endpoint = aws.String(endpoint)
 
 	se, err := kubecli.CoreV1().Secrets(ns).Get(secret, metav1.GetOptions{})
 	if err != nil {

--- a/pkg/util/awsutil/s3factory/client_test.go
+++ b/pkg/util/awsutil/s3factory/client_test.go
@@ -38,3 +38,45 @@ func TestSetupAWSConfig(t *testing.T) {
 		t.Errorf("got: %s wanted: %s", *opts.Config.Endpoint, e)
 	}
 }
+
+func TestS3ClientForIAMRoles(t *testing.T) {
+	tests := []struct {
+		name   string
+		cfg    ClientConfig
+		expErr bool
+	}{
+		{
+			name: "A configuration without AWS secret, should return a client without credentials.",
+			cfg: ClientConfig{
+				Endpoint: "s3.eu-west-1.amazonaws.com",
+			},
+			expErr: false,
+		},
+		{
+			name: "A configuration without AWS secret and bad endpoint without region, should return a error.",
+			cfg: ClientConfig{
+				Endpoint: "s3.amazonaws.com",
+			},
+			expErr: true,
+		},
+		{
+			name:   "A configuration without AWS secret and no endpoint, should return a error.",
+			cfg:    ClientConfig{},
+			expErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			client := fake.NewSimpleClientset()
+			_, err := NewClient(test.cfg, client)
+
+			if test.expErr && err == nil {
+				t.Errorf("error expected, dind't got error")
+			} else if !test.expErr && err != nil {
+				t.Errorf("error not expected got: %s", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1682 

This PR allows not using credentials and use instead node IAM roles or applications like Kiam or Kube2iam.

- Add new S3 client without credentials if not `awsSecret` present.
- The region when not using `awsSecret` will be inferred from the S3 endpoint.
- Add documentation and example of how to use based on IAM roles.
- Format some parts of the docs markdown.

I added Minio-go dependency only to infer the region,  I thought it would be cleaner and had fewer corner cases/errors than implementing myself as it has a little [bit of logic](https://github.com/minio/minio-go/blob/c085651199f9403929babaa1e6524a53085d2395/pkg/s3utils/utils.go#L99) depending on the kind of regions/cases.

