### PR TITLE
example: added securityContext to deployment

### DIFF
--- a/example/deployment.yaml
+++ b/example/deployment.yaml
@@ -9,6 +9,8 @@ spec:
       labels:
         name: etcd-operator
     spec:
+      securityContext:
+        runAsUser: 1000
       containers:
       - name: etcd-operator
         image: quay.io/coreos/etcd-operator:v0.9.3


### PR DESCRIPTION
Allows deploying in clusters with PodSecurityPolicy enforcing
runAsNonRoot without getting the following error:
“Error: container has runAsNonRoot and image has non-numeric
user (etcd-operator), cannot verify user is non-root”


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
