### PR TITLE
example: added "root secure" deployment yaml

### DIFF
--- a/example/deployment_psp.yaml
+++ b/example/deployment_psp.yaml
@@ -1,0 +1,30 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etcd-operator
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: etcd-operator
+    spec:
+      securityContext:
+        runAsUser: 1000
+        fsGroup: 1000
+      containers:
+      - name: etcd-operator
+        image: quay.io/coreos/etcd-operator:v0.9.3
+        command:
+        - etcd-operator
+        # Uncomment to act for resources in all namespaces. More information in doc/user/clusterwide.md
+        #- -cluster-wide
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name


### PR DESCRIPTION
Allows deploying in clusters with PodSecurityPolicy enforcing
runAsNonRoot without getting the following error:
“Error: container has runAsNonRoot and image has non-numeric
user (etcd-operator), cannot verify user is non-root”


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
