### PR TITLE
pkg/controller: Fix CR with same name in different namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed a bug where `same CR names` in different namespaces with cluster-wide operator were not working as expected [#2026](https://github.com/coreos/etcd-operator/pull/2026)
+
 ### Deprecated
 
 ### Security

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -86,7 +86,7 @@ type Cluster struct {
 }
 
 func New(config Config, cl *api.EtcdCluster) *Cluster {
-	lg := logrus.WithField("pkg", "cluster").WithField("cluster-name", cl.Name)
+	lg := logrus.WithField("pkg", "cluster").WithField("cluster-name", cl.Name).WithField("cluster-namespace", cl.Namespace)
 
 	c := &Cluster{
 		logger:    lg,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -73,7 +73,7 @@ func (c *Controller) handleClusterEvent(event *Event) (bool, error) {
 	if clus.Status.IsFailed() {
 		clustersFailed.Inc()
 		if event.Type == kwatch.Deleted {
-			delete(c.clusters, clus.Name)
+			delete(c.clusters, getNamespacedName(clus))
 			return false, nil
 		}
 		return false, fmt.Errorf("ignore failed cluster (%s). Please delete its CR", clus.Name)
@@ -87,30 +87,30 @@ func (c *Controller) handleClusterEvent(event *Event) (bool, error) {
 
 	switch event.Type {
 	case kwatch.Added:
-		if _, ok := c.clusters[clus.Name]; ok {
+		if _, ok := c.clusters[getNamespacedName(clus)]; ok {
 			return false, fmt.Errorf("unsafe state. cluster (%s) was created before but we received event (%s)", clus.Name, event.Type)
 		}
 
 		nc := cluster.New(c.makeClusterConfig(), clus)
 
-		c.clusters[clus.Name] = nc
+		c.clusters[getNamespacedName(clus)] = nc
 
 		clustersCreated.Inc()
 		clustersTotal.Inc()
 
 	case kwatch.Modified:
-		if _, ok := c.clusters[clus.Name]; !ok {
+		if _, ok := c.clusters[getNamespacedName(clus)]; !ok {
 			return false, fmt.Errorf("unsafe state. cluster (%s) was never created but we received event (%s)", clus.Name, event.Type)
 		}
-		c.clusters[clus.Name].Update(clus)
+		c.clusters[getNamespacedName(clus)].Update(clus)
 		clustersModified.Inc()
 
 	case kwatch.Deleted:
-		if _, ok := c.clusters[clus.Name]; !ok {
+		if _, ok := c.clusters[getNamespacedName(clus)]; !ok {
 			return false, fmt.Errorf("unsafe state. cluster (%s) was never created but we received event (%s)", clus.Name, event.Type)
 		}
-		c.clusters[clus.Name].Delete()
-		delete(c.clusters, clus.Name)
+		c.clusters[getNamespacedName(clus)].Delete()
+		delete(c.clusters, getNamespacedName(clus))
 		clustersDeleted.Inc()
 		clustersTotal.Dec()
 	}
@@ -131,4 +131,8 @@ func (c *Controller) initCRD() error {
 		return fmt.Errorf("failed to create CRD: %v", err)
 	}
 	return k8sutil.WaitCRDReady(c.KubeExtCli, api.EtcdClusterCRDName)
+}
+
+func getNamespacedName(c *api.EtcdCluster) string {
+	return fmt.Sprintf("%s%c%s", c.Namespace, '/', c.Name)
 }

--- a/pkg/controller/informer.go
+++ b/pkg/controller/informer.go
@@ -129,7 +129,7 @@ func (c *Controller) syncEtcdClus(clus *api.EtcdCluster) {
 	// re-watch or restart could give ADD event.
 	// If for an ADD event the cluster spec is invalid then it is not added to the local cache
 	// so modifying that cluster will result in another ADD event
-	if _, ok := c.clusters[clus.Name]; ok {
+	if _, ok := c.clusters[getNamespacedName(clus)]; ok {
 		ev.Type = kwatch.Modified
 	}
 


### PR DESCRIPTION
This patch uses `<namespace>/<cluster-name>` as key to store the cluster in Controller struct to avoid over-writing same named CR's in different namespaces.

Fixes #1954


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
