### PR TITLE
pkg/*: allow to add extra arguments to cluster members

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -99,6 +99,9 @@ type ClusterSpec struct {
 
 	// etcd cluster TLS configuration
 	TLS *TLSPolicy `json:"TLS,omitempty"`
+
+	// ExtendedArgs is a form to add more arguments that can be used for all etcd instances
+	ExtendedArgs string `json:"extendedArgs,omitempty"`
 }
 
 // PodPolicy defines the policy to create pod for the etcd container.

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -315,6 +315,7 @@ func (c *Cluster) startSeedMember() error {
 		Namespace:    c.cluster.Namespace,
 		SecurePeer:   c.isSecurePeer(),
 		SecureClient: c.isSecureClient(),
+		ExtendedArgs: c.cluster.Spec.ExtendedArgs,
 	}
 	ms := etcdutil.NewMemberSet(m)
 	if err := c.createPod(ms, m, "new"); err != nil {

--- a/pkg/util/etcdutil/member.go
+++ b/pkg/util/etcdutil/member.go
@@ -33,6 +33,9 @@ type Member struct {
 
 	SecurePeer   bool
 	SecureClient bool
+
+	// ExtendedArgs
+	ExtendedArgs string
 }
 
 func (m *Member) Addr() string {

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -309,6 +309,7 @@ func newEtcdPod(m *etcdutil.Member, initialCluster []string, clusterName, state,
 	if state == "new" {
 		commands = fmt.Sprintf("%s --initial-cluster-token=%s", commands, token)
 	}
+	commands += fmt.Sprintf(" %s", m.ExtendedArgs)
 
 	labels := map[string]string{
 		"app":          "etcd",


### PR DESCRIPTION
With this changes, users will be able to specifiy extra arguments on all
cluster members running in the etcd cluster.

Signed-off-by: André Martins <aanm90@gmail.com>


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
