### PR TITLE
Allow EtcdRestore to restore cluster without an existing EtcdCluster

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -65,6 +65,9 @@ func (c *EtcdCluster) AsOwner() metav1.OwnerReference {
 }
 
 type ClusterSpec struct {
+	// Optional; only useful when creating a cluster from a backup using restore-operator
+	Name string `json:"name"`
+
 	// Size is the expected size of the etcd cluster.
 	// The etcd-operator will eventually make the size of the running
 	// cluster equal to the expected size.

--- a/pkg/apis/etcd/v1beta2/restore_types.go
+++ b/pkg/apis/etcd/v1beta2/restore_types.go
@@ -47,7 +47,7 @@ type RestoreSpec struct {
 	// will be used to create the new restored EtcdCluster CR.
 	// This reference EtcdCluster CR and all its resources will be deleted before the
 	// restored EtcdCluster CR is created.
-	EtcdCluster EtcdClusterRef `json:"etcdCluster"`
+	EtcdCluster ClusterSpec `json:"etcdCluster"`
 }
 
 // EtcdCluster references an EtcdCluster resource whose metadata and spec


### PR DESCRIPTION
Example scenario;
 - I have my backups available in the object storage. But my etcd cluster does not exist anymore. I want to restore my backup into a new cluster.

Changes;
 - `EtcdRestore.spec.etcdCluster` is now `ClusterSpec` instead of `EtcdClusterRef`
 - added `Name` property to `ClusterSpec`, to make it compatible with `EtcdClusterRef`
 - Now, `etcd-restore-operator` checks for `EtcdCluster` resource existence
   - If exists; current behavior works (snapshot spec, delete old one, create new one)
   - If not; uses `EtcdRestore.spec.etcdCluster` as cluster spec

Example EtcdRestore yaml;

```yaml
apiVersion: "etcd.database.coreos.com/v1beta2"
kind: "EtcdRestore"
metadata:
  name: new-etcd-cluster-from-backup
  namespace: etcd-op
spec:
  etcdCluster:
    name: new-etcd-cluster-from-backup
    size: 5
    version: "3.2.13"
    # pod:
    #   persistentVolumeClaimSpec:
    #     storageClassName: standard
    #     accessModes:
    #     - ReadWriteOnce
    #     resources:
    #       requests:
    #         storage: 1Gi
  backupStorageType: S3
  storageType: S3
  s3:
    path: etcd-backups/20190129.backup
    awsSecret: minio-credentials
    endpoint: http://minio.etcd-op.svc.cluster.local:9000
    forcePathStyle: true
```

I'm not used to golang code, please let me know if any part needs fixing, or a different approach.

Thanks