### PR TITLE
test/e2e/e2eslow: fix restore tests

### DIFF
--- a/test/e2e/e2eslow/backup_restore_test.go
+++ b/test/e2e/e2eslow/backup_restore_test.go
@@ -190,7 +190,7 @@ func testEtcdBackupOperatorForPeriodicS3Backup(t *testing.T, clusterName, operat
 
 	// initialize s3 client
 	s3cli, err := s3factory.NewClientFromSecret(
-		f.KubeClient, f.Namespace, backupS3Source.Endpoint, backupS3Source.AWSSecret)
+		f.KubeClient, f.Namespace, backupS3Source.Endpoint, backupS3Source.AWSSecret, backupS3Source.ForcePathStyle)
 	if err != nil {
 		t.Fatalf("failed to initialize s3client: %v", err)
 	}


### PR DESCRIPTION
This PR is to cleanup CI failures
```
ok  	github.com/coreos/etcd-operator/test/e2e	198.722s
# github.com/coreos/etcd-operator/test/e2e/e2eslow [github.com/coreos/etcd-operator/test/e2e/e2eslow.test]
test/e2e/e2eslow/backup_restore_test.go:192:45: not enough arguments in call to s3factory.NewClientFromSecret
	have (kubernetes.Interface, string, string, string)
	want (kubernetes.Interface, string, string, string, bool)
```