### PR TITLE
Azure blob storage: use correct list prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Don't expose unready nodes via client service. [#2063](https://github.com/coreos/etcd-operator/pull/2063)
+- Azure blob storage: use correct list prefix [#2071](https://github.com/coreos/etcd-operator/pull/2071)
 
 ### Deprecated
 

--- a/pkg/backup/writer/abs_writer.go
+++ b/pkg/backup/writer/abs_writer.go
@@ -103,7 +103,7 @@ func (absw *absWriter) Write(ctx context.Context, path string, r io.Reader) (int
 
 func (absw *absWriter) List(ctx context.Context, basePath string) ([]string, error) {
 	// TODO: support context.
-	container, _, err := util.ParseBucketAndKey(basePath)
+	container, key, err := util.ParseBucketAndKey(basePath)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +118,7 @@ func (absw *absWriter) List(ctx context.Context, basePath string) ([]string, err
 	}
 
 	blobs, err := containerRef.ListBlobs(
-		storage.ListBlobsParameters{Prefix: basePath})
+		storage.ListBlobsParameters{Prefix: key})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Azure bloc storage implementation didn't use the right prefix resulting on no backup cleanup being performed.