### PR TITLE
removed auto-adding v to the etcd image version

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 5
-  version: "3.2.13"
+  version: "v3.2.13"
 ```
 
 Apply the size change to the cluster CR:
@@ -129,7 +129,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "3.2.13"
+  version: "v3.2.13"
 ```
 ```
 $ kubectl apply -f example/example-etcd-cluster.yaml
@@ -222,7 +222,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "3.1.10"
+  version: "v3.1.10"
   repository: "quay.io/coreos/etcd"
 ```
 
@@ -254,7 +254,7 @@ metadata:
   name: "example-etcd-cluster"
 spec:
   size: 3
-  version: "3.2.13"
+  version: "v3.2.13"
 ```
 
 Apply the version change to the cluster CR:

--- a/example/example-etcd-cluster.yaml
+++ b/example/example-etcd-cluster.yaml
@@ -8,4 +8,4 @@ metadata:
   #   etcd.database.coreos.com/scope: clusterwide
 spec:
   size: 3
-  version: "3.2.13"
+  version: "v3.2.13"

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -189,7 +189,8 @@ func (e *EtcdCluster) SetDefaults() {
 		c.Version = DefaultEtcdVersion
 	}
 
-	c.Version = strings.TrimLeft(c.Version, "v")
+	// not used anymore, we take the full version name as final version (not prepending v to the version)
+	// c.Version = strings.TrimLeft(c.Version, "v")
 
 	// convert PodPolicy.AntiAffinity to Pod.Affinity.PodAntiAffinity
 	// TODO: Remove this once PodPolicy.AntiAffinity is removed

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -135,7 +135,7 @@ fi
 }
 
 func ImageName(repo, version string) string {
-	return fmt.Sprintf("%s:v%v", repo, version)
+	return fmt.Sprintf("%s:%s", repo, version)
 }
 
 // imageNameBusybox returns the default image for busybox init container, or the image specified in the PodPolicy


### PR DESCRIPTION
When creating an `etcdCluster` resource, you provide an `Image` and a `Version.
`Version` is a semver version depending on the EtcD image version you wish to use. 

The default is to use Quay images, which are versioned using a pattern of `v` + `semver`, like `v3.0.12`.

So defining :
```
apiVersion: "etcd.database.coreos.com/v1beta2"
kind: "EtcdCluster"
metadata:
  name: "example-etcd-cluster"
spec:
  size: 3
  version: "3.1.10"
  repository: "quay.io/coreos/etcd"
```

Will create a Pod using image `quay.io/coreos/etcd:v3.1.10`.

This may be fine with `Quay` images, but when you are working with other Docker Registries, you may not want to add the `v` to the version.

The Operator should not force you to use a specific version pattern.

This PR removes the `v` addition to the version, allowing to use a real version name in the CRD.