### PR TITLE
Allow specifying Cluster Domain for clientURLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+- Added `spec.Pod.ClusterDomain` to explicitly set the cluster domain used for the etcd member URLs. [#2082](https://github.com/coreos/etcd-operator/pull/2082)
+
 ### Changed
 
 ### Removed

--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -157,6 +157,11 @@ type PodPolicy struct {
 	// reverse DNS lookup its IP given the hostname.
 	// The default is to wait indefinitely and has a vaule of 0.
 	DNSTimeoutInSecond int64 `json:"DNSTimeoutInSecond,omitempty"`
+
+	// ClusterDomain is the cluster domain to use for member URLs E.g.
+	// '.cluster.local'.
+	// The default is to not set a cluster domain explicitly.
+	ClusterDomain string `json:"ClusterDomain"`
 }
 
 // TODO: move this to initializer

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -316,6 +316,9 @@ func (c *Cluster) startSeedMember() error {
 		SecurePeer:   c.isSecurePeer(),
 		SecureClient: c.isSecureClient(),
 	}
+	if c.cluster.Spec.Pod != nil {
+		m.ClusterDomain = c.cluster.Spec.Pod.ClusterDomain
+	}
 	ms := etcdutil.NewMemberSet(m)
 	if err := c.createPod(ms, m, "new"); err != nil {
 		return fmt.Errorf("failed to create seed member (%s): %v", m.Name, err)

--- a/pkg/cluster/member.go
+++ b/pkg/cluster/member.go
@@ -51,12 +51,17 @@ func (c *Cluster) updateMembers(known etcdutil.MemberSet) error {
 
 func (c *Cluster) newMember() *etcdutil.Member {
 	name := k8sutil.UniqueMemberName(c.cluster.Name)
-	return &etcdutil.Member{
+	m := &etcdutil.Member{
 		Name:         name,
 		Namespace:    c.cluster.Namespace,
 		SecurePeer:   c.isSecurePeer(),
 		SecureClient: c.isSecureClient(),
 	}
+
+	if c.cluster.Spec.Pod != nil {
+		m.ClusterDomain = c.cluster.Spec.Pod.ClusterDomain
+	}
+	return m
 }
 
 func podsToMemberSet(pods []*v1.Pod, sc bool) etcdutil.MemberSet {

--- a/pkg/controller/restore-operator/sync.go
+++ b/pkg/controller/restore-operator/sync.go
@@ -217,6 +217,9 @@ func (r *Restore) createSeedMember(ec *api.EtcdCluster, svcAddr, clusterName str
 		SecurePeer:   ec.Spec.TLS.IsSecurePeer(),
 		SecureClient: ec.Spec.TLS.IsSecureClient(),
 	}
+	if ec.Spec.Pod != nil {
+		m.ClusterDomain = ec.Spec.Pod.ClusterDomain
+	}
 	ms := etcdutil.NewMemberSet(m)
 	backupURL := backupapi.BackupURLForRestore("http", svcAddr, clusterName)
 	ec.SetDefaults()

--- a/pkg/util/etcdutil/member.go
+++ b/pkg/util/etcdutil/member.go
@@ -33,10 +33,13 @@ type Member struct {
 
 	SecurePeer   bool
 	SecureClient bool
+
+	// ClusterDomain is the DNS name of the cluster. E.g. .cluster.local.
+	ClusterDomain string
 }
 
 func (m *Member) Addr() string {
-	return fmt.Sprintf("%s.%s.%s.svc", m.Name, clusterNameFromMemberName(m.Name), m.Namespace)
+	return fmt.Sprintf("%s.%s.%s.svc%s", m.Name, clusterNameFromMemberName(m.Name), m.Namespace, m.ClusterDomain)
 }
 
 // ClientURL is the client URL for this member


### PR DESCRIPTION
This allows setting the cluster domain as a flag on the operator. The
cluster domain is used as a suffix in the Client URLs for the etcd
members.

The ability to set a custom cluster domain is desirable when running in
clusters with a custom DNS configuration.

In our case we need this because we have decided to default the DNS config to use `ndots:2` instead of the default `ndots:5` setting which can result in up to 10 additional DNS queries for every single name lookup, which causes an unnecessary overhead for the DNS infrastructure and for applications.

Ref: https://github.com/kubernetes/dns/issues/159#issuecomment-336449931

An alternative way to fix this would be to allow specifying the DNS config of the pod spec: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-config