### PR TITLE
Add curl image parameter

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster.go
+++ b/pkg/apis/etcd/v1beta2/cluster.go
@@ -18,7 +18,7 @@ import (
 	"errors"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -162,6 +162,11 @@ type PodPolicy struct {
 	// '.cluster.local'.
 	// The default is to not set a cluster domain explicitly.
 	ClusterDomain string `json:"ClusterDomain"`
+
+	// curl init container image. default is tutum/curl.
+	// pulling tutum/curl:latest requires external access.
+	// More info: https://github.com/coreos/etcd-operator/issues/1933
+	CurlImage string `json:"curlImage,omitempty"`
 }
 
 // TODO: move this to initializer

--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -63,6 +63,7 @@ const (
 	MaxNameLength = 63 - randomSuffixLength - 1
 
 	defaultBusyboxImage = "busybox:1.28.0-glibc"
+	defaultCurlImage = "tutum/curl:latest"
 
 	// AnnotationScope annotation name for defining instance scope. Used for specifying cluster wide clusters.
 	AnnotationScope = "etcd.database.coreos.com/scope"
@@ -104,7 +105,8 @@ func makeRestoreInitContainers(backupURL *url.URL, token, repo, version string, 
 	return []v1.Container{
 		{
 			Name:  "fetch-backup",
-			Image: "tutum/curl",
+			//Image default: "tutum/curl:latest",
+			Image: imageNameCurl(cs.Pod),
 			Command: []string{
 				"/bin/bash", "-ec",
 				fmt.Sprintf(`
@@ -145,6 +147,14 @@ func imageNameBusybox(policy *api.PodPolicy) string {
 		return policy.BusyboxImage
 	}
 	return defaultBusyboxImage
+}
+
+// imageNameCurl returns the default image for curl init container, or the image specified in the PodPolicy
+func imageNameCurl(policy *api.PodPolicy) string {
+	if policy != nil && len(policy.CurlImage) > 0 {
+		return policy.CurlImage
+	}
+	return defaultCurlImage
 }
 
 func PodWithNodeSelector(p *v1.Pod, ns map[string]string) *v1.Pod {

--- a/pkg/util/k8sutil/k8sutils_test.go
+++ b/pkg/util/k8sutil/k8sutils_test.go
@@ -47,3 +47,31 @@ func TestSetBusyboxImageName(t *testing.T) {
 		t.Errorf("expect image=%s, get=%s", expected, image)
 	}
 }
+
+func TestDefaultCurlImageName(t *testing.T) {
+	policy := &api.PodPolicy{}
+	image := imageNameCurl(policy)
+	expected := defaultCurlImage
+	if image != expected {
+		t.Errorf("expect image=%s, get=%s", expected, image)
+	}
+}
+
+func TestDefaultNilCurlImageName(t *testing.T) {
+	image := imageNameCurl(nil)
+	expected := defaultCurlImage
+	if image != expected {
+		t.Errorf("expect image=%s, get=%s", expected, image)
+	}
+}
+
+func TestSetBusyboxImageName(t *testing.T) {
+	policy := &api.PodPolicy{
+		CurlImage: "myRepo/curl:1.3.2",
+	}
+	image := imageNameCurl(policy)
+	expected := "myRepo/curl:1.3.2"
+	if image != expected {
+		t.Errorf("expect image=%s, get=%s", expected, image)
+	}
+}


### PR DESCRIPTION
cluster: add option to specify curl image

add an option in EtcdCluster.spec:
CurlImage. Defaults to "tutum/curl:latest"

see https://github.com/coreos/etcd-operator/issues/1933
