### PR TITLE
k8sutil: Restarting pods in an etcd cluster with PVC is safe.

### DIFF
--- a/pkg/util/k8sutil/k8sutil.go
+++ b/pkg/util/k8sutil/k8sutil.go
@@ -253,6 +253,8 @@ func AddEtcdVolumeToPod(pod *v1.Pod, pvc *v1.PersistentVolumeClaim) {
 		vol.VolumeSource = v1.VolumeSource{
 			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvc.Name},
 		}
+		// When PVC is used, make the pod auto recover in case of failure
+		pod.Spec.RestartPolicy = v1.RestartPolicyAlways
 	} else {
 		vol.VolumeSource = v1.VolumeSource{EmptyDir: &v1.EmptyDirVolumeSource{}}
 	}


### PR DESCRIPTION
This is a simple fix that addresses Case C from
https://github.com/coreos/etcd-operator/blob/master/doc/design/persistent_volumes_etcd_data.md

It makes the etcd cluster with PVC able to recover from full k8s cluster
outage. Inspired by https://github.com/coreos/etcd-operator/issues/1323#issuecomment-359206459

Fixes #1323


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
