### PR TITLE
Include timeout option in backups example CR

### DIFF
--- a/example/etcd-backup-operator/periodic_backup_cr.yaml
+++ b/example/etcd-backup-operator/periodic_backup_cr.yaml
@@ -9,6 +9,8 @@ spec:
     # 0 > enable periodic backup
     backupIntervalInSecond: 125
     maxBackups: 4
+    # Backup timeout default is 60 seconds.
+    timeoutInSecond: 120
   s3:
     # The format of "path" must be: "<s3-bucket-name>/<path-to-backup-file>"
     # e.g: "mybucket/etcd.backup"


### PR DESCRIPTION
The backup timeout was made configurable in https://github.com/coreos/etcd-operator/pull/1908 but is not documented. This adds a note about the default value and makes it clear this is an optional feature.


Please read https://github.com/coreos/etcd-operator/blob/master/CONTRIBUTING.md#contribution-flow
