### PR TITLE
Add support for SecretTypeTLS secrets

### DIFF
--- a/pkg/util/k8sutil/tls.go
+++ b/pkg/util/k8sutil/tls.go
@@ -16,6 +16,7 @@ package k8sutil
 
 import (
 	"github.com/coreos/etcd-operator/pkg/util/etcdutil"
+	v1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/util/k8sutil/tls.go
+++ b/pkg/util/k8sutil/tls.go
@@ -33,6 +33,15 @@ func GetTLSDataFromSecret(kubecli kubernetes.Interface, ns, se string) (*TLSData
 	if err != nil {
 		return nil, err
 	}
+
+	if secret.Type == v1.SecretTypeTLS {
+		return &TLSData{
+			CertData: secret.Data["tls.crt"],
+			KeyData:  secret.Data["tls.key"],
+			CAData:   secret.Data["ca.crt"],
+		}, nil
+	}
+
 	return &TLSData{
 		CertData: secret.Data[etcdutil.CliCertFile],
 		KeyData:  secret.Data[etcdutil.CliKeyFile],


### PR DESCRIPTION
Kubernetes knows specific TLS secrets (SecretTypeTLS). This kind of
secrets has specifically named fields (tls.crt, tls.key, ca.crt)
different from those supported by the etcd-operator. Such secretes
are e.g. generated by the cert-manager. This change adds support for
such secrets.
