### PR TITLE
Provide documentation on etcd-operator-builder.  Remove references to gcr.io image.

### DIFF
--- a/doc/dev/developer_guide.md
+++ b/doc/dev/developer_guide.md
@@ -2,7 +2,8 @@
 
 This document explains how to setup your dev environment. 
 
-## Fetch dependency
+## Using Local Environment
+### Fetch dependency
 
 We use [dep](https://github.com/golang/dep) to manage dependency.
 Install dependency if you haven't:
@@ -11,8 +12,8 @@ Install dependency if you haven't:
 ./hack/update_vendor.sh
 ```
 
-## How to build
 
+### How to build
 Requirement:
 - Go 1.10+
 
@@ -22,4 +23,46 @@ Build in project root dir:
 ./hack/build/operator/build
 ./hack/build/backup-operator/build
 ./hack/build/restore-operator/build
+```
+
+## Using etcd-operator-builder
+### Building the Builder
+For convenience and easy of building, a Dockerfile has been provided to create an
+etcd-operator-builder image.  This image contains a fully configured go envrionment
+used for fetching dependencies and building the different etcd-operator binaries.
+
+To build the etcd-operator-builder image, you first need to have docker installed.
+
+Once installed, set the IMAGE environment variable to the desired name:
+```
+export IMAGE=etcd-operator-builder
+```
+
+Now, run the build script to generate the etcd-operator-builder:
+```
+./hack/build/e2e/builder/build
+```
+
+Once completed, the etcd-operator-builder:latest image should be available for use.
+
+
+### Updating the Dependencies Using the Builder
+Updating dependencies using this image can be performed by running the ci get_dep script:
+```
+./hack/ci/get_dep
+```
+
+
+### Building etcd-operator Using the Builder
+Then build the project using the image:
+```
+./hack/build/build
+```
+
+
+## Creating the etcd-operator Docker Image
+Finally, build the etcd-operator image:
+```
+export IMAGE=etcd-operator
+docker build --tag "${IMAGE}" -f hack/build/Dockerfile . 1>/dev/null
 ```

--- a/hack/build/build
+++ b/hack/build/build
@@ -13,7 +13,7 @@ DOCKER_REPO_ROOT="/go/src/github.com/coreos/etcd-operator"
 docker run --rm \
 	-v "$PWD":"$DOCKER_REPO_ROOT" \
 	-w "$DOCKER_REPO_ROOT" \
-	gcr.io/coreos-k8s-scale-testing/etcd-operator-builder:0.4.1-2 \
+	etcd-operator-builder:latest \
 	/bin/bash -c "hack/build/operator/build && \
 		hack/build/backup-operator/build && \
 		hack/build/restore-operator/build"

--- a/hack/build/e2e/builder/Dockerfile
+++ b/hack/build/e2e/builder/Dockerfile
@@ -2,5 +2,5 @@ FROM golang:1.11.5
 
 RUN curl -L https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 -o /usr/local/bin/dep \
     && chmod +x /usr/local/bin/dep \
-    && go get honnef.co/go/tools/cmd/gosimple \
-    && go get honnef.co/go/tools/cmd/unused
+    && go get honnef.co/go/tools/simple \
+    && go get honnef.co/go/tools/unused

--- a/hack/build/e2e/builder/build
+++ b/hack/build/e2e/builder/build
@@ -11,11 +11,11 @@ if ! which docker > /dev/null; then
 	exit 1
 fi
 
-: ${IMAGE:?"Need to set IMAGE, e.g. gcr.io/coreos-k8s-scale-testing/etcd-operator-builder"}
+: ${IMAGE:?"Need to set IMAGE, e.g. etcd-operator-builder"}
 
 echo "building container..."
 docker build --tag "${IMAGE}" -f hack/build/e2e/builder/Dockerfile . 1>/dev/null
 
-# For gcr users, do "gcloud docker -a" to have access.
-echo "pushing container..."
-docker push "${IMAGE}"
+# If using a non-local docker registry, push the image:
+# echo "pushing image..."
+# docker push "${IMAGE}"

--- a/hack/ci/get_dep
+++ b/hack/ci/get_dep
@@ -7,5 +7,5 @@ DOCKER_REPO_ROOT="/go/src/github.com/coreos/etcd-operator"
 docker run --rm \
 	-v "$PWD":"$DOCKER_REPO_ROOT" \
 	-w "$DOCKER_REPO_ROOT" \
-	gcr.io/coreos-k8s-scale-testing/etcd-operator-builder:0.4.1-2 \
+	etcd-operator-builder:latest \
 	hack/update_vendor.sh

--- a/hack/test
+++ b/hack/test
@@ -22,7 +22,7 @@ function fmt_pass {
 	docker run --rm \
 		-v "${PWD}":"${DOCKER_REPO_ROOT}" \
 		-w "${DOCKER_REPO_ROOT}" \
-		gcr.io/coreos-k8s-scale-testing/etcd-operator-builder:0.4.1-2 \
+		etcd-operator-builder:latest \
 		"./hack/fmt_pass"
 }
 


### PR DESCRIPTION
This addresses #2156 and likely will close it.

if there is a need to use the builder image just build it locally and push it where you need it.

Added documentation for generating builder and using it.