### PR TITLE
fix bug in tls validation

### DIFF
--- a/pkg/apis/etcd/v1beta2/cluster_tls.go
+++ b/pkg/apis/etcd/v1beta2/cluster_tls.go
@@ -47,7 +47,7 @@ func (tp *TLSPolicy) Validate() error {
 	st := tp.Static
 
 	if len(st.OperatorSecret) != 0 {
-		if len(st.Member.ServerSecret) == 0 {
+		if st.Member == nil || len(st.Member.ServerSecret) == 0 {
 			return errors.New("operator secret set but member serverSecret not set")
 		}
 	} else if st.Member != nil && len(st.Member.ServerSecret) != 0 {


### PR DESCRIPTION
Fix bug in tls validation when the operatorSecret is set but the member
obj is nil. The error is as following:
Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
