### PR TITLE
example: add client auth to server profile in CA config

### DIFF
--- a/example/tls/certs/ca-config.json
+++ b/example/tls/certs/ca-config.json
@@ -9,7 +9,8 @@
                 "usages": [
                     "signing",
                     "key encipherment",
-                    "server auth"
+                    "server auth",
+                    "client auth"
                 ]
             },
             "client": {


### PR DESCRIPTION
I recently tried etcd 3.4.3, hit the same issue https://github.com/etcd-io/etcd/issues/9398 when turning on TLS. 
